### PR TITLE
Add top-bar file picker launchers

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
@@ -49,6 +49,21 @@ actual fun rememberCameraPermissionController(): CameraPermissionController {
 }
 
 @Composable
+actual fun rememberFilePickerLauncher(): FilePickerLauncher {
+    val pickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument(),
+    ) { }
+
+    return remember(pickerLauncher) {
+        FilePickerLauncher(
+            launch = {
+                pickerLauncher.launch(arrayOf("*/*"))
+            },
+        )
+    }
+}
+
+@Composable
 actual fun CameraPreviewHost(
     modifier: Modifier,
     lensFacing: CameraLensFacing,

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -8,4 +8,5 @@
     <string name="camera_permission_open_settings_button">設定を開く</string>
     <string name="camera_permission_launch_button">カメラを起動</string>
     <string name="camera_switch_button">カメラ切り替え</string>
+    <string name="file_picker_open_button">ファイルを開く</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraPermissionController.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraPermissionController.kt
@@ -11,8 +11,16 @@ data class CameraPermissionController(
     val requestPermission: () -> Unit,
 )
 
+@Immutable
+data class FilePickerLauncher(
+    val launch: () -> Unit,
+)
+
 @Composable
 expect fun rememberCameraPermissionController(): CameraPermissionController
+
+@Composable
+expect fun rememberFilePickerLauncher(): FilePickerLauncher
 
 @Composable
 expect fun CameraPreviewHost(

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -26,6 +28,7 @@ import vtubercamera_kmp_ver.composeapp.generated.resources.camera_permission_gra
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_permission_request_button
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_permission_required_message
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_switch_button
+import vtubercamera_kmp_ver.composeapp.generated.resources.file_picker_open_button
 
 @Composable
 fun CameraRoute(
@@ -33,6 +36,7 @@ fun CameraRoute(
     cameraViewModel: CameraViewModel = viewModel { CameraViewModel() },
 ) {
     val permissionController = rememberCameraPermissionController()
+    val filePickerLauncher = rememberFilePickerLauncher()
     val uiState by cameraViewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(permissionController.isGranted, permissionController.isChecking) {
@@ -46,6 +50,7 @@ fun CameraRoute(
         modifier = modifier,
         uiState = uiState,
         onRequestPermission = permissionController.requestPermission,
+        onOpenFilePicker = filePickerLauncher.launch,
         onLensFacingChanged = cameraViewModel::onLensFacingChanged,
         onLensFacingToggle = cameraViewModel::onToggleLensFacing,
     )
@@ -55,6 +60,7 @@ fun CameraRoute(
 fun CameraScreen(
     uiState: CameraUiState,
     onRequestPermission: () -> Unit,
+    onOpenFilePicker: () -> Unit,
     onLensFacingChanged: (CameraLensFacing) -> Unit,
     onLensFacingToggle: () -> Unit,
     modifier: Modifier = Modifier,
@@ -69,6 +75,7 @@ fun CameraScreen(
             uiState.isPermissionChecking -> LoadingState()
             uiState.isPermissionGranted -> CameraPreviewState(
                 uiState = uiState,
+                onOpenFilePicker = onOpenFilePicker,
                 onLensFacingChanged = onLensFacingChanged,
                 onLensFacingToggle = onLensFacingToggle,
             )
@@ -82,6 +89,7 @@ fun CameraScreen(
 @Composable
 private fun CameraPreviewState(
     uiState: CameraUiState,
+    onOpenFilePicker: () -> Unit,
     onLensFacingChanged: (CameraLensFacing) -> Unit,
     onLensFacingToggle: () -> Unit,
 ) {
@@ -91,13 +99,20 @@ private fun CameraPreviewState(
             lensFacing = uiState.lensFacing,
             onLensFacingChanged = onLensFacingChanged,
         )
-        Button(
-            onClick = onLensFacingToggle,
+        Row(
             modifier = Modifier
-                .align(Alignment.TopEnd)
+                .fillMaxWidth()
+                .align(Alignment.TopCenter)
                 .padding(MaterialTheme.spacing.xl),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(stringResource(Res.string.camera_switch_button))
+            Button(onClick = onOpenFilePicker) {
+                Text(stringResource(Res.string.file_picker_open_button))
+            }
+            Button(onClick = onLensFacingToggle) {
+                Text(stringResource(Res.string.camera_switch_button))
+            }
         }
     }
 }

--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
@@ -10,9 +10,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import platform.UIKit.UIApplication
-import platform.UIKit.UIDocumentPickerModeImport
+import platform.UIKit.UIDocumentPickerMode
 import platform.UIKit.UIDocumentPickerViewController
 import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
 
 @Composable
 actual fun rememberCameraPermissionController(): CameraPermissionController {
@@ -33,7 +34,7 @@ actual fun rememberFilePickerLauncher(): FilePickerLauncher {
                 currentPresentedViewController()?.let { viewController ->
                     val pickerViewController = UIDocumentPickerViewController(
                         documentTypes = listOf("public.item"),
-                        inMode = UIDocumentPickerModeImport,
+                        inMode = UIDocumentPickerMode.UIDocumentPickerModeImport,
                     )
                     viewController.presentViewController(
                         viewControllerToPresent = pickerViewController,
@@ -64,11 +65,12 @@ actual fun CameraPreviewHost(
 
 private fun currentPresentedViewController(): UIViewController? {
     var currentViewController = UIApplication.sharedApplication.windows
-        .firstOrNull { window -> window.isKeyWindow }
+        .filterIsInstance<UIWindow>()
+        .firstOrNull { window -> window.isKeyWindow() }
         ?.rootViewController
 
     while (currentViewController?.presentedViewController != null) {
-        currentViewController = currentViewController?.presentedViewController
+        currentViewController = currentViewController.presentedViewController
     }
 
     return currentViewController

--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
@@ -9,6 +9,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import platform.UIKit.UIApplication
+import platform.UIKit.UIDocumentPickerModeImport
+import platform.UIKit.UIDocumentPickerViewController
+import platform.UIKit.UIViewController
 
 @Composable
 actual fun rememberCameraPermissionController(): CameraPermissionController {
@@ -17,6 +21,27 @@ actual fun rememberCameraPermissionController(): CameraPermissionController {
             isGranted = false,
             isChecking = false,
             requestPermission = {},
+        )
+    }
+}
+
+@Composable
+actual fun rememberFilePickerLauncher(): FilePickerLauncher {
+    return remember {
+        FilePickerLauncher(
+            launch = {
+                currentPresentedViewController()?.let { viewController ->
+                    val pickerViewController = UIDocumentPickerViewController(
+                        documentTypes = listOf("public.item"),
+                        inMode = UIDocumentPickerModeImport,
+                    )
+                    viewController.presentViewController(
+                        viewControllerToPresent = pickerViewController,
+                        animated = true,
+                        completion = null,
+                    )
+                }
+            },
         )
     }
 }
@@ -37,47 +62,14 @@ actual fun CameraPreviewHost(
     }
 }
 
-/*
-@Composable actual fun を使用している理由
+private fun currentPresentedViewController(): UIViewController? {
+    var currentViewController = UIApplication.sharedApplication.windows
+        .firstOrNull { window -> window.isKeyWindow }
+        ?.rootViewController
 
-理由は 2 つあります。
-1. これは Kotlin Multiplatform の expect/actual で、プラットフォームごとの差し替え点だから
-2. その差し替え点が Compose のコンポジション内で呼ばれる API だから
-コード上では、共通側でこの契約が定義されています。
-- CameraPermissionController.kt
+    while (currentViewController?.presentedViewController != null) {
+        currentViewController = currentViewController?.presentedViewController
+    }
 
-ここで
-- rememberCameraPermissionController は expect
-- しかも @Composable 付き
-になっています。つまり「各プラットフォームで実装は違ってよいが、Compose から呼べる形で実装してくれ」という契約です。
-
-実際に共通 UI からその関数を呼んでいるのはここです。
-- CameraScreen.kt
-- CameraScreen.kt
-ここでは CameraScreen の中で permissionController を取得しており、完全に Compose の描画フローの一部です。なので、各プラットフォーム実装も Composable である必要があります。
-
-iOS 側は今は簡易実装ですが、それでも Composable にしてあるのは自然です。
-- IOSCameraPreview.kt
-この関数の中でも remember を使っています。remember 自体が Compose のコンポジション内でしか使えないので、関数は @Composable でなければなりません。
-
-Android 側を見ると、その必要性はさらに明確です。
-- AndroidCameraPreview.kt
-Android 実装では
-- LocalContext.current
-- rememberLauncherForActivityResult
-- LaunchedEffect
-- remember
-を使っています。これらは全部 Compose 専用 API なので、普通の関数にはできません。
-
-要するに整理するとこうです。
-
-- actual が付いている理由
-  - 共通の expect 宣言に対する iOS 実装だから
-- @Composable が付いている理由
-  - 共通 UI のコンポジション中で呼ばれる
-  - 関数内部で remember などの Compose API を使う
-  - expect 側が @Composable 契約になっているので、actual 側もそれに合わせる必要がある
-
-補足すると、actual fun だから Composable なのではありません。逆です。
-「Compose から呼ぶ platform 差し替え関数」なので、結果として @Composable actual fun になっています。
-*/
+    return currentViewController
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 @preconcurrency import AVFoundation
 import ComposeApp
+import UniformTypeIdentifiers
 import UIKit
 
 struct ContentView: View {
     @StateObject private var viewModel = IOSCameraViewModel()
+    @State private var isFileImporterPresented = false
 
     var body: some View {
         ZStack {
@@ -13,12 +15,19 @@ struct ContentView: View {
                     CameraPreviewView(avCaptureSession: viewModel.avCaptureSession)
                         .ignoresSafeArea()
 
-                    if viewModel.canSwitchCamera, let texts = viewModel.permissionTexts {
-                        Button(texts.switchCameraButtonTitle, action: viewModel.switchCamera)
-                            .buttonStyle(.borderedProminent)
-                            .padding(.top, 16)
-                            .padding(.trailing, 16)
+                    HStack(spacing: 12) {
+                        Button("ファイルを開く") {
+                            isFileImporterPresented = true
+                        }
+                        .buttonStyle(.borderedProminent)
+
+                        if viewModel.canSwitchCamera, let texts = viewModel.permissionTexts {
+                            Button(texts.switchCameraButtonTitle, action: viewModel.switchCamera)
+                                .buttonStyle(.borderedProminent)
+                        }
                     }
+                    .padding(.top, 16)
+                    .padding(.trailing, 16)
                 }
             } else {
                 PermissionPromptView(
@@ -29,6 +38,11 @@ struct ContentView: View {
             }
         }
         .background(Color.black.ignoresSafeArea())
+        .fileImporter(
+            isPresented: $isFileImporterPresented,
+            allowedContentTypes: [.item],
+            allowsMultipleSelection: false
+        ) { _ in }
         .onAppear {
             viewModel.refreshAuthorization()
         }


### PR DESCRIPTION
### Motivation
- Allow users to open the system file picker from the camera preview UI on Android and iOS via a button placed at the top of the screen.
- Expose a small cross-platform contract so Compose UI can trigger native pickers without leaking platform details into the shared view logic.

### Description
- Add a shared `FilePickerLauncher` contract (`expect/actual`) alongside the existing `CameraPermissionController` and wire `rememberFilePickerLauncher()` into `CameraRoute` and `CameraScreen` so the shared UI can call `onOpenFilePicker`.
- Add a top-row in the preview (`CameraPreviewState`) with two buttons: a file picker opener and the existing camera lens toggle, and add the localized string `file_picker_open_button`.
- Android actual implements the launcher using `rememberLauncherForActivityResult` with `ActivityResultContracts.OpenDocument()` and launches `pickerLauncher.launch(arrayOf("*/*"))`.
- iOS Compose actual uses `UIDocumentPickerViewController` to present a document picker from the current presented view controller, and the native SwiftUI `ContentView` was updated to include a "ファイルを開く" button and `.fileImporter(...)` to also present the picker from the host app.

### Testing
- Attempted `./gradlew :composeApp:compileDebugKotlinAndroid :composeApp:compileKotlinIosSimulatorArm64`, which could not complete because the environment failed to resolve plugin `org.gradle.toolchains.foojay-resolver-convention:0.10.0` so Gradle build did not finish.
- Attempted `xcodebuild ...` for the iOS scheme, but `xcodebuild` is unavailable in this environment so an Xcode build could not be run.
- Attempted `swiftc -typecheck iosApp/iosApp/ContentView.swift`, which failed on Linux because the `SwiftUI` module is not available here, so iOS SwiftUI type-check could not be validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfd9bd685483308f9c9272636dbbb9)