### PR TITLE
Add camera preview screen

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.CAMERA" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
@@ -1,0 +1,98 @@
+package com.example.vtubercamera_kmp_ver.camera
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+@Composable
+actual fun rememberCameraPermissionController(): CameraPermissionController {
+    val context = LocalContext.current
+    var permissionGranted by remember { mutableStateOf<Boolean?>(null) }
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        permissionGranted = granted
+    }
+
+    LaunchedEffect(context) {
+        permissionGranted = context.hasCameraPermission()
+    }
+
+    return remember(permissionGranted, permissionLauncher) {
+        CameraPermissionController(
+            isGranted = permissionGranted == true,
+            isChecking = permissionGranted == null,
+            requestPermission = {
+                permissionLauncher.launch(Manifest.permission.CAMERA)
+            },
+        )
+    }
+}
+
+@Composable
+actual fun CameraPreviewHost(modifier: Modifier) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val cameraProviderFuture = remember(context) { ProcessCameraProvider.getInstance(context) }
+    val previewView = remember {
+        PreviewView(context).apply {
+            implementationMode = PreviewView.ImplementationMode.COMPATIBLE
+            scaleType = PreviewView.ScaleType.FILL_CENTER
+        }
+    }
+
+    AndroidView(
+        modifier = modifier,
+        factory = { previewView },
+    )
+
+    DisposableEffect(lifecycleOwner, previewView, cameraProviderFuture) {
+        val executor = ContextCompat.getMainExecutor(context)
+        val listener = Runnable {
+            val cameraProvider = cameraProviderFuture.get()
+            val preview = Preview.Builder()
+                .build()
+                .also { it.surfaceProvider = previewView.surfaceProvider }
+
+            cameraProvider.unbindAll()
+            cameraProvider.bindToLifecycle(
+                lifecycleOwner,
+                CameraSelector.DEFAULT_BACK_CAMERA,
+                preview,
+            )
+        }
+
+        cameraProviderFuture.addListener(listener, executor)
+
+        onDispose {
+            if (cameraProviderFuture.isDone) {
+                cameraProviderFuture.get().unbindAll()
+            }
+        }
+    }
+}
+
+private fun Context.hasCameraPermission(): Boolean {
+    return ContextCompat.checkSelfPermission(
+        this,
+        Manifest.permission.CAMERA,
+    ) == PackageManager.PERMISSION_GRANTED
+}

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,5 @@
+<resources>
+    <string name="camera_permission_required_message">カメラプレビューを表示するにはカメラ権限が必要です。</string>
+    <string name="camera_permission_granted_description">権限を許可すると背面カメラのプレビューを表示します。</string>
+    <string name="camera_permission_request_button">カメラを許可</string>
+</resources>

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/App.kt
@@ -1,49 +1,14 @@
 package com.example.vtubercamera_kmp_ver
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import org.jetbrains.compose.resources.painterResource
-
-import vtubercamera_kmp_ver.composeapp.generated.resources.Res
-import vtubercamera_kmp_ver.composeapp.generated.resources.compose_multiplatform
+import com.example.vtubercamera_kmp_ver.camera.CameraScreen
 
 @Composable
 @Preview
 fun App() {
     MaterialTheme {
-        var showContent by remember { mutableStateOf(false) }
-        Column(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .safeContentPadding()
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Button(onClick = { showContent = !showContent }) {
-                Text("Click me!")
-            }
-            AnimatedVisibility(showContent) {
-                val greeting = remember { Greeting().greet() }
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Image(painterResource(Res.drawable.compose_multiplatform), null)
-                    Text("Compose: $greeting")
-                }
-            }
-        }
+        CameraScreen()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/Greeting.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/Greeting.kt
@@ -1,9 +1,0 @@
-package com.example.vtubercamera_kmp_ver
-
-class Greeting {
-    private val platform = getPlatform()
-
-    fun greet(): String {
-        return "Hello, ${platform.name}!"
-    }
-}

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/Platform.kt
@@ -1,7 +1,0 @@
-package com.example.vtubercamera_kmp_ver
-
-interface Platform {
-    val name: String
-}
-
-expect fun getPlatform(): Platform

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraPermissionController.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraPermissionController.kt
@@ -1,0 +1,18 @@
+package com.example.vtubercamera_kmp_ver.camera
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Modifier
+
+@Immutable
+data class CameraPermissionController(
+    val isGranted: Boolean,
+    val isChecking: Boolean,
+    val requestPermission: () -> Unit,
+)
+
+@Composable
+expect fun rememberCameraPermissionController(): CameraPermissionController
+
+@Composable
+expect fun CameraPreviewHost(modifier: Modifier = Modifier)

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
@@ -15,6 +15,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import vtubercamera_kmp_ver.composeapp.generated.resources.Res
+import vtubercamera_kmp_ver.composeapp.generated.resources.camera_permission_granted_description
+import vtubercamera_kmp_ver.composeapp.generated.resources.camera_permission_request_button
+import vtubercamera_kmp_ver.composeapp.generated.resources.camera_permission_required_message
 
 @Composable
 fun CameraScreen(modifier: Modifier = Modifier) {
@@ -55,18 +60,18 @@ private fun PermissionDeniedState(onRequestPermission: () -> Unit) {
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
-            text = "カメラプレビューを表示するにはカメラ権限が必要です。",
+            text = stringResource(Res.string.camera_permission_required_message),
             style = MaterialTheme.typography.headlineSmall,
             textAlign = TextAlign.Center,
         )
         Text(
-            text = "権限を許可すると背面カメラのプレビューを表示します。",
+            text = stringResource(Res.string.camera_permission_granted_description),
             modifier = Modifier.padding(top = 12.dp, bottom = 24.dp),
             style = MaterialTheme.typography.bodyMedium,
             textAlign = TextAlign.Center,
         )
         Button(onClick = onRequestPermission) {
-            Text("カメラを許可")
+            Text(stringResource(Res.string.camera_permission_request_button))
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
@@ -1,0 +1,72 @@
+package com.example.vtubercamera_kmp_ver.camera
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CameraScreen(modifier: Modifier = Modifier) {
+    val permissionController = rememberCameraPermissionController()
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.scrim),
+    ) {
+        when {
+            permissionController.isChecking -> LoadingState()
+            permissionController.isGranted -> CameraPreviewHost(modifier = Modifier.fillMaxSize())
+            else -> PermissionDeniedState(
+                onRequestPermission = permissionController.requestPermission,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingState() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun PermissionDeniedState(onRequestPermission: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "カメラプレビューを表示するにはカメラ権限が必要です。",
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = "権限を許可すると背面カメラのプレビューを表示します。",
+            modifier = Modifier.padding(top = 12.dp, bottom = 24.dp),
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+        )
+        Button(onClick = onRequestPermission) {
+            Text("カメラを許可")
+        }
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/Platform.ios.kt
@@ -1,9 +1,0 @@
-package com.example.vtubercamera_kmp_ver
-
-import platform.UIKit.UIDevice
-
-class IOSPlatform: Platform {
-    override val name: String = UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
-}
-
-actual fun getPlatform(): Platform = IOSPlatform()

--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
@@ -1,0 +1,34 @@
+package com.example.vtubercamera_kmp_ver.camera
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+actual fun rememberCameraPermissionController(): CameraPermissionController {
+    return remember {
+        CameraPermissionController(
+            isGranted = false,
+            isChecking = false,
+            requestPermission = {},
+        )
+    }
+}
+
+@Composable
+actual fun CameraPreviewHost(modifier: Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text("iOS camera preview is not implemented yet.")
+    }
+}

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.vtubercamera.kmp.ver.vtubercamera.kmpver;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -47,6 +47,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BA7F9B9537C3B640DD1F7DCD /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5AC11AEC8E5CA456A456FB53 /* VtuberCamera_KMP_ver.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		E0BCE6F1CD09480B2B87FCD7 = {
 			isa = PBXGroup;
 			children = (
@@ -54,14 +62,6 @@
 				AA7B557DDCE017950D340666 /* iosApp */,
 				BA7F9B9537C3B640DD1F7DCD /* Products */,
 			);
-			sourceTree = "<group>";
-		};
-		BA7F9B9537C3B640DD1F7DCD /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				5AC11AEC8E5CA456A456FB53 /* VtuberCamera_KMP_ver.app */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -167,6 +167,35 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		18715BBE006200E8DC9546D6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		375EA0673073AEE39B2A0982 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = DD3CAD0C25E49F35E7E1A928 /* Configuration */;
@@ -299,7 +328,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "${TEAM_ID}";
+				DEVELOPMENT_TEAM = AW4XX4A8C2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
@@ -312,39 +341,12 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
-		};
-		18715BBE006200E8DC9546D6 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = arm64;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "${TEAM_ID}";
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = iosApp/Info.plist;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
 		};
 /* End XCBuildConfiguration section */
 


### PR DESCRIPTION
Summary
- replace the sample composable with a shared `CameraScreen` that shows loading, permission, or preview states via a shared controller interface
- add common `CameraPermissionController`/`CameraPreviewHost` APIs plus Android/iOS expectations; Android implementation wires CameraX+permission handling while iOS shows a placeholder
- declare the camera permission in `AndroidManifest.xml`

Testing
- Not run (not requested)