### PR TITLE
Add VRM picker validation and avatar preview

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
         }
         commonMain.dependencies {
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.serialization.json)
             implementation(libs.compose.runtime)
             implementation(libs.compose.foundation)
             implementation(libs.compose.material3)

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
 
     <application
         android:allowBackup="true"

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
@@ -45,6 +45,14 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.example.vtubercamera_kmp_ver.theme.spacing
+import org.jetbrains.compose.resources.stringResource
+import vtubercamera_kmp_ver.composeapp.generated.resources.Res
+import vtubercamera_kmp_ver.composeapp.generated.resources.avatar_preview_author_label
+import vtubercamera_kmp_ver.composeapp.generated.resources.avatar_preview_version_label
+import vtubercamera_kmp_ver.composeapp.generated.resources.avatar_preview_vrm_badge
+import vtubercamera_kmp_ver.composeapp.generated.resources.file_picker_open_failed
+import vtubercamera_kmp_ver.composeapp.generated.resources.file_picker_read_failed
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_read_failed
 
 @Composable
 actual fun rememberCameraPermissionController(): CameraPermissionController {
@@ -60,15 +68,13 @@ actual fun rememberCameraPermissionController(): CameraPermissionController {
         permissionGranted = context.hasCameraPermission()
     }
 
-    return remember(permissionGranted, permissionLauncher) {
-        CameraPermissionController(
-            isGranted = permissionGranted == true,
-            isChecking = permissionGranted == null,
-            requestPermission = {
-                permissionLauncher.launch(Manifest.permission.CAMERA)
-            },
-        )
-    }
+    return CameraPermissionController(
+        isGranted = permissionGranted == true,
+        isChecking = permissionGranted == null,
+        requestPermission = {
+            permissionLauncher.launch(Manifest.permission.CAMERA)
+        },
+    )
 }
 
 @Composable
@@ -86,26 +92,24 @@ actual fun rememberFilePickerLauncher(onFilePicked: (FilePickerResult) -> Unit):
         val result = runCatching {
             context.contentResolver.openInputStream(uri)?.use { input ->
                 input.readBytes()
-            } ?: error("ファイルを開けませんでした。")
+            } ?: throw FilePickerException(Res.string.file_picker_read_failed)
         }.fold(
             onSuccess = { bytes ->
                 VrmAvatarParser.parse(fileName = fileName, bytes = bytes).fold(
                     onSuccess = { FilePickerResult.Success(it) },
-                    onFailure = { FilePickerResult.Error(it.message ?: "VRMファイルの読み込みに失敗しました。") },
+                    onFailure = { throwable -> throwable.toFilePickerError() },
                 )
             },
-            onFailure = { FilePickerResult.Error(it.message ?: "ファイルを開けませんでした。") },
+            onFailure = { throwable -> throwable.toFilePickerError(defaultMessageRes = Res.string.file_picker_open_failed) },
         )
         onFilePicked(result)
     }
 
-    return remember(pickerLauncher) {
-        FilePickerLauncher(
-            launch = {
-                pickerLauncher.launch(arrayOf("*/*"))
-            },
-        )
-    }
+    return FilePickerLauncher(
+        launch = {
+            pickerLauncher.launch(arrayOf("*/*"))
+        },
+    )
 }
 
 @Composable
@@ -206,7 +210,7 @@ actual fun AvatarPreviewOverlay(
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
-                        text = "VRM",
+                        text = stringResource(Res.string.avatar_preview_vrm_badge),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
                     )
@@ -229,13 +233,13 @@ actual fun AvatarPreviewOverlay(
                 )
                 avatarPreview.authorName?.let { author ->
                     Text(
-                        text = "Author: $author",
+                        text = stringResource(Res.string.avatar_preview_author_label, author),
                         style = MaterialTheme.typography.bodyMedium,
                     )
                 }
                 avatarPreview.vrmVersion?.let { version ->
                     Text(
-                        text = "Version: $version",
+                        text = stringResource(Res.string.avatar_preview_version_label, version),
                         style = MaterialTheme.typography.bodyMedium,
                     )
                 }
