### PR TITLE
Add Dependabot auto-merge workflow with Android/iOS build checks

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,149 @@
+name: Dependabot Auto Merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  IOS_SCHEME: iosApp
+  IOS_PROJECT_PATH: iosApp/iosApp.xcodeproj
+  MAX_CHANGED_FILES: 10
+  MAX_TOTAL_CHANGES: 300
+
+jobs:
+  assess:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    outputs:
+      eligible: ${{ steps.policy.outputs.eligible }}
+      reason: ${{ steps.policy.outputs.reason }}
+      update_type: ${{ steps.metadata.outputs.update-type }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Evaluate auto-merge policy
+        id: policy
+        uses: actions/github-script@v7
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        with:
+          script: |
+            const updateType = process.env.UPDATE_TYPE || '';
+            const pr = context.payload.pull_request;
+            const semverAllowed = [
+              'version-update:semver-patch',
+              'version-update:semver-minor',
+            ].includes(updateType);
+            const changedFiles = pr.changed_files ?? 0;
+            const totalChanges = (pr.additions ?? 0) + (pr.deletions ?? 0);
+            const withinSizeLimit = changedFiles <= Number(process.env.MAX_CHANGED_FILES)
+              && totalChanges <= Number(process.env.MAX_TOTAL_CHANGES);
+            const eligible = semverAllowed && withinSizeLimit;
+
+            const reasons = [];
+            if (!semverAllowed) {
+              reasons.push(`update type ${updateType || 'unknown'} is outside patch/minor`);
+            }
+            if (!withinSizeLimit) {
+              reasons.push(`diff too large (${changedFiles} files, ${totalChanges} lines changed)`);
+            }
+
+            core.setOutput('eligible', eligible ? 'true' : 'false');
+            core.setOutput('reason', reasons.join('; ') || 'eligible for auto-merge');
+
+      - name: Apply review labels
+        uses: actions/github-script@v7
+        env:
+          ELIGIBLE: ${{ steps.policy.outputs.eligible }}
+          REASON: ${{ steps.policy.outputs.reason }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.pull_request.number;
+            const eligible = process.env.ELIGIBLE === 'true';
+            const labelsToAdd = eligible
+              ? ['dependencies', 'automerge-candidate']
+              : ['dependencies', 'manual-review-required'];
+            const labelsToRemove = eligible
+              ? ['manual-review-required']
+              : ['automerge-candidate'];
+
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: labelsToAdd });
+
+            for (const name of labelsToRemove) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }
+
+            const summary = eligible
+              ? `Auto-merge candidate: ${process.env.UPDATE_TYPE}`
+              : `Manual review required: ${process.env.REASON}`;
+            core.notice(summary);
+
+  build:
+    if: github.actor == 'dependabot[bot]'
+    needs: assess
+    runs-on: macos-15
+    steps:
+      - name: Check out pull request head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build Android debug app
+        run: ./gradlew :composeApp:assembleDebug
+
+      - name: Build iOS app for simulator
+        run: |
+          xcodebuild \
+            -project "$IOS_PROJECT_PATH" \
+            -scheme "$IOS_SCHEME" \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            build
+
+  enable-automerge:
+    if: github.actor == 'dependabot[bot]' && needs.assess.outputs.eligible == 'true'
+    needs:
+      - assess
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable pull request auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -configuration Debug 
 - `composeApp/src/iosMain` の `CameraPreviewHost` はプレースホルダーで、iOS のネイティブホスト前提です。
 - package 名と applicationId は現在サンプル値の `com.example.vtubercamera_kmp_ver` を使用しています。
 
+## Dependabot 運用ポリシー
+
+- Dependabot の Pull Request では GitHub Actions で Android / iOS ビルドを自動実行します。
+- 自動マージ対象は `patch` / `minor` 相当の更新で、かつ差分が `10` ファイル以内・追加削除合計 `300` 行以内のものに限定します。
+- `major` 更新や大きな差分の更新は `manual-review-required` ラベルを付け、人間の確認を必須にします。
+
 ## 今後の整理候補
 
 - iOS 側の実装を shared UI / shared state とどう整合させるかを明確にする


### PR DESCRIPTION
### Motivation

- Dependabot の軽微な依存更新（パッチ / マイナー）は自動でビルドして問題なければ自動マージしたいという運用要件に対応するため。 
- 一方でメジャーアップデートや大きな差分は人間の確認を必須にして安全性を保つため。 

### Description

- 新規に `.github/workflows/dependabot-auto-merge.yml` を追加し、`pull_request_target` トリガーで `dependabot[bot]` の PR を評価するジョブを実装しました。 
- Dependabot メタデータ（`dependabot/fetch-metadata@v2`）で更新種別を判定し、`patch` / `minor` のみ候補としつつ差分制限（最大 `10` ファイル、変更行合計 `300` 行）を設けて判定するロジックを導入しました。 
- 判定結果に基づきラベル付け（`automerge-candidate` / `manual-review-required`）を行い、判定可の場合は Android の `./gradlew :composeApp:assembleDebug` と iOS の `xcodebuild`（シミュレータ向け）でビルドを実行し、ビルド成功後に `peter-evans/enable-pull-request-automerge@v3` で squash マージを有効化します。 
- `README.md` に Dependabot 運用ポリシーを追記して、自動ビルド／自動マージ条件と手動レビュー要件を明記しました。 

### Testing

- ワークフローファイルと既存の `.github/dependabot.yml` を Ruby の `YAML.load_file` で検証し両方ともパース出来ることを確認しました。 
- `git diff --check` を実行して差分整合性に問題がないことを確認しました。 
- これらの自動検証は成功しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c09f8c6b2c8330b61692800fab86f6)