@@ -290,5 +294,12 @@ private fun ProcessCameraProvider.hasCameraSafely(selector: CameraSelector): Boo
         false
     } catch (_: IllegalArgumentException) {
         false
+    }
+}
+
+private fun Throwable.toFilePickerError(defaultMessageRes: org.jetbrains.compose.resources.StringResource = Res.string.vrm_error_read_failed): FilePickerResult.Error {
+    return when (this) {
+        is FilePickerException -> FilePickerResult.Error(messageRes)
+        else -> FilePickerResult.Error(defaultMessageRes)
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
@@ -88,7 +88,7 @@ actual fun rememberFilePickerLauncher(onFilePicked: (FilePickerResult) -> Unit):
             return@rememberLauncherForActivityResult
         }
 
-        val fileName = context.resolveDisplayName(uri) ?: uri.lastPathSegment ?: "selected.vrm"
+        val fileName = context.resolveDisplayName(uri) ?: uri.lastPathSegment ?: "selected.glb"
         val result = runCatching {
             context.contentResolver.openInputStream(uri)?.use { input ->
                 input.readBytes()

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
@@ -3,6 +3,8 @@ package com.example.vtubercamera_kmp_ver.camera
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.graphics.BitmapFactory
+import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.CameraInfoUnavailableException
@@ -10,6 +12,21 @@ import androidx.camera.core.CameraSelector
 import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -17,11 +34,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.example.vtubercamera_kmp_ver.theme.spacing
 
 @Composable
 actual fun rememberCameraPermissionController(): CameraPermissionController {
@@ -49,10 +72,32 @@ actual fun rememberCameraPermissionController(): CameraPermissionController {
 }
 
 @Composable
-actual fun rememberFilePickerLauncher(): FilePickerLauncher {
+actual fun rememberFilePickerLauncher(onFilePicked: (FilePickerResult) -> Unit): FilePickerLauncher {
+    val context = LocalContext.current
     val pickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument(),
-    ) { }
+    ) { uri ->
+        if (uri == null) {
+            onFilePicked(FilePickerResult.Cancelled)
+            return@rememberLauncherForActivityResult
+        }
+
+        val fileName = context.resolveDisplayName(uri) ?: uri.lastPathSegment ?: "selected.vrm"
+        val result = runCatching {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                input.readBytes()
+            } ?: error("ファイルを開けませんでした。")
+        }.fold(
+            onSuccess = { bytes ->
+                VrmAvatarParser.parse(fileName = fileName, bytes = bytes).fold(
+                    onSuccess = { FilePickerResult.Success(it) },
+                    onFailure = { FilePickerResult.Error(it.message ?: "VRMファイルの読み込みに失敗しました。") },
+                )
+            },
+            onFailure = { FilePickerResult.Error(it.message ?: "ファイルを開けませんでした。") },
+        )
+        onFilePicked(result)
+    }
 
     return remember(pickerLauncher) {
         FilePickerLauncher(
@@ -121,11 +166,101 @@ actual fun CameraPreviewHost(
     }
 }
 
+@Composable
+actual fun AvatarPreviewOverlay(
+    avatarPreview: AvatarPreviewData,
+    modifier: Modifier,
+) {
+    val thumbnailBitmap = remember(avatarPreview.thumbnailBytes) {
+        avatarPreview.thumbnailBytes?.let { bytes ->
+            BitmapFactory.decodeByteArray(bytes, 0, bytes.size)?.asImageBitmap()
+        }
+    }
+
+    Surface(
+        modifier = modifier.fillMaxWidth(0.72f),
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f),
+        tonalElevation = 8.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(MaterialTheme.spacing.lg),
+            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (thumbnailBitmap != null) {
+                Image(
+                    bitmap = thumbnailBitmap,
+                    contentDescription = avatarPreview.avatarName,
+                    modifier = Modifier.size(96.dp),
+                    contentScale = ContentScale.Crop,
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .size(96.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                            shape = RoundedCornerShape(16.dp),
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "VRM",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier.heightIn(min = 96.dp),
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = avatarPreview.avatarName,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = avatarPreview.fileName,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                avatarPreview.authorName?.let { author ->
+                    Text(
+                        text = "Author: $author",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                avatarPreview.vrmVersion?.let { version ->
+                    Text(
+                        text = "Version: $version",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+        }
+    }
+}
+
 private fun Context.hasCameraPermission(): Boolean {
     return ContextCompat.checkSelfPermission(
         this,
         Manifest.permission.CAMERA,
     ) == PackageManager.PERMISSION_GRANTED
+}
+
+private fun Context.resolveDisplayName(uri: android.net.Uri): String? {
+    return contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+        ?.use { cursor ->
+            val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (nameIndex >= 0 && cursor.moveToFirst()) {
+                cursor.getString(nameIndex)
+            } else {
+                null
+            }
+        }
 }
 
 private fun CameraLensFacing.toCameraSelector(): CameraSelector {

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -17,8 +17,8 @@
     <string name="avatar_preview_author_label">Author: %1$s</string>
     <string name="avatar_preview_version_label">Version: %1$s</string>
     <string name="ios_camera_preview_placeholder">iOS のカメラプレビューはネイティブ iOS 側で表示されます。</string>
-    <string name="vrm_error_select_file">VRMファイルを選択してください。</string>
-    <string name="vrm_error_read_failed">VRMファイルの読み込みに失敗しました。</string>
-    <string name="vrm_error_invalid_format">VRMファイルの形式が不正です。</string>
-    <string name="vrm_error_metadata_parse_failed">VRMメタデータの解析に失敗しました。</string>
+    <string name="vrm_error_select_file">VRM/GLBファイルを選択してください。</string>
+    <string name="vrm_error_read_failed">VRM/GLBファイルの読み込みに失敗しました。</string>
+    <string name="vrm_error_invalid_format">VRM/GLBファイルの形式が不正です。</string>
+    <string name="vrm_error_metadata_parse_failed">VRM/GLBメタデータの解析に失敗しました。</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -9,6 +9,16 @@
     <string name="camera_permission_launch_button">カメラを起動</string>
     <string name="camera_switch_button">カメラ切り替え</string>
     <string name="file_picker_open_button">ファイルを開く</string>
+    <string name="file_picker_open_failed">ファイルを開けませんでした。</string>
+    <string name="file_picker_read_failed">ファイルの読み込みに失敗しました。</string>
     <string name="avatar_error_dialog_title">ファイルエラー</string>
     <string name="avatar_error_dialog_confirm">閉じる</string>
+    <string name="avatar_preview_vrm_badge">VRM</string>
+    <string name="avatar_preview_author_label">Author: %1$s</string>
+    <string name="avatar_preview_version_label">Version: %1$s</string>
+    <string name="ios_camera_preview_placeholder">iOS のカメラプレビューはネイティブ iOS 側で表示されます。</string>
+    <string name="vrm_error_select_file">VRMファイルを選択してください。</string>
+    <string name="vrm_error_read_failed">VRMファイルの読み込みに失敗しました。</string>
+    <string name="vrm_error_invalid_format">VRMファイルの形式が不正です。</string>
+    <string name="vrm_error_metadata_parse_failed">VRMメタデータの解析に失敗しました。</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -9,4 +9,6 @@
     <string name="camera_permission_launch_button">カメラを起動</string>
     <string name="camera_switch_button">カメラ切り替え</string>
     <string name="file_picker_open_button">ファイルを開く</string>
+    <string name="avatar_error_dialog_title">ファイルエラー</string>
+    <string name="avatar_error_dialog_confirm">閉じる</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraPermissionController.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraPermissionController.kt
@@ -16,15 +16,36 @@ data class FilePickerLauncher(
     val launch: () -> Unit,
 )
 
+@Immutable
+data class AvatarPreviewData(
+    val fileName: String,
+    val avatarName: String,
+    val authorName: String?,
+    val vrmVersion: String?,
+    val thumbnailBytes: ByteArray?,
+)
+
+sealed interface FilePickerResult {
+    data class Success(val avatarPreview: AvatarPreviewData) : FilePickerResult
+    data class Error(val message: String) : FilePickerResult
+    data object Cancelled : FilePickerResult
+}
+
 @Composable
 expect fun rememberCameraPermissionController(): CameraPermissionController
 
 @Composable
-expect fun rememberFilePickerLauncher(): FilePickerLauncher
+expect fun rememberFilePickerLauncher(onFilePicked: (FilePickerResult) -> Unit): FilePickerLauncher
 
 @Composable
 expect fun CameraPreviewHost(
     modifier: Modifier = Modifier,
     lensFacing: CameraLensFacing,
     onLensFacingChanged: (CameraLensFacing) -> Unit,
+)
+
+@Composable
+expect fun AvatarPreviewOverlay(
+    avatarPreview: AvatarPreviewData,
+    modifier: Modifier = Modifier,
 )

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraPermissionController.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraPermissionController.kt
@@ -3,6 +3,7 @@ package com.example.vtubercamera_kmp_ver.camera
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
+import org.jetbrains.compose.resources.StringResource
 
 @Immutable
 data class CameraPermissionController(
@@ -27,9 +28,13 @@ data class AvatarPreviewData(
 
 sealed interface FilePickerResult {
     data class Success(val avatarPreview: AvatarPreviewData) : FilePickerResult
-    data class Error(val message: String) : FilePickerResult
+    data class Error(val messageRes: StringResource) : FilePickerResult
     data object Cancelled : FilePickerResult
 }
+
+class FilePickerException(
+    val messageRes: StringResource,
+) : IllegalArgumentException()
 
 @Composable
 expect fun rememberCameraPermissionController(): CameraPermissionController

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -24,6 +25,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.vtubercamera_kmp_ver.theme.spacing
 import org.jetbrains.compose.resources.stringResource
 import vtubercamera_kmp_ver.composeapp.generated.resources.Res
+import vtubercamera_kmp_ver.composeapp.generated.resources.avatar_error_dialog_confirm
+import vtubercamera_kmp_ver.composeapp.generated.resources.avatar_error_dialog_title
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_permission_granted_description
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_permission_request_button
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_permission_required_message
@@ -36,7 +39,7 @@ fun CameraRoute(
     cameraViewModel: CameraViewModel = viewModel { CameraViewModel() },
 ) {
     val permissionController = rememberCameraPermissionController()
-    val filePickerLauncher = rememberFilePickerLauncher()
+    val filePickerLauncher = rememberFilePickerLauncher(cameraViewModel::onFilePicked)
     val uiState by cameraViewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(permissionController.isGranted, permissionController.isChecking) {
@@ -51,6 +54,7 @@ fun CameraRoute(
         uiState = uiState,
         onRequestPermission = permissionController.requestPermission,
         onOpenFilePicker = filePickerLauncher.launch,
+        onDismissFilePickerError = cameraViewModel::onDismissFilePickerError,
         onLensFacingChanged = cameraViewModel::onLensFacingChanged,
         onLensFacingToggle = cameraViewModel::onToggleLensFacing,
     )
@@ -61,11 +65,11 @@ fun CameraScreen(
     uiState: CameraUiState,
     onRequestPermission: () -> Unit,
     onOpenFilePicker: () -> Unit,
+    onDismissFilePickerError: () -> Unit,
     onLensFacingChanged: (CameraLensFacing) -> Unit,
     onLensFacingToggle: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -81,6 +85,19 @@ fun CameraScreen(
             )
             else -> PermissionDeniedState(
                 onRequestPermission = onRequestPermission,
+            )
+        }
+
+        uiState.filePickerErrorMessage?.let { message ->
+            AlertDialog(
+                onDismissRequest = onDismissFilePickerError,
+                title = { Text(stringResource(Res.string.avatar_error_dialog_title)) },
+                text = { Text(message) },
+                confirmButton = {
+                    Button(onClick = onDismissFilePickerError) {
+                        Text(stringResource(Res.string.avatar_error_dialog_confirm))
+                    }
+                },
             )
         }
     }
@@ -113,6 +130,14 @@ private fun CameraPreviewState(
             Button(onClick = onLensFacingToggle) {
                 Text(stringResource(Res.string.camera_switch_button))
             }
+        }
+        uiState.avatarPreview?.let { avatarPreview ->
+            AvatarPreviewOverlay(
+                avatarPreview = avatarPreview,
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(MaterialTheme.spacing.xl),
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
@@ -88,11 +88,11 @@ fun CameraScreen(
             )
         }
 
-        uiState.filePickerErrorMessage?.let { message ->
+        uiState.filePickerErrorMessageRes?.let { messageRes ->
             AlertDialog(
                 onDismissRequest = onDismissFilePickerError,
                 title = { Text(stringResource(Res.string.avatar_error_dialog_title)) },
-                text = { Text(message) },
+                text = { Text(stringResource(messageRes)) },
                 confirmButton = {
                     Button(onClick = onDismissFilePickerError) {
                         Text(stringResource(Res.string.avatar_error_dialog_confirm))

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
@@ -1,10 +1,11 @@
 import com.example.vtubercamera_kmp_ver.camera.AvatarPreviewData
 import com.example.vtubercamera_kmp_ver.camera.CameraLensFacing
+import org.jetbrains.compose.resources.StringResource
 
 data class CameraUiState(
     val lensFacing: CameraLensFacing = CameraLensFacing.Back,
     val isPermissionGranted: Boolean = false,
     val isPermissionChecking: Boolean = true,
     val avatarPreview: AvatarPreviewData? = null,
-    val filePickerErrorMessage: String? = null,
+    val filePickerErrorMessageRes: StringResource? = null,
 )

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
@@ -1,7 +1,10 @@
+import com.example.vtubercamera_kmp_ver.camera.AvatarPreviewData
 import com.example.vtubercamera_kmp_ver.camera.CameraLensFacing
 
 data class CameraUiState(
     val lensFacing: CameraLensFacing = CameraLensFacing.Back,
     val isPermissionGranted: Boolean = false,
     val isPermissionChecking: Boolean = true,
+    val avatarPreview: AvatarPreviewData? = null,
+    val filePickerErrorMessage: String? = null,
 )

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
-
 class CameraViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(CameraUiState())
     val uiState: StateFlow<CameraUiState> = _uiState.asStateFlow()
@@ -33,6 +32,27 @@ class CameraViewModel : ViewModel() {
     fun onToggleLensFacing() {
         _uiState.update { currentState ->
             currentState.copy(lensFacing = currentState.lensFacing.toggled())
+        }
+    }
+
+    fun onFilePicked(result: FilePickerResult) {
+        _uiState.update { currentState ->
+            when (result) {
+                is FilePickerResult.Success -> currentState.copy(
+                    avatarPreview = result.avatarPreview,
+                    filePickerErrorMessage = null,
+                )
+                is FilePickerResult.Error -> currentState.copy(
+                    filePickerErrorMessage = result.message,
+                )
+                FilePickerResult.Cancelled -> currentState
+            }
+        }
+    }
+
+    fun onDismissFilePickerError() {
+        _uiState.update { currentState ->
+            currentState.copy(filePickerErrorMessage = null)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
@@ -40,10 +40,10 @@ class CameraViewModel : ViewModel() {
             when (result) {
                 is FilePickerResult.Success -> currentState.copy(
                     avatarPreview = result.avatarPreview,
-                    filePickerErrorMessage = null,
+                    filePickerErrorMessageRes = null,
                 )
                 is FilePickerResult.Error -> currentState.copy(
-                    filePickerErrorMessage = result.message,
+                    filePickerErrorMessageRes = result.messageRes,
                 )
                 FilePickerResult.Cancelled -> currentState
             }
@@ -52,7 +52,7 @@ class CameraViewModel : ViewModel() {
 
     fun onDismissFilePickerError() {
         _uiState.update { currentState ->
-            currentState.copy(filePickerErrorMessage = null)
+            currentState.copy(filePickerErrorMessageRes = null)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt
@@ -1,0 +1,150 @@
+package com.example.vtubercamera_kmp_ver.camera
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.intOrNull
+
+object VrmAvatarParser {
+    private const val glbHeaderMagic = 0x46546C67
+    private const val jsonChunkType = 0x4E4F534A
+    private const val binaryChunkType = 0x004E4942
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun parse(fileName: String, bytes: ByteArray): Result<AvatarPreviewData> {
+        if (!fileName.lowercase().endsWith(".vrm")) {
+            return Result.failure(IllegalArgumentException("VRMファイルを選択してください。"))
+        }
+        if (bytes.size < 20) {
+            return Result.failure(IllegalArgumentException("VRMファイルの読み込みに失敗しました。"))
+        }
+
+        val magic = bytes.readIntLE(0)
+        if (magic != glbHeaderMagic) {
+            return Result.failure(IllegalArgumentException("VRMファイルを選択してください。"))
+        }
+
+        val declaredLength = bytes.readIntLE(8)
+        if (declaredLength > bytes.size || declaredLength < 20) {
+            return Result.failure(IllegalArgumentException("VRMファイルの形式が不正です。"))
+        }
+
+        var offset = 12
+        var jsonChunk: String? = null
+        var binaryChunk: ByteArray? = null
+        while (offset + 8 <= declaredLength) {
+            val chunkLength = bytes.readIntLE(offset)
+            val chunkType = bytes.readIntLE(offset + 4)
+            val chunkStart = offset + 8
+            val chunkEnd = chunkStart + chunkLength
+            if (chunkLength < 0 || chunkEnd > declaredLength) {
+                return Result.failure(IllegalArgumentException("VRMファイルの形式が不正です。"))
+            }
+            when (chunkType) {
+                jsonChunkType -> jsonChunk = bytes.decodeToString(chunkStart, chunkEnd)
+                binaryChunkType -> binaryChunk = bytes.copyOfRange(chunkStart, chunkEnd)
+            }
+            offset = chunkEnd
+        }
+
+        val root = jsonChunk
+            ?.let { runCatching { json.parseToJsonElement(it).jsonObject }.getOrNull() }
+            ?: return Result.failure(IllegalArgumentException("VRMメタデータの解析に失敗しました。"))
+
+        val meta = root.vrm0Meta() ?: root.vrm1Meta()
+        val avatarName = meta?.string("title")
+            ?: meta?.string("name")
+            ?: fileName.substringBeforeLast('.')
+        val authorName = meta?.string("author") ?: meta?.stringArray("authors")?.firstOrNull()
+        val vrmVersion = meta?.string("version")
+            ?: root.jsonObject("extensions")?.jsonObject("VRMC_vrm")?.string("specVersion")
+            ?: root.jsonObject("asset")?.string("version")
+
+        val thumbnailIndex = root.resolveThumbnailImageIndex()
+        val thumbnailBytes = if (thumbnailIndex != null && binaryChunk != null) {
+            root.extractImageBytes(thumbnailIndex, binaryChunk)
+        } else {
+            null
+        }
+
+        return Result.success(
+            AvatarPreviewData(
+                fileName = fileName,
+                avatarName = avatarName,
+                authorName = authorName,
+                vrmVersion = vrmVersion,
+                thumbnailBytes = thumbnailBytes,
+            ),
+        )
+    }
+
+    private fun JsonObject.vrm0Meta(): JsonObject? =
+        jsonObject("extensions")?.jsonObject("VRM")?.jsonObject("meta")
+
+    private fun JsonObject.vrm1Meta(): JsonObject? =
+        jsonObject("extensions")?.jsonObject("VRMC_vrm")?.jsonObject("meta")
+
+    private fun JsonObject.resolveThumbnailImageIndex(): Int? {
+        val vrm0Meta = vrm0Meta()
+        val vrm0TextureIndex = vrm0Meta?.int("texture")
+        if (vrm0TextureIndex != null) {
+            val imageIndex = jsonArray("textures")
+                ?.getOrNull(vrm0TextureIndex)
+                ?.jsonObjectOrNull()
+                ?.int("source")
+            if (imageIndex != null) return imageIndex
+        }
+
+        return vrm1Meta()?.int("thumbnailImage")
+    }
+
+    private fun JsonObject.extractImageBytes(imageIndex: Int, binaryChunk: ByteArray): ByteArray? {
+        val image = jsonArray("images")
+            ?.getOrNull(imageIndex)
+            ?.jsonObjectOrNull()
+            ?: return null
+        val bufferViewIndex = image.int("bufferView") ?: return null
+        val mimeType = image.string("mimeType") ?: return null
+        if (!mimeType.startsWith("image/")) return null
+
+        val bufferView = jsonArray("bufferViews")
+            ?.getOrNull(bufferViewIndex)
+            ?.jsonObjectOrNull()
+            ?: return null
+        val byteOffset = bufferView.int("byteOffset") ?: 0
+        val byteLength = bufferView.int("byteLength") ?: return null
+        val end = byteOffset + byteLength
+        if (byteOffset < 0 || end > binaryChunk.size) return null
+        return binaryChunk.copyOfRange(byteOffset, end)
+    }
+
+    private fun JsonObject.jsonObject(key: String): JsonObject? = get(key)?.jsonObjectOrNull()
+
+    private fun JsonObject.jsonArray(key: String): JsonArray? = get(key)?.jsonArrayOrNull()
+
+    private fun JsonObject.string(key: String): String? = get(key)?.jsonPrimitiveOrNull()?.contentOrNull?.takeIf { it.isNotBlank() }
+
+    private fun JsonObject.int(key: String): Int? = get(key)?.jsonPrimitiveOrNull()?.intOrNull
+
+    private fun JsonObject.stringArray(key: String): List<String>? {
+        return jsonArray(key)
+            ?.mapNotNull { it.jsonPrimitiveOrNull()?.contentOrNull?.takeIf { value -> value.isNotBlank() } }
+            ?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun JsonElement.jsonObjectOrNull(): JsonObject? = this as? JsonObject
+
+    private fun JsonElement.jsonArrayOrNull(): JsonArray? = this as? JsonArray
+
+    private fun JsonElement.jsonPrimitiveOrNull(): JsonPrimitive? = this as? JsonPrimitive
+
+    private fun ByteArray.readIntLE(offset: Int): Int {
+        return (this[offset].toInt() and 0xFF) or
+            ((this[offset + 1].toInt() and 0xFF) shl 8) or
+            ((this[offset + 2].toInt() and 0xFF) shl 16) or
+            ((this[offset + 3].toInt() and 0xFF) shl 24)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt
@@ -6,6 +6,11 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.intOrNull
+import vtubercamera_kmp_ver.composeapp.generated.resources.Res
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_invalid_format
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_metadata_parse_failed
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_read_failed
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_select_file
 
 object VrmAvatarParser {
     private const val glbHeaderMagic = 0x46546C67
@@ -16,20 +21,20 @@ object VrmAvatarParser {
 
     fun parse(fileName: String, bytes: ByteArray): Result<AvatarPreviewData> {
         if (!fileName.lowercase().endsWith(".vrm")) {
-            return Result.failure(IllegalArgumentException("VRMファイルを選択してください。"))
+            return Result.failure(FilePickerException(Res.string.vrm_error_select_file))
         }
         if (bytes.size < 20) {
-            return Result.failure(IllegalArgumentException("VRMファイルの読み込みに失敗しました。"))
+            return Result.failure(FilePickerException(Res.string.vrm_error_read_failed))
         }
 
         val magic = bytes.readIntLE(0)
         if (magic != glbHeaderMagic) {
-            return Result.failure(IllegalArgumentException("VRMファイルを選択してください。"))
+            return Result.failure(FilePickerException(Res.string.vrm_error_select_file))
         }
 
         val declaredLength = bytes.readIntLE(8)
         if (declaredLength > bytes.size || declaredLength < 20) {
-            return Result.failure(IllegalArgumentException("VRMファイルの形式が不正です。"))
+            return Result.failure(FilePickerException(Res.string.vrm_error_invalid_format))
         }
 
         var offset = 12
@@ -41,7 +46,7 @@ object VrmAvatarParser {
             val chunkStart = offset + 8
             val chunkEnd = chunkStart + chunkLength
             if (chunkLength < 0 || chunkEnd > declaredLength) {
-                return Result.failure(IllegalArgumentException("VRMファイルの形式が不正です。"))
+                return Result.failure(FilePickerException(Res.string.vrm_error_invalid_format))
             }
             when (chunkType) {
                 jsonChunkType -> jsonChunk = bytes.decodeToString(chunkStart, chunkEnd)
@@ -51,8 +56,10 @@ object VrmAvatarParser {
         }
 
         val root = jsonChunk
-            ?.let { runCatching { json.parseToJsonElement(it).jsonObject }.getOrNull() }
-            ?: return Result.failure(IllegalArgumentException("VRMメタデータの解析に失敗しました。"))
+            ?.let { chunk ->
+                runCatching { json.parseToJsonElement(chunk) as? JsonObject }.getOrNull()
+            }
+            ?: return Result.failure(FilePickerException(Res.string.vrm_error_metadata_parse_failed))
 
         val meta = root.vrm0Meta() ?: root.vrm1Meta()
         val avatarName = meta?.string("title")
@@ -60,8 +67,8 @@ object VrmAvatarParser {
             ?: fileName.substringBeforeLast('.')
         val authorName = meta?.string("author") ?: meta?.stringArray("authors")?.firstOrNull()
         val vrmVersion = meta?.string("version")
-            ?: root.jsonObject("extensions")?.jsonObject("VRMC_vrm")?.string("specVersion")
-            ?: root.jsonObject("asset")?.string("version")
+            ?: root.childObject("extensions")?.childObject("VRMC_vrm")?.string("specVersion")
+            ?: root.childObject("asset")?.string("version")
 
         val thumbnailIndex = root.resolveThumbnailImageIndex()
         val thumbnailBytes = if (thumbnailIndex != null && binaryChunk != null) {
@@ -82,16 +89,16 @@ object VrmAvatarParser {
     }
 
     private fun JsonObject.vrm0Meta(): JsonObject? =
-        jsonObject("extensions")?.jsonObject("VRM")?.jsonObject("meta")
+        childObject("extensions")?.childObject("VRM")?.childObject("meta")
 
     private fun JsonObject.vrm1Meta(): JsonObject? =
-        jsonObject("extensions")?.jsonObject("VRMC_vrm")?.jsonObject("meta")
+        childObject("extensions")?.childObject("VRMC_vrm")?.childObject("meta")
 
     private fun JsonObject.resolveThumbnailImageIndex(): Int? {
         val vrm0Meta = vrm0Meta()
         val vrm0TextureIndex = vrm0Meta?.int("texture")
         if (vrm0TextureIndex != null) {
-            val imageIndex = jsonArray("textures")
+            val imageIndex = childArray("textures")
                 ?.getOrNull(vrm0TextureIndex)
                 ?.jsonObjectOrNull()
                 ?.int("source")
@@ -102,7 +109,7 @@ object VrmAvatarParser {
     }
 
     private fun JsonObject.extractImageBytes(imageIndex: Int, binaryChunk: ByteArray): ByteArray? {
-        val image = jsonArray("images")
+        val image = childArray("images")
             ?.getOrNull(imageIndex)
             ?.jsonObjectOrNull()
             ?: return null
@@ -110,7 +117,7 @@ object VrmAvatarParser {
         val mimeType = image.string("mimeType") ?: return null
         if (!mimeType.startsWith("image/")) return null
 
-        val bufferView = jsonArray("bufferViews")
+        val bufferView = childArray("bufferViews")
             ?.getOrNull(bufferViewIndex)
             ?.jsonObjectOrNull()
             ?: return null
@@ -121,17 +128,20 @@ object VrmAvatarParser {
         return binaryChunk.copyOfRange(byteOffset, end)
     }
 
-    private fun JsonObject.jsonObject(key: String): JsonObject? = get(key)?.jsonObjectOrNull()
+    private fun JsonObject.childObject(key: String): JsonObject? = get(key)?.jsonObjectOrNull()
 
-    private fun JsonObject.jsonArray(key: String): JsonArray? = get(key)?.jsonArrayOrNull()
+    private fun JsonObject.childArray(key: String): JsonArray? = get(key)?.jsonArrayOrNull()
 
-    private fun JsonObject.string(key: String): String? = get(key)?.jsonPrimitiveOrNull()?.contentOrNull?.takeIf { it.isNotBlank() }
+    private fun JsonObject.string(key: String): String? =
+        get(key)?.jsonPrimitiveOrNull()?.content?.takeIf { value -> value.isNotBlank() }
 
     private fun JsonObject.int(key: String): Int? = get(key)?.jsonPrimitiveOrNull()?.intOrNull
 
     private fun JsonObject.stringArray(key: String): List<String>? {
-        return jsonArray(key)
-            ?.mapNotNull { it.jsonPrimitiveOrNull()?.contentOrNull?.takeIf { value -> value.isNotBlank() } }
+        return childArray(key)
+            ?.mapNotNull { element ->
+                element.jsonPrimitiveOrNull()?.content?.takeIf { value -> value.isNotBlank() }
+            }
             ?.takeIf { it.isNotEmpty() }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt
@@ -16,11 +16,12 @@ object VrmAvatarParser {
     private const val glbHeaderMagic = 0x46546C67
     private const val jsonChunkType = 0x4E4F534A
     private const val binaryChunkType = 0x004E4942
+    private val supportedExtensions = setOf("vrm", "glb")
 
     private val json = Json { ignoreUnknownKeys = true }
 
     fun parse(fileName: String, bytes: ByteArray): Result<AvatarPreviewData> {
-        if (!fileName.lowercase().endsWith(".vrm")) {
+        if (!fileName.hasSupportedExtension()) {
             return Result.failure(FilePickerException(Res.string.vrm_error_select_file))
         }
         if (bytes.size < 20) {
@@ -150,6 +151,11 @@ object VrmAvatarParser {
     private fun JsonElement.jsonArrayOrNull(): JsonArray? = this as? JsonArray
 
     private fun JsonElement.jsonPrimitiveOrNull(): JsonPrimitive? = this as? JsonPrimitive
+
+    private fun String.hasSupportedExtension(): Boolean {
+        val extension = substringAfterLast('.', missingDelimiterValue = "")
+        return extension.lowercase() in supportedExtensions
+    }
 
     private fun ByteArray.readIntLE(offset: Int): Int {
         return (this[offset].toInt() and 0xFF) or

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
@@ -3,8 +3,11 @@ package com.example.vtubercamera_kmp_ver
 import com.example.vtubercamera_kmp_ver.camera.VrmAvatarParser
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import vtubercamera_kmp_ver.composeapp.generated.resources.Res
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_select_file
 
 class ComposeAppCommonTest {
 
@@ -51,7 +54,8 @@ class ComposeAppCommonTest {
         val exception = VrmAvatarParser.parse("image.png", glb).exceptionOrNull()
 
         assertNotNull(exception)
-        assertEquals("VRMファイルを選択してください。", exception.message)
+        val filePickerException = assertIs<com.example.vtubercamera_kmp_ver.camera.FilePickerException>(exception)
+        assertEquals(Res.string.vrm_error_select_file, filePickerException.messageRes)
     }
 
     private fun createGlb(json: String, binary: ByteArray): ByteArray {

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
@@ -1,12 +1,86 @@
 package com.example.vtubercamera_kmp_ver
 
+import com.example.vtubercamera_kmp_ver.camera.VrmAvatarParser
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class ComposeAppCommonTest {
 
     @Test
-    fun example() {
-        assertEquals(3, 1 + 2)
+    fun parseVrmAvatarExtractsMetadataAndThumbnail() {
+        val thumbnailBytes = byteArrayOf(1, 2, 3, 4)
+        val glb = createGlb(
+            json = """
+                {
+                  "asset": {"version": "2.0"},
+                  "extensions": {
+                    "VRM": {
+                      "meta": {
+                        "title": "Sample Avatar",
+                        "author": "OpenAI",
+                        "version": "1.0",
+                        "texture": 0
+                      }
+                    }
+                  },
+                  "textures": [{"source": 0}],
+                  "images": [{"bufferView": 0, "mimeType": "image/png"}],
+                  "bufferViews": [{"buffer": 0, "byteOffset": 0, "byteLength": 4}]
+                }
+            """.trimIndent(),
+            binary = thumbnailBytes,
+        )
+
+        val result = VrmAvatarParser.parse("sample.vrm", glb).getOrThrow()
+
+        assertEquals("Sample Avatar", result.avatarName)
+        assertEquals("OpenAI", result.authorName)
+        assertEquals("1.0", result.vrmVersion)
+        assertTrue(result.thumbnailBytes!!.contentEquals(thumbnailBytes))
+    }
+
+    @Test
+    fun parseVrmAvatarRejectsNonVrmExtension() {
+        val glb = createGlb(
+            json = """{"asset":{"version":"2.0"}}""",
+            binary = ByteArray(0),
+        )
+
+        val exception = VrmAvatarParser.parse("image.png", glb).exceptionOrNull()
+
+        assertNotNull(exception)
+        assertEquals("VRMファイルを選択してください。", exception.message)
+    }
+
+    private fun createGlb(json: String, binary: ByteArray): ByteArray {
+        val jsonBytes = json.encodeToByteArray().padTo4Bytes(0x20)
+        val binaryBytes = binary.padTo4Bytes(0x00)
+        val totalLength = 12 + 8 + jsonBytes.size + 8 + binaryBytes.size
+        return buildList<Byte>() {
+            addIntLE(0x46546C67)
+            addIntLE(2)
+            addIntLE(totalLength)
+            addIntLE(jsonBytes.size)
+            addIntLE(0x4E4F534A)
+            addAll(jsonBytes.toList())
+            addIntLE(binaryBytes.size)
+            addIntLE(0x004E4942)
+            addAll(binaryBytes.toList())
+        }.toByteArray()
+    }
+
+    private fun ByteArray.padTo4Bytes(paddingByte: Int): ByteArray {
+        val padding = (4 - size % 4) % 4
+        if (padding == 0) return this
+        return this + ByteArray(padding) { paddingByte.toByte() }
+    }
+
+    private fun MutableList<Byte>.addIntLE(value: Int) {
+        add((value and 0xFF).toByte())
+        add(((value ushr 8) and 0xFF).toByte())
+        add(((value ushr 16) and 0xFF).toByte())
+        add(((value ushr 24) and 0xFF).toByte())
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
@@ -45,7 +45,39 @@ class ComposeAppCommonTest {
     }
 
     @Test
-    fun parseVrmAvatarRejectsNonVrmExtension() {
+        fun parseGlbAvatarExtractsMetadataAndThumbnail() {
+                val thumbnailBytes = byteArrayOf(5, 6, 7, 8)
+                val glb = createGlb(
+                        json = """
+                                {
+                                    "asset": {"version": "2.0"},
+                                    "extensions": {
+                                        "VRMC_vrm": {
+                                            "specVersion": "1.0",
+                                            "meta": {
+                                                "name": "Sample GLB Avatar",
+                                                "authors": ["OpenAI GLB"],
+                                                "thumbnailImage": 0
+                                            }
+                                        }
+                                    },
+                                    "images": [{"bufferView": 0, "mimeType": "image/png"}],
+                                    "bufferViews": [{"buffer": 0, "byteOffset": 0, "byteLength": 4}]
+                                }
+                        """.trimIndent(),
+                        binary = thumbnailBytes,
+                )
+
+                val result = VrmAvatarParser.parse("sample.glb", glb).getOrThrow()
+
+                assertEquals("Sample GLB Avatar", result.avatarName)
+                assertEquals("OpenAI GLB", result.authorName)
+                assertEquals("1.0", result.vrmVersion)
+                assertTrue(result.thumbnailBytes!!.contentEquals(thumbnailBytes))
+        }
+
+        @Test
+        fun parseAvatarRejectsNonGlbBasedExtension() {
         val glb = createGlb(
             json = """{"asset":{"version":"2.0"}}""",
             binary = ByteArray(0),

--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
@@ -27,7 +27,7 @@ actual fun rememberCameraPermissionController(): CameraPermissionController {
 }
 
 @Composable
-actual fun rememberFilePickerLauncher(): FilePickerLauncher {
+actual fun rememberFilePickerLauncher(onFilePicked: (FilePickerResult) -> Unit): FilePickerLauncher {
     return remember {
         FilePickerLauncher(
             launch = {
@@ -41,7 +41,7 @@ actual fun rememberFilePickerLauncher(): FilePickerLauncher {
                         animated = true,
                         completion = null,
                     )
-                }
+                } ?: onFilePicked(FilePickerResult.Error("ファイルピッカーを起動できませんでした。"))
             },
         )
     }
@@ -60,6 +60,19 @@ actual fun CameraPreviewHost(
         contentAlignment = Alignment.Center,
     ) {
         Text("iOS camera preview is hosted by the native iOS app.")
+    }
+}
+
+@Composable
+actual fun AvatarPreviewOverlay(
+    avatarPreview: AvatarPreviewData,
+    modifier: Modifier,
+) {
+    Box(
+        modifier = modifier.background(MaterialTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(avatarPreview.avatarName)
     }
 }
 

--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
@@ -9,11 +9,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import org.jetbrains.compose.resources.stringResource
 import platform.UIKit.UIApplication
 import platform.UIKit.UIDocumentPickerMode
 import platform.UIKit.UIDocumentPickerViewController
 import platform.UIKit.UIViewController
 import platform.UIKit.UIWindow
+import vtubercamera_kmp_ver.composeapp.generated.resources.Res
+import vtubercamera_kmp_ver.composeapp.generated.resources.file_picker_open_failed
+import vtubercamera_kmp_ver.composeapp.generated.resources.ios_camera_preview_placeholder
 
 @Composable
 actual fun rememberCameraPermissionController(): CameraPermissionController {
@@ -41,7 +45,7 @@ actual fun rememberFilePickerLauncher(onFilePicked: (FilePickerResult) -> Unit):
                         animated = true,
                         completion = null,
                     )
-                } ?: onFilePicked(FilePickerResult.Error("ファイルピッカーを起動できませんでした。"))
+                } ?: onFilePicked(FilePickerResult.Error(Res.string.file_picker_open_failed))
             },
         )
     }
@@ -59,7 +63,7 @@ actual fun CameraPreviewHost(
             .background(MaterialTheme.colorScheme.surfaceVariant),
         contentAlignment = Alignment.Center,
     ) {
-        Text("iOS camera preview is hosted by the native iOS app.")
+        Text(stringResource(Res.string.ios_camera_preview_placeholder))
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ androidx-testExt = "1.3.0"
 cameraX = "1.4.2"
 composeMultiplatform = "1.10.0"
 coroutines = "1.10.2"
+kotlinxSerializationJson = "1.9.0"
 junit = "4.13.2"
 kotlin = "2.3.0"
 material3 = "1.10.0-alpha05"
@@ -42,6 +43,7 @@ compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMul
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 [plugins]

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -7,8 +7,6 @@ import UIKit
 struct ContentView: View {
     @StateObject private var viewModel = IOSCameraViewModel()
     @State private var isFileImporterPresented = false
-    @State private var avatarPreview: IOSAvatarPreview?
-    @State private var fileErrorMessage: String?
 
     var body: some View {
         ZStack {
@@ -31,7 +29,7 @@ struct ContentView: View {
                     .padding(.top, 16)
                     .padding(.trailing, 16)
 
-                    if let avatarPreview {
+                    if let avatarPreview = viewModel.avatarPreview {
                         VStack {
                             Spacer()
                             IOSAvatarPreviewCard(avatarPreview: avatarPreview)
@@ -54,44 +52,27 @@ struct ContentView: View {
             isPresented: $isFileImporterPresented,
             allowedContentTypes: [.item],
             allowsMultipleSelection: false,
-            onCompletion: handleFileImport
+            onCompletion: viewModel.handleFileImport
         )
         .alert("ファイルエラー", isPresented: Binding(
-            get: { fileErrorMessage != nil },
+            get: { viewModel.isFileErrorPresented },
             set: { isPresented in
                 if !isPresented {
-                    fileErrorMessage = nil
+                    viewModel.dismissFileError()
                 }
             }
         )) {
             Button("閉じる", role: .cancel) {
-                fileErrorMessage = nil
+                viewModel.dismissFileError()
             }
         } message: {
-            Text(fileErrorMessage ?? "")
+            Text(viewModel.fileErrorMessage ?? "")
         }
         .onAppear {
             viewModel.refreshAuthorization()
         }
         .onDisappear {
             viewModel.stopSession()
-        }
-    }
-
-    private func handleFileImport(_ result: Result<[URL], Error>) {
-        switch result {
-        case .success(let urls):
-            guard let url = urls.first else { return }
-            do {
-                avatarPreview = try IOSVrmAvatarParser.parse(url: url)
-                fileErrorMessage = nil
-            } catch {
-                avatarPreview = nil
-                fileErrorMessage = error.localizedDescription
-            }
-        case .failure(let error):
-            avatarPreview = nil
-            fileErrorMessage = error.localizedDescription
         }
     }
 }
@@ -209,387 +190,5 @@ private struct IOSAvatarPreviewCard: View {
         .padding(16)
         .frame(maxWidth: 320, alignment: .leading)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
-    }
-}
-
-private struct IOSAvatarPreview {
-    let fileName: String
-    let avatarName: String
-    let authorName: String?
-    let vrmVersion: String?
-    let thumbnail: UIImage?
-}
-
-private enum IOSVrmAvatarParser {
-    private static let supportedExtensions: Set<String> = ["vrm", "glb"]
-
-    static func parse(url: URL) throws -> IOSAvatarPreview {
-        let didAccess = url.startAccessingSecurityScopedResource()
-        defer {
-            if didAccess {
-                url.stopAccessingSecurityScopedResource()
-            }
-        }
-
-        let fileName = url.lastPathComponent
-        guard supportedExtensions.contains(url.pathExtension.lowercased()) else {
-            throw ParserError.invalidFileType
-        }
-
-        let data = try Data(contentsOf: url)
-        let fileBytes = [UInt8](data)
-        guard fileBytes.count >= 20 else {
-            throw ParserError.readFailed
-        }
-        guard readIntLE(fileBytes, offset: 0) == 0x46546C67 else {
-            throw ParserError.invalidFileType
-        }
-
-        let declaredLength = readIntLE(fileBytes, offset: 8)
-        guard declaredLength <= fileBytes.count, declaredLength >= 20 else {
-            throw ParserError.invalidFormat
-        }
-
-        var offset = 12
-        var jsonChunk: Data?
-        var binaryChunk: Data?
-        while offset + 8 <= declaredLength {
-            let chunkLength = readIntLE(fileBytes, offset: offset)
-            let chunkType = readIntLE(fileBytes, offset: offset + 4)
-            let chunkStart = offset + 8
-            let chunkEnd = chunkStart + chunkLength
-            guard chunkLength >= 0, chunkEnd <= declaredLength else {
-                throw ParserError.invalidFormat
-            }
-
-            let chunkData = data.subdata(in: chunkStart..<chunkEnd)
-            if chunkType == 0x4E4F534A {
-                jsonChunk = chunkData
-            } else if chunkType == 0x004E4942 {
-                binaryChunk = chunkData
-            }
-            offset = chunkEnd
-        }
-
-        guard
-            let jsonChunk,
-            let jsonObject = try JSONSerialization.jsonObject(with: jsonChunk) as? [String: Any]
-        else {
-            throw ParserError.metadataFailed
-        }
-
-        let meta0 = (((jsonObject["extensions"] as? [String: Any])?["VRM"] as? [String: Any])?["meta"] as? [String: Any])
-        let meta1 = (((jsonObject["extensions"] as? [String: Any])?["VRMC_vrm"] as? [String: Any])?["meta"] as? [String: Any])
-        let avatarName = (meta0?["title"] as? String)
-            ?? (meta1?["name"] as? String)
-            ?? (fileName as NSString).deletingPathExtension
-        let authorName = (meta0?["author"] as? String)
-            ?? ((meta1?["authors"] as? [String])?.first)
-        let vrmVersion = (meta0?["version"] as? String)
-            ?? (((jsonObject["extensions"] as? [String: Any])?["VRMC_vrm"] as? [String: Any])?["specVersion"] as? String)
-            ?? ((jsonObject["asset"] as? [String: Any])?["version"] as? String)
-
-        let thumbnailImageIndex: Int? = {
-            if
-                let textureIndex = meta0?["texture"] as? Int,
-                let textures = jsonObject["textures"] as? [[String: Any]],
-                textureIndex >= 0,
-                textureIndex < textures.count,
-                let source = textures[textureIndex]["source"] as? Int
-            {
-                return source
-            }
-            return meta1?["thumbnailImage"] as? Int
-        }()
-
-        let thumbnail: UIImage? = {
-            guard
-                let thumbnailImageIndex,
-                let binaryChunk,
-                let images = jsonObject["images"] as? [[String: Any]],
-                thumbnailImageIndex >= 0,
-                thumbnailImageIndex < images.count,
-                let bufferViewIndex = images[thumbnailImageIndex]["bufferView"] as? Int,
-                let mimeType = images[thumbnailImageIndex]["mimeType"] as? String,
-                mimeType.hasPrefix("image/"),
-                let bufferViews = jsonObject["bufferViews"] as? [[String: Any]],
-                bufferViewIndex >= 0,
-                bufferViewIndex < bufferViews.count,
-                let byteLength = bufferViews[bufferViewIndex]["byteLength"] as? Int
-            else {
-                return nil
-            }
-
-            let byteOffset = (bufferViews[bufferViewIndex]["byteOffset"] as? Int) ?? 0
-            let end = byteOffset + byteLength
-            guard byteOffset >= 0, end <= binaryChunk.count else {
-                return nil
-            }
-            let imageData = binaryChunk.subdata(in: byteOffset..<end)
-            return UIImage(data: imageData)
-        }()
-
-        return IOSAvatarPreview(
-            fileName: fileName,
-            avatarName: avatarName,
-            authorName: authorName,
-            vrmVersion: vrmVersion,
-            thumbnail: thumbnail
-        )
-    }
-
-    private static func readIntLE(_ bytes: [UInt8], offset: Int) -> Int {
-        Int(bytes[offset])
-            | (Int(bytes[offset + 1]) << 8)
-            | (Int(bytes[offset + 2]) << 16)
-            | (Int(bytes[offset + 3]) << 24)
-    }
-
-    private enum ParserError: LocalizedError {
-        case invalidFileType
-        case readFailed
-        case invalidFormat
-        case metadataFailed
-
-        var errorDescription: String? {
-            switch self {
-            case .invalidFileType:
-                return "VRM/GLBファイルを選択してください。"
-            case .readFailed:
-                return "VRM/GLBファイルの読み込みに失敗しました。"
-            case .invalidFormat:
-                return "VRM/GLBファイルの形式が不正です。"
-            case .metadataFailed:
-                return "VRM/GLBメタデータの解析に失敗しました。"
-            }
-        }
-    }
-}
-
-@MainActor
-private final class IOSCameraViewModel: ObservableObject {
-    private enum LensFacing {
-        case back
-        case front
-
-        var devicePosition: AVCaptureDevice.Position {
-            switch self {
-            case .back:
-                return .back
-            case .front:
-                return .front
-            }
-        }
-
-        var toggled: LensFacing {
-            switch self {
-            case .back:
-                return .front
-            case .front:
-                return .back
-            }
-        }
-    }
-
-    @Published var authorizationStatus: AVAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
-    @Published var permissionTexts: CameraPermissionTexts?
-    @Published private(set) var canSwitchCamera = false
-
-    let avCaptureSession = AVCaptureSession()
-
-    private let sessionQueue = DispatchQueue(label: "IOSCameraViewModel.sessionQueue", qos: .userInitiated)
-    private var isConfigured = false
-    private var lensFacing: LensFacing = .back
-    private var currentInput: AVCaptureDeviceInput?
-    private let permissionTextsLoader = CameraPermissionTextsLoader()
-
-    init() {
-        refreshCameraCapabilities()
-        loadPermissionTexts()
-    }
-
-    var isAuthorized: Bool {
-        authorizationStatus == .authorized
-    }
-
-    func refreshAuthorization() {
-        authorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
-        refreshCameraCapabilities()
-        if isAuthorized {
-            startSession()
-        } else {
-            stopSession()
-        }
-    }
-
-    func handlePrimaryAction() {
-        switch authorizationStatus {
-        case .authorized:
-            startSession()
-        case .notDetermined:
-            requestPermission()
-        case .denied, .restricted:
-            openAppSettings()
-        @unknown default:
-            break
-        }
-    }
-
-    func stopSession() {
-        let captureSession = avCaptureSession
-        guard captureSession.isRunning else { return }
-        sessionQueue.async {
-            captureSession.stopRunning()
-        }
-    }
-
-    private func loadPermissionTexts() {
-        permissionTextsLoader.load { texts, _ in
-            guard let texts else { return }
-            Task { @MainActor in
-                self.permissionTexts = texts
-            }
-        }
-    }
-
-    private func requestPermission() {
-        AVCaptureDevice.requestAccess(for: .video) { granted in
-            DispatchQueue.main.async {
-                self.authorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
-                if granted {
-                    self.startSession()
-                }
-            }
-        }
-    }
-
-    private func startSession() {
-        guard configureSessionIfNeeded() else { return }
-        let captureSession = avCaptureSession
-        guard !captureSession.isRunning else { return }
-        sessionQueue.async {
-            captureSession.startRunning()
-        }
-    }
-
-    func switchCamera() {
-        guard canSwitchCamera else { return }
-        let nextLensFacing = lensFacing.toggled
-        guard availableLensFacings().contains(nextLensFacing) else { return }
-        lensFacing = nextLensFacing
-        _ = configureSession(for: lensFacing)
-    }
-
-    @discardableResult
-    private func configureSessionIfNeeded() -> Bool {
-        if isConfigured, currentInput?.device.position == lensFacing.devicePosition {
-            return true
-        }
-
-        return configureSession(for: lensFacing)
-    }
-
-    @discardableResult
-    private func configureSession(for requestedLensFacing: LensFacing) -> Bool {
-        let availableLensFacings = availableLensFacings()
-        guard let resolvedLensFacing = resolvedLensFacing(
-            requestedLensFacing,
-            availableLensFacings: availableLensFacings
-        ) else {
-            isConfigured = false
-            return false
-        }
-
-        guard
-            let camera = cameraDevice(for: resolvedLensFacing),
-            let input = try? AVCaptureDeviceInput(device: camera)
-        else {
-            isConfigured = false
-            return false
-        }
-
-        avCaptureSession.beginConfiguration()
-        defer { avCaptureSession.commitConfiguration() }
-
-        if let currentInput, currentInput.device.uniqueID == input.device.uniqueID {
-            lensFacing = resolvedLensFacing
-            isConfigured = true
-            return true
-        }
-
-        if let currentInput {
-            avCaptureSession.removeInput(currentInput)
-        }
-
-        guard avCaptureSession.canAddInput(input) else {
-            if let currentInput, avCaptureSession.canAddInput(currentInput) {
-                avCaptureSession.addInput(currentInput)
-            }
-            isConfigured = currentInput != nil
-            return false
-        }
-
-        avCaptureSession.addInput(input)
-        currentInput = input
-        lensFacing = resolvedLensFacing
-        isConfigured = true
-        return true
-    }
-
-    private func openAppSettings() {
-        guard
-            let url = URL(string: UIApplication.openSettingsURLString),
-            UIApplication.shared.canOpenURL(url)
-        else {
-            return
-        }
-        UIApplication.shared.open(url)
-    }
-
-    private func refreshCameraCapabilities() {
-        let availableLensFacings = availableLensFacings()
-        canSwitchCamera = availableLensFacings.count > 1
-        if let resolvedLensFacing = resolvedLensFacing(
-            lensFacing,
-            availableLensFacings: availableLensFacings
-        ) {
-            lensFacing = resolvedLensFacing
-        }
-    }
-
-    private func availableLensFacings() -> Set<LensFacing> {
-        var lensFacings = Set<LensFacing>()
-        if cameraDevice(for: .back) != nil {
-            lensFacings.insert(.back)
-        }
-        if cameraDevice(for: .front) != nil {
-            lensFacings.insert(.front)
-        }
-        return lensFacings
-    }
-
-    private func resolvedLensFacing(
-        _ requestedLensFacing: LensFacing,
-        availableLensFacings: Set<LensFacing>
-    ) -> LensFacing? {
-        if availableLensFacings.contains(requestedLensFacing) {
-            return requestedLensFacing
-        }
-        if availableLensFacings.contains(.back) {
-            return .back
-        }
-        if availableLensFacings.contains(.front) {
-            return .front
-        }
-        return nil
-    }
-
-    private func cameraDevice(for lensFacing: LensFacing) -> AVCaptureDevice? {
-        let discoverySession = AVCaptureDevice.DiscoverySession(
-            deviceTypes: [.builtInWideAngleCamera],
-            mediaType: .video,
-            position: lensFacing.devicePosition
-        )
-        return discoverySession.devices.first
     }
 }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -7,6 +7,8 @@ import UIKit
 struct ContentView: View {
     @StateObject private var viewModel = IOSCameraViewModel()
     @State private var isFileImporterPresented = false
+    @State private var avatarPreview: IOSAvatarPreview?
+    @State private var fileErrorMessage: String?
 
     var body: some View {
         ZStack {
@@ -28,6 +30,16 @@ struct ContentView: View {
                     }
                     .padding(.top, 16)
                     .padding(.trailing, 16)
+
+                    if let avatarPreview {
+                        VStack {
+                            Spacer()
+                            IOSAvatarPreviewCard(avatarPreview: avatarPreview)
+                                .padding(.leading, 16)
+                                .padding(.bottom, 24)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
                 }
             } else {
                 PermissionPromptView(
@@ -41,13 +53,45 @@ struct ContentView: View {
         .fileImporter(
             isPresented: $isFileImporterPresented,
             allowedContentTypes: [.item],
-            allowsMultipleSelection: false
-        ) { _ in }
+            allowsMultipleSelection: false,
+            onCompletion: handleFileImport
+        )
+        .alert("ファイルエラー", isPresented: Binding(
+            get: { fileErrorMessage != nil },
+            set: { isPresented in
+                if !isPresented {
+                    fileErrorMessage = nil
+                }
+            }
+        )) {
+            Button("閉じる", role: .cancel) {
+                fileErrorMessage = nil
+            }
+        } message: {
+            Text(fileErrorMessage ?? "")
+        }
         .onAppear {
             viewModel.refreshAuthorization()
         }
         .onDisappear {
             viewModel.stopSession()
+        }
+    }
+
+    private func handleFileImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            do {
+                avatarPreview = try IOSVrmAvatarParser.parse(url: url)
+                fileErrorMessage = nil
+            } catch {
+                avatarPreview = nil
+                fileErrorMessage = error.localizedDescription
+            }
+        case .failure(let error):
+            avatarPreview = nil
+            fileErrorMessage = error.localizedDescription
         }
     }
 }
@@ -119,6 +163,204 @@ private final class PreviewContainerView: UIView {
 
     var previewLayer: AVCaptureVideoPreviewLayer {
         layer as! AVCaptureVideoPreviewLayer
+    }
+}
+
+private struct IOSAvatarPreviewCard: View {
+    let avatarPreview: IOSAvatarPreview
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Group {
+                if let thumbnail = avatarPreview.thumbnail {
+                    Image(uiImage: thumbnail)
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(Color.white.opacity(0.12))
+                        Text("VRM")
+                            .font(.headline.weight(.bold))
+                            .foregroundStyle(.white)
+                    }
+                }
+            }
+            .frame(width: 96, height: 96)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(avatarPreview.avatarName)
+                    .font(.headline)
+                Text(avatarPreview.fileName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let authorName = avatarPreview.authorName {
+                    Text("Author: \(authorName)")
+                        .font(.subheadline)
+                }
+                if let vrmVersion = avatarPreview.vrmVersion {
+                    Text("Version: \(vrmVersion)")
+                        .font(.subheadline)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(16)
+        .frame(maxWidth: 320, alignment: .leading)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
+    }
+}
+
+private struct IOSAvatarPreview {
+    let fileName: String
+    let avatarName: String
+    let authorName: String?
+    let vrmVersion: String?
+    let thumbnail: UIImage?
+}
+
+private enum IOSVrmAvatarParser {
+    static func parse(url: URL) throws -> IOSAvatarPreview {
+        let didAccess = url.startAccessingSecurityScopedResource()
+        defer {
+            if didAccess {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        let fileName = url.lastPathComponent
+        guard url.pathExtension.lowercased() == "vrm" else {
+            throw ParserError.invalidFileType
+        }
+
+        let data = try Data(contentsOf: url)
+        let fileBytes = [UInt8](data)
+        guard fileBytes.count >= 20 else {
+            throw ParserError.readFailed
+        }
+        guard readIntLE(fileBytes, offset: 0) == 0x46546C67 else {
+            throw ParserError.invalidFileType
+        }
+
+        let declaredLength = readIntLE(fileBytes, offset: 8)
+        guard declaredLength <= fileBytes.count, declaredLength >= 20 else {
+            throw ParserError.invalidFormat
+        }
+
+        var offset = 12
+        var jsonChunk: Data?
+        var binaryChunk: Data?
+        while offset + 8 <= declaredLength {
+            let chunkLength = readIntLE(fileBytes, offset: offset)
+            let chunkType = readIntLE(fileBytes, offset: offset + 4)
+            let chunkStart = offset + 8
+            let chunkEnd = chunkStart + chunkLength
+            guard chunkLength >= 0, chunkEnd <= declaredLength else {
+                throw ParserError.invalidFormat
+            }
+
+            let chunkData = data.subdata(in: chunkStart..<chunkEnd)
+            if chunkType == 0x4E4F534A {
+                jsonChunk = chunkData
+            } else if chunkType == 0x004E4942 {
+                binaryChunk = chunkData
+            }
+            offset = chunkEnd
+        }
+
+        guard
+            let jsonChunk,
+            let jsonObject = try JSONSerialization.jsonObject(with: jsonChunk) as? [String: Any]
+        else {
+            throw ParserError.metadataFailed
+        }
+
+        let meta0 = (((jsonObject["extensions"] as? [String: Any])?["VRM"] as? [String: Any])?["meta"] as? [String: Any])
+        let meta1 = (((jsonObject["extensions"] as? [String: Any])?["VRMC_vrm"] as? [String: Any])?["meta"] as? [String: Any])
+        let avatarName = (meta0?["title"] as? String)
+            ?? (meta1?["name"] as? String)
+            ?? (fileName as NSString).deletingPathExtension
+        let authorName = (meta0?["author"] as? String)
+            ?? ((meta1?["authors"] as? [String])?.first)
+        let vrmVersion = (meta0?["version"] as? String)
+            ?? (((jsonObject["extensions"] as? [String: Any])?["VRMC_vrm"] as? [String: Any])?["specVersion"] as? String)
+            ?? ((jsonObject["asset"] as? [String: Any])?["version"] as? String)
+
+        let thumbnailImageIndex: Int? = {
+            if
+                let textureIndex = meta0?["texture"] as? Int,
+                let textures = jsonObject["textures"] as? [[String: Any]],
+                textureIndex >= 0,
+                textureIndex < textures.count,
+                let source = textures[textureIndex]["source"] as? Int
+            {
+                return source
+            }
+            return meta1?["thumbnailImage"] as? Int
+        }()
+
+        let thumbnail: UIImage? = {
+            guard
+                let thumbnailImageIndex,
+                let binaryChunk,
+                let images = jsonObject["images"] as? [[String: Any]],
+                thumbnailImageIndex >= 0,
+                thumbnailImageIndex < images.count,
+                let bufferViewIndex = images[thumbnailImageIndex]["bufferView"] as? Int,
+                let mimeType = images[thumbnailImageIndex]["mimeType"] as? String,
+                mimeType.hasPrefix("image/"),
+                let bufferViews = jsonObject["bufferViews"] as? [[String: Any]],
+                bufferViewIndex >= 0,
+                bufferViewIndex < bufferViews.count,
+                let byteLength = bufferViews[bufferViewIndex]["byteLength"] as? Int
+            else {
+                return nil
+            }
+
+            let byteOffset = (bufferViews[bufferViewIndex]["byteOffset"] as? Int) ?? 0
+            let end = byteOffset + byteLength
+            guard byteOffset >= 0, end <= binaryChunk.count else {
+                return nil
+            }
+            let imageData = binaryChunk.subdata(in: byteOffset..<end)
+            return UIImage(data: imageData)
+        }()
+
+        return IOSAvatarPreview(
+            fileName: fileName,
+            avatarName: avatarName,
+            authorName: authorName,
+            vrmVersion: vrmVersion,
+            thumbnail: thumbnail
+        )
+    }
+
+    private static func readIntLE(_ bytes: [UInt8], offset: Int) -> Int {
+        Int(bytes[offset])
+            | (Int(bytes[offset + 1]) << 8)
+            | (Int(bytes[offset + 2]) << 16)
+            | (Int(bytes[offset + 3]) << 24)
+    }
+
+    private enum ParserError: LocalizedError {
+        case invalidFileType
+        case readFailed
+        case invalidFormat
+        case metadataFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidFileType:
+                return "VRMファイルを選択してください。"
+            case .readFailed:
+                return "VRMファイルの読み込みに失敗しました。"
+            case .invalidFormat:
+                return "VRMファイルの形式が不正です。"
+            case .metadataFailed:
+                return "VRMメタデータの解析に失敗しました。"
+            }
+        }
     }
 }
 

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -221,6 +221,8 @@ private struct IOSAvatarPreview {
 }
 
 private enum IOSVrmAvatarParser {
+    private static let supportedExtensions: Set<String> = ["vrm", "glb"]
+
     static func parse(url: URL) throws -> IOSAvatarPreview {
         let didAccess = url.startAccessingSecurityScopedResource()
         defer {
@@ -230,7 +232,7 @@ private enum IOSVrmAvatarParser {
         }
 
         let fileName = url.lastPathComponent
-        guard url.pathExtension.lowercased() == "vrm" else {
+        guard supportedExtensions.contains(url.pathExtension.lowercased()) else {
             throw ParserError.invalidFileType
         }
 
@@ -352,13 +354,13 @@ private enum IOSVrmAvatarParser {
         var errorDescription: String? {
             switch self {
             case .invalidFileType:
-                return "VRMファイルを選択してください。"
+                return "VRM/GLBファイルを選択してください。"
             case .readFailed:
-                return "VRMファイルの読み込みに失敗しました。"
+                return "VRM/GLBファイルの読み込みに失敗しました。"
             case .invalidFormat:
-                return "VRMファイルの形式が不正です。"
+                return "VRM/GLBファイルの形式が不正です。"
             case .metadataFailed:
-                return "VRMメタデータの解析に失敗しました。"
+                return "VRM/GLBメタデータの解析に失敗しました。"
             }
         }
     }

--- a/iosApp/iosApp/IOSCameraViewModel.swift
+++ b/iosApp/iosApp/IOSCameraViewModel.swift
@@ -1,0 +1,258 @@
+import SwiftUI
+@preconcurrency import AVFoundation
+import ComposeApp
+
+@MainActor
+final class IOSCameraViewModel: ObservableObject {
+    private enum LensFacing {
+        case back
+        case front
+
+        var devicePosition: AVCaptureDevice.Position {
+            switch self {
+            case .back:
+                return .back
+            case .front:
+                return .front
+            }
+        }
+
+        var toggled: LensFacing {
+            switch self {
+            case .back:
+                return .front
+            case .front:
+                return .back
+            }
+        }
+    }
+
+    @Published var authorizationStatus: AVAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+    @Published var permissionTexts: CameraPermissionTexts?
+    @Published private(set) var canSwitchCamera = false
+    @Published private(set) var avatarPreview: IOSAvatarPreview?
+    @Published private(set) var fileErrorMessage: String?
+
+    let avCaptureSession = AVCaptureSession()
+
+    private let sessionQueue = DispatchQueue(label: "IOSCameraViewModel.sessionQueue", qos: .userInitiated)
+    private var isConfigured = false
+    private var lensFacing: LensFacing = .back
+    private var currentInput: AVCaptureDeviceInput?
+    private let permissionTextsLoader = CameraPermissionTextsLoader()
+
+    init() {
+        refreshCameraCapabilities()
+        loadPermissionTexts()
+    }
+
+    var isAuthorized: Bool {
+        authorizationStatus == .authorized
+    }
+
+    var isFileErrorPresented: Bool {
+        fileErrorMessage != nil
+    }
+
+    func refreshAuthorization() {
+        authorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+        refreshCameraCapabilities()
+        if isAuthorized {
+            startSession()
+        } else {
+            stopSession()
+        }
+    }
+
+    func handlePrimaryAction() {
+        switch authorizationStatus {
+        case .authorized:
+            startSession()
+        case .notDetermined:
+            requestPermission()
+        case .denied, .restricted:
+            openAppSettings()
+        @unknown default:
+            break
+        }
+    }
+
+    func handleFileImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            do {
+                avatarPreview = try IOSVrmAvatarParser.parse(url: url)
+                fileErrorMessage = nil
+            } catch {
+                avatarPreview = nil
+                fileErrorMessage = error.localizedDescription
+            }
+        case .failure(let error):
+            avatarPreview = nil
+            fileErrorMessage = error.localizedDescription
+        }
+    }
+
+    func dismissFileError() {
+        fileErrorMessage = nil
+    }
+
+    func stopSession() {
+        let captureSession = avCaptureSession
+        guard captureSession.isRunning else { return }
+        sessionQueue.async {
+            captureSession.stopRunning()
+        }
+    }
+
+    private func loadPermissionTexts() {
+        permissionTextsLoader.load { texts, _ in
+            guard let texts else { return }
+            Task { @MainActor in
+                self.permissionTexts = texts
+            }
+        }
+    }
+
+    private func requestPermission() {
+        AVCaptureDevice.requestAccess(for: .video) { granted in
+            DispatchQueue.main.async {
+                self.authorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+                if granted {
+                    self.startSession()
+                }
+            }
+        }
+    }
+
+    private func startSession() {
+        guard configureSessionIfNeeded() else { return }
+        let captureSession = avCaptureSession
+        guard !captureSession.isRunning else { return }
+        sessionQueue.async {
+            captureSession.startRunning()
+        }
+    }
+
+    func switchCamera() {
+        guard canSwitchCamera else { return }
+        let nextLensFacing = lensFacing.toggled
+        guard availableLensFacings().contains(nextLensFacing) else { return }
+        lensFacing = nextLensFacing
+        _ = configureSession(for: lensFacing)
+    }
+
+    @discardableResult
+    private func configureSessionIfNeeded() -> Bool {
+        if isConfigured, currentInput?.device.position == lensFacing.devicePosition {
+            return true
+        }
+
+        return configureSession(for: lensFacing)
+    }
+
+    @discardableResult
+    private func configureSession(for requestedLensFacing: LensFacing) -> Bool {
+        let availableLensFacings = availableLensFacings()
+        guard let resolvedLensFacing = resolvedLensFacing(
+            requestedLensFacing,
+            availableLensFacings: availableLensFacings
+        ) else {
+            isConfigured = false
+            return false
+        }
+
+        guard
+            let camera = cameraDevice(for: resolvedLensFacing),
+            let input = try? AVCaptureDeviceInput(device: camera)
+        else {
+            isConfigured = false
+            return false
+        }
+
+        avCaptureSession.beginConfiguration()
+        defer { avCaptureSession.commitConfiguration() }
+
+        if let currentInput, currentInput.device.uniqueID == input.device.uniqueID {
+            lensFacing = resolvedLensFacing
+            isConfigured = true
+            return true
+        }
+
+        if let currentInput {
+            avCaptureSession.removeInput(currentInput)
+        }
+
+        guard avCaptureSession.canAddInput(input) else {
+            if let currentInput, avCaptureSession.canAddInput(currentInput) {
+                avCaptureSession.addInput(currentInput)
+            }
+            isConfigured = currentInput != nil
+            return false
+        }
+
+        avCaptureSession.addInput(input)
+        currentInput = input
+        lensFacing = resolvedLensFacing
+        isConfigured = true
+        return true
+    }
+
+    private func openAppSettings() {
+        guard
+            let url = URL(string: UIApplication.openSettingsURLString),
+            UIApplication.shared.canOpenURL(url)
+        else {
+            return
+        }
+        UIApplication.shared.open(url)
+    }
+
+    private func refreshCameraCapabilities() {
+        let availableLensFacings = availableLensFacings()
+        canSwitchCamera = availableLensFacings.count > 1
+        if let resolvedLensFacing = resolvedLensFacing(
+            lensFacing,
+            availableLensFacings: availableLensFacings
+        ) {
+            lensFacing = resolvedLensFacing
+        }
+    }
+
+    private func availableLensFacings() -> Set<LensFacing> {
+        var lensFacings = Set<LensFacing>()
+        if cameraDevice(for: .back) != nil {
+            lensFacings.insert(.back)
+        }
+        if cameraDevice(for: .front) != nil {
+            lensFacings.insert(.front)
+        }
+        return lensFacings
+    }
+
+    private func resolvedLensFacing(
+        _ requestedLensFacing: LensFacing,
+        availableLensFacings: Set<LensFacing>
+    ) -> LensFacing? {
+        if availableLensFacings.contains(requestedLensFacing) {
+            return requestedLensFacing
+        }
+        if availableLensFacings.contains(.back) {
+            return .back
+        }
+        if availableLensFacings.contains(.front) {
+            return .front
+        }
+        return nil
+    }
+
+    private func cameraDevice(for lensFacing: LensFacing) -> AVCaptureDevice? {
+        let discoverySession = AVCaptureDevice.DiscoverySession(
+            deviceTypes: [.builtInWideAngleCamera],
+            mediaType: .video,
+            position: lensFacing.devicePosition
+        )
+        return discoverySession.devices.first
+    }
+}

--- a/iosApp/iosApp/IOSVrmAvatarParser.swift
+++ b/iosApp/iosApp/IOSVrmAvatarParser.swift
@@ -1,0 +1,156 @@
+import Foundation
+import UIKit
+
+struct IOSAvatarPreview {
+    let fileName: String
+    let avatarName: String
+    let authorName: String?
+    let vrmVersion: String?
+    let thumbnail: UIImage?
+}
+
+enum IOSVrmAvatarParser {
+    private static let supportedExtensions: Set<String> = ["vrm", "glb"]
+
+    static func parse(url: URL) throws -> IOSAvatarPreview {
+        let didAccess = url.startAccessingSecurityScopedResource()
+        defer {
+            if didAccess {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        let fileName = url.lastPathComponent
+        guard supportedExtensions.contains(url.pathExtension.lowercased()) else {
+            throw ParserError.invalidFileType
+        }
+
+        let data = try Data(contentsOf: url)
+        let fileBytes = [UInt8](data)
+        guard fileBytes.count >= 20 else {
+            throw ParserError.readFailed
+        }
+        guard readIntLE(fileBytes, offset: 0) == 0x46546C67 else {
+            throw ParserError.invalidFileType
+        }
+
+        let declaredLength = readIntLE(fileBytes, offset: 8)
+        guard declaredLength <= fileBytes.count, declaredLength >= 20 else {
+            throw ParserError.invalidFormat
+        }
+
+        var offset = 12
+        var jsonChunk: Data?
+        var binaryChunk: Data?
+        while offset + 8 <= declaredLength {
+            let chunkLength = readIntLE(fileBytes, offset: offset)
+            let chunkType = readIntLE(fileBytes, offset: offset + 4)
+            let chunkStart = offset + 8
+            let chunkEnd = chunkStart + chunkLength
+            guard chunkLength >= 0, chunkEnd <= declaredLength else {
+                throw ParserError.invalidFormat
+            }
+
+            let chunkData = data.subdata(in: chunkStart..<chunkEnd)
+            if chunkType == 0x4E4F534A {
+                jsonChunk = chunkData
+            } else if chunkType == 0x004E4942 {
+                binaryChunk = chunkData
+            }
+            offset = chunkEnd
+        }
+
+        guard
+            let jsonChunk,
+            let jsonObject = try JSONSerialization.jsonObject(with: jsonChunk) as? [String: Any]
+        else {
+            throw ParserError.metadataFailed
+        }
+
+        let meta0 = (((jsonObject["extensions"] as? [String: Any])?["VRM"] as? [String: Any])?["meta"] as? [String: Any])
+        let meta1 = (((jsonObject["extensions"] as? [String: Any])?["VRMC_vrm"] as? [String: Any])?["meta"] as? [String: Any])
+        let avatarName = (meta0?["title"] as? String)
+            ?? (meta1?["name"] as? String)
+            ?? (fileName as NSString).deletingPathExtension
+        let authorName = (meta0?["author"] as? String)
+            ?? ((meta1?["authors"] as? [String])?.first)
+        let vrmVersion = (meta0?["version"] as? String)
+            ?? (((jsonObject["extensions"] as? [String: Any])?["VRMC_vrm"] as? [String: Any])?["specVersion"] as? String)
+            ?? ((jsonObject["asset"] as? [String: Any])?["version"] as? String)
+
+        let thumbnailImageIndex: Int? = {
+            if
+                let textureIndex = meta0?["texture"] as? Int,
+                let textures = jsonObject["textures"] as? [[String: Any]],
+                textureIndex >= 0,
+                textureIndex < textures.count,
+                let source = textures[textureIndex]["source"] as? Int
+            {
+                return source
+            }
+            return meta1?["thumbnailImage"] as? Int
+        }()
+
+        let thumbnail: UIImage? = {
+            guard
+                let thumbnailImageIndex,
+                let binaryChunk,
+                let images = jsonObject["images"] as? [[String: Any]],
+                thumbnailImageIndex >= 0,
+                thumbnailImageIndex < images.count,
+                let bufferViewIndex = images[thumbnailImageIndex]["bufferView"] as? Int,
+                let mimeType = images[thumbnailImageIndex]["mimeType"] as? String,
+                mimeType.hasPrefix("image/"),
+                let bufferViews = jsonObject["bufferViews"] as? [[String: Any]],
+                bufferViewIndex >= 0,
+                bufferViewIndex < bufferViews.count,
+                let byteLength = bufferViews[bufferViewIndex]["byteLength"] as? Int
+            else {
+                return nil
+            }
+
+            let byteOffset = (bufferViews[bufferViewIndex]["byteOffset"] as? Int) ?? 0
+            let end = byteOffset + byteLength
+            guard byteOffset >= 0, end <= binaryChunk.count else {
+                return nil
+            }
+            let imageData = binaryChunk.subdata(in: byteOffset..<end)
+            return UIImage(data: imageData)
+        }()
+
+        return IOSAvatarPreview(
+            fileName: fileName,
+            avatarName: avatarName,
+            authorName: authorName,
+            vrmVersion: vrmVersion,
+            thumbnail: thumbnail
+        )
+    }
+
+    private static func readIntLE(_ bytes: [UInt8], offset: Int) -> Int {
+        Int(bytes[offset])
+            | (Int(bytes[offset + 1]) << 8)
+            | (Int(bytes[offset + 2]) << 16)
+            | (Int(bytes[offset + 3]) << 24)
+    }
+
+    private enum ParserError: LocalizedError {
+        case invalidFileType
+        case readFailed
+        case invalidFormat
+        case metadataFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidFileType:
+                return "VRM/GLBファイルを選択してください。"
+            case .readFailed:
+                return "VRM/GLBファイルの読み込みに失敗しました。"
+            case .invalidFormat:
+                return "VRM/GLBファイルの形式が不正です。"
+            case .metadataFailed:
+                return "VRM/GLBメタデータの解析に失敗しました。"
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- File picker should reject non-VRM selections with a user-facing error and, when a VRM is selected, display avatar metadata and thumbnail on the camera screen.
- Provide a shared parser and platform integrations so both Android and iOS can validate VRM/GLB files and surface avatar info to the Compose UI.

### Description
- Add a common `VrmAvatarParser` that validates GLB/VRM structure, extracts VRM 0.x / VRM 1.0 meta fields and an embedded image thumbnail, returning `AvatarPreviewData` or an error via `Result`.
- Extend shared UI/state: `CameraUiState` now holds `avatarPreview` and `filePickerErrorMessage`, `CameraPermissionController` adds `FilePicker` related types, and `CameraViewModel` handles `FilePickerResult` and dismissing errors.
- Update Compose UI (`CameraScreen`) to show an error `AlertDialog` for non-VRM selections and to overlay an avatar preview card when a VRM is successfully parsed; add string resources for the dialog.
- Implement platform integrations: Android `rememberFilePickerLauncher` now reads the selected document, invokes `VrmAvatarParser` and reports `FilePickerResult` back to the view model; added `AvatarPreviewOverlay` composable on Android; iOS `ContentView.swift` handles `fileImporter` completion, validates/parses VRM in-native (`IOSVrmAvatarParser`), presents an alert on error, and shows a preview card on success.
- Add `kotlinx-serialization-json` dependency and a common unit test `ComposeAppCommonTest` covering successful metadata+thumbnail extraction and rejection of non-`.vrm` extension.
- Changes committed as: `Add VRM picker validation and avatar preview`.

### Testing
- `git diff --check` executed and passed.
- Added unit tests under `composeApp/src/commonTest` (`ComposeAppCommonTest`) that exercise `VrmAvatarParser`, but running `./gradlew :composeApp:allTests` in this environment failed during Gradle initialization because the `org.gradle.toolchains.foojay-resolver-convention:0.10.0` plugin could not be resolved from configured repositories (build did not reach test execution).
- Verified repository status with `git status --short` and committed the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c090e9020c8330b80c1577177f46e4)