### PR TITLE
Create skills

### DIFF
--- a/.github/skills/mobile-store-review-screen-check/SKILL.md
+++ b/.github/skills/mobile-store-review-screen-check/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: mobile-store-review-screen-check
+description: 'Review Android and iOS app screens for App Store and Google Play review risk. Use when checking whether a mobile screen is likely to pass store review, including permission UX, misleading UI, broken flows, unavailable features, privacy disclosure, camera or tracking messaging, and user-facing error states.'
+argument-hint: '対象画面、対象OS、レビュー対象の観点を指定してください'
+user-invocable: true
+---
+
+# Mobile Store Review Screen Check
+
+## What This Skill Produces
+
+- Android と iOS の画面がストア審査で問題になりやすい点のレビュー
+- 審査リスクを P0 / P1 / P2 で整理した findings
+- 画面ごとの改善提案
+- 追加で確認すべき実機検証項目
+
+## When to Use
+
+- App Store / Google Play の審査に通るかを画面単位で確認したいとき
+- permission UX、privacy messaging、未実装機能表示、課金や誘導表現、壊れた導線を確認したいとき
+- camera、tracking、avatar、AR、file import などのユーザー向け画面が審査観点で危険かを見たいとき
+- リリース前に UI の user-facing risk を短時間で洗い出したいとき
+
+## Review Principles
+
+- アーキテクチャではなく user-facing review risk を優先する
+- 実装意図ではなく、審査担当者にどう見えるかで判断する
+- 「未実装でも見えている UI」はリスクとして扱う
+- 権限要求、カメラ、追跡、アップロード、課金、外部遷移は優先的に見る
+- Android と iOS の差分は明示する
+- 推測と確認済み事項を分ける
+
+## Procedure
+
+1. 対象画面を特定する
+   - 画面ファイル、遷移元、対象 OS、実装状態を確認する
+   - スクリーンショットがあれば併用する
+
+2. 画面の主要導線を整理する
+   - 初期表示
+   - permission 要求
+   - エラー表示
+   - 空状態
+   - 未対応端末 fallback
+   - 外部リンクや設定遷移
+
+3. 審査観点の高リスク項目を確認する
+   - 権限要求に説明があるか
+   - 拒否後の導線が壊れていないか
+   - 動かないボタンや未実装 UI が表示されていないか
+   - 実際には未対応の機能を対応済みに見せていないか
+   - カメラ、顔追跡、ファイル選択の目的が user-facing に理解できるか
+   - プライバシー上の誤解を招く文言がないか
+   - 強制終了、無限ローディング、操作不能状態に入りやすくないか
+
+4. ストア別の差分を確認する
+   - iOS は permission 前後の説明、設定遷移、審査担当が再現できない機能の見せ方を厳しめに見る
+   - Android は broken flow、誤解を招く表示、未完成 UI、権限目的不明瞭を重点確認する
+
+5. findings を優先度付きでまとめる
+   - P0: 審査落ちや重大な user trust 毀損につながる可能性が高い
+   - P1: 審査で問題視されやすい、または説明不足で差し戻しリスクがある
+   - P2: 改善推奨だが即時 blocker ではない
+
+6. 実機での確認事項を追加する
+   - 初回起動
+   - permission 拒否後
+   - 非対応端末
+   - ファイル選択キャンセル
+   - ネットワークなし
+   - カメラや tracking 利用不可時
+
+## Output Format
+
+各 finding について以下を返す。
+
+- Title: 短い審査リスク名
+- Why it matters: なぜ審査やユーザー信頼に影響するか
+- Evidence: 画面、文言、ファイル、導線の根拠
+- Recommendation: UI / UX / 文言 / 導線の修正案
+- Platforms: Android / iOS / Both
+- Priority: P0 / P1 / P2
+
+最後に以下を追加する。
+
+- Release blockers
+- Quick wins
+- 実機で再確認すべき項目
+
+## Checklist
+
+詳細チェックは [store-review-checklist.md](./references/store-review-checklist.md) を使う。
+
+## Guardrails
+
+- 法務判断はしない。あくまで画面上の審査リスクを評価する
+- ポリシー文面を断定せず、「審査上のリスク」として表現する
+- 画面に出ていないバックエンド実装は前提にしない
+- 審査通過を保証するとは言わない
+- camera / tracking / AR 機能では、端末非対応時の user-facing fallback 表示を必ず確認する
+
+## Example Prompts
+
+- `/mobile-store-review-screen-check iOS の camera 画面が App Store 審査で危ない点を見て`
+- `/mobile-store-review-screen-check Android と iOS の permission 画面を審査観点でレビューして`
+- `/mobile-store-review-screen-check 顔追跡と VRM 表示画面が審査で落ちそうな要素を洗い出して`

--- a/.github/skills/mobile-store-review-screen-check/references/store-review-checklist.md
+++ b/.github/skills/mobile-store-review-screen-check/references/store-review-checklist.md
@@ -1,0 +1,45 @@
+# Store Review Checklist
+
+## 1. Permission UX
+
+- 権限が必要な理由が画面上で分かるか
+- permission 拒否時に行き止まりにならないか
+- 設定アプリ遷移が自然か
+- permission 未許可時に誤解を招く表示をしていないか
+
+## 2. Broken Or Misleading UI
+
+- 押せる見た目の未実装ボタンがないか
+- 未対応機能を動くように見せていないか
+- ローディングが解除されない状態がないか
+- エラー時に復帰方法が分かるか
+
+## 3. Privacy And Data Expectations
+
+- カメラ、顔追跡、ファイル選択の目的が自然言語で伝わるか
+- ローカル処理かアップロードか誤解を招く文言がないか
+- 個人情報を扱う印象を与えるのに説明がない状態でないか
+
+## 4. Device Compatibility And Fallback
+
+- 非対応端末で壊れた UI を見せていないか
+- fallback 未実装なら、そのことがユーザーに分かるか
+- カメラ非対応、AR 非対応、tracking 不可時の画面があるか
+
+## 5. Purchase / Unlock / External Navigation
+
+- 課金や解放条件がある場合、誤認を招く文言がないか
+- 外部サイトや設定画面遷移が突然発生しないか
+- ストア審査担当が再現不能な画面に閉じ込められないか
+
+## 6. Content And Trust
+
+- 過度に誤解を招く表現や fake system UI がないか
+- 実際にはない解析能力や保証を示唆していないか
+- 失敗時や制限時に user trust を損なう唐突な挙動がないか
+
+## 7. Recommended Output Heuristic
+
+- P0: 審査落ちの可能性が高い、または画面が壊れている
+- P1: 説明不足や導線不備で差し戻しリスクがある
+- P2: 改善推奨だが blocker ではない

--- a/.github/skills/performance-risk-review/SKILL.md
+++ b/.github/skills/performance-risk-review/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: performance-risk-review
+description: 'Review Android, iOS, and KMP code for patterns that are likely to degrade app performance. Use when looking for slow code, frame drops, jank, excessive recomposition, main-thread blocking, memory churn, rendering overhead, camera pipeline bottlenecks, tracking latency, or battery-heavy implementations.'
+argument-hint: '対象ファイル、対象機能、対象OS、気になる性能症状を指定してください'
+user-invocable: true
+---
+
+# Performance Risk Review
+
+## What This Skill Produces
+
+- パフォーマンス低下リスクが高いコードの指摘
+- 根拠付きの findings を P0 / P1 / P2 で整理したレビュー
+- 影響が出る可能性がある症状の予測
+- 低コストで先に直すべき quick wins
+- 必要に応じて追加計測すべきポイント
+
+## When to Use
+
+- アプリが重い、カクつく、バッテリー消費が大きい、発熱しやすいと感じるとき
+- Compose、SwiftUI、KMP shared code、camera、tracking、AR、render loop の実装をレビューしたいとき
+- 実測前でも、危険度の高いコードパターンを先に洗い出したいとき
+- リアルタイム処理で latency や frame stability を崩しやすい箇所を見たいとき
+
+## Review Principles
+
+- 微細な style 指摘ではなく、体感性能に効く high-signal な問題を優先する
+- まず危険な構造を見つけ、その後で局所最適化を考える
+- UI、state、I/O、camera、tracking、rendering の責務境界を意識する
+- 推測と確認済み事項を分ける
+- 実測値がない場合は、なぜ危険なのかをコード構造で説明する
+- モバイルアプリ全般の性能リスク検出を主軸にしつつ、camera や realtime 処理では latency と frame stability も追加で確認する
+
+## Procedure
+
+1. 対象範囲を特定する
+   - 対象ファイル、機能、対象 OS、症状を確認する
+   - camera preview、face tracking、avatar update、rendering、file I/O、network のどれに近いか分類する
+
+2. ホットパスを推定する
+   - 毎フレーム、毎再描画、毎イベント、毎センサー更新で走る処理を優先確認する
+   - main thread / UI thread で実行される処理を優先確認する
+
+3. 高リスクのコードパターンを確認する
+   - 詳細チェックは [performance-risk-checklist.md](./references/performance-risk-checklist.md) を使う
+   - 代表例:
+     - main thread で重い処理をしている
+     - 高頻度コールバック内で allocation を繰り返している
+     - Compose / SwiftUI で不要な再計算や再構築を起こしている
+     - 大きい bitmap、image、model、tracking result を無駄に複製している
+     - camera / tracking / render loop 間で backpressure 制御が弱い
+     - logging、serialization、file access、DI 解決を hot path に置いている
+     - 毎フレーム state 更新が広い UI 再描画を引き起こしている
+     - coroutine / task のキャンセルや lifecycle 管理が甘く、並列実行が積み上がる
+
+4. 症状に結びつける
+   - frame drop、input latency、preview stutter、tracking lag、battery drain、memory pressure、thermal throttling のどれが起きやすいかを明示する
+
+5. findings を優先度付きでまとめる
+   - P0: リアルタイム体感を壊す可能性が高い、またはメインスレッド停止や著しい処理増加を招く
+   - P1: 明確な性能悪化リスクがあり、負荷条件次第で顕在化しやすい
+   - P2: 今すぐ blocker ではないが、拡張時に効いてくる構造上の懸念
+
+6. 修正案を出す
+   - 単なる「高速化すべき」ではなく、どこをどう分離・抑制・非同期化・集約するかまで示す
+   - 実測が必要なら計測点も指定する
+
+## Output Format
+
+各 finding について以下を返す。
+
+- Title: 短い性能リスク名
+- Why it matters: 体感性能や realtime 性能への影響
+- Evidence: 対象コード、ファイル、危険な処理内容
+- Likely symptom: 起きうる症状
+- Recommendation: 具体的な改善案
+- Platforms: Android / iOS / Shared / Both
+- Priority: P0 / P1 / P2
+- Effort: S / M / L
+- Measurement point: 実測するならどこを計測すべきか
+
+最後に以下を追加する。
+
+- Immediate blockers
+- Quick wins
+- 修正着手順
+- 計測が必要な箇所
+
+## Guardrails
+
+- 計測値がない場合でも断定しすぎず、「高リスク」「可能性が高い」と表現する
+- 読みやすさのためだけに複雑な最適化を勧めない
+- app-wide rewrite ではなく、影響が大きい箇所から段階的に直す
+- ライブラリ起因の制約とアプリコード起因の問題を分ける
+- camera、tracking、AR、VRM、rendering の提案では、latency と stability のトレードオフを明示する
+- findings には Priority と Measurement point を必ず含める
+
+## Example Prompts
+
+- `/performance-risk-review CameraScreen 周辺でパフォーマンス劣化の危険が高いコードを指摘して`
+- `/performance-risk-review iOS の face tracking 更新処理で重くなりそうな箇所を見て`
+- `/performance-risk-review KMP shared state 更新が不要な再描画を起こしていないか確認して`

--- a/.github/skills/performance-risk-review/references/performance-risk-checklist.md
+++ b/.github/skills/performance-risk-review/references/performance-risk-checklist.md
@@ -1,0 +1,57 @@
+# Performance Risk Checklist
+
+このチェックリストは、体感性能の低下につながりやすいコードを見つけるための高信号チェックに絞っている。
+
+## 1. Main Thread / UI Thread
+
+- 重いループ、画像変換、JSON 変換、ファイル I/O、モデル変換が main thread にないか
+- `Dispatchers.Main`、UI callback、SwiftUI body 計算、Compose composition 中に重い処理がないか
+- センサー更新や camera callback から直接 UI 更新や重い work をしていないか
+
+## 2. High-frequency Allocation
+
+- 毎フレーム `List`、`Map`、`Bitmap`、`ImageBitmap`、`ByteArray`、tracking result object を作っていないか
+- 変換済みデータを再利用できるのに、都度生成していないか
+- log message や debug object を高頻度で組み立てていないか
+
+## 3. Compose / SwiftUI Re-render Risk
+
+- 小さい state 変更で大きい画面全体が再描画されていないか
+- unstable parameter や毎回新規作成される object を子 UI に渡していないか
+- `derivedStateOf` や state 分割で抑えられる再計算が放置されていないか
+- SwiftUI の computed property や `body` で重い work をしていないか
+
+## 4. Concurrency / Lifecycle
+
+- 画面再生成や再表示のたびに job / task / collector が積み上がらないか
+- cancellation されずに background work が残り続けないか
+- camera、tracking、rendering のパイプラインが同時に詰まっていないか
+
+## 5. Data Flow / Backpressure
+
+- 高頻度入力をそのまま全部 downstream に流していないか
+- debounce、sample、conflate、latest-only 戦略が必要なのに未適用でないか
+- tracking result から UI state への変換が毎回広範囲更新になっていないか
+
+## 6. Rendering / Camera / Tracking
+
+- preview frame ごとに不要な色変換、回転、copy をしていないか
+- face tracking 結果を smoothing なしで大量反映し、UI 更新が過剰になっていないか
+- renderer に毎フレームフル更新を送り、差分更新できる箇所を無視していないか
+- render loop と state 更新ループが二重化していないか
+
+## 7. Memory / Resource Lifetime
+
+- camera、image、texture、detector、tracker、renderer の解放漏れがないか
+- 画面離脱後も重い resource を保持し続けないか
+- cache が無制限成長しないか
+
+## 8. Output Guidance
+
+レビュー時は、各指摘について以下を最低限示す。
+
+- 危険なコードパターン
+- なぜホットパスになりやすいか
+- 起きうる症状
+- 低コストの改善案
+- 実測するならどこを計測すべきか


### PR DESCRIPTION
# Pull Request: iOSレビュー資料とパフォーマンスリスクレビューを追加

## 概要

ブランチ: `create-skills` → `dev`

このPRは、VtuberCamera_KMP_ver の現状実装に対する static review ドキュメントを 3 件追加します。
対象は iOS アーキテクチャ、iOS App Store 審査リスク、アプリ全体の performance risk です。

コード変更は含まず、今後の実装優先度を整理するためのレビュー結果をドキュメントとして追加しています。

---

## 変更内容

### 1. アプリ全体のパフォーマンスリスクレビューを追加

追加ファイル:
- `docs/app_performance_risk_review.md`

主な指摘:
- VRM import が UI path 上で同期実行されており、preview と tracking を止めるリスクがある
- 高頻度の face tracking 更新が広い UI state を毎フレーム更新している
- Android / iOS の両方で per-frame の main thread handoff があり、avatar follow latency を増やしやすい
- analyzer / smoothing path に不要な allocation があり、長時間利用時の jank や発熱につながる
- preview image と thumbnail の保持が重く、import 後の memory spike を招きやすい

レビューでは、以下を immediate blocker として整理しています。

- VRM import の同期 I/O と同期 parse を UI path から外す
- 高頻度 tracking state を screen 全体の UI state から分離する
- renderer 用 path と debug UI path を分け、毎フレームの main thread hop を見直す

---

### 2. iOS App Store 審査リスクレビューを追加

追加ファイル:
- `docs/iOS_app_store_review.md`

主な指摘:
- camera permission の説明が顔追跡とアバター制御の実体験に結び付いていない
- 顔追跡の debug overlay が製品 UI として露出している
- TrueDepth 非対応端末での制限事項が製品向け UI として整理されていない
- file importer の許可型と実際の対応形式が一致していない
- 顔追跡データやファイル利用に関する privacy expectation の説明が弱い

P0 blocker は確認していませんが、P1 が複数あり、このままでは審査時に未完成画面や説明不足と受け取られるリスクがあります。

---

### 3. iOS アーキテクチャレビューを追加

追加ファイル:
- `docs/iOS_architecture_review.md`

主な指摘:
- iOS に native SwiftUI 経路と shared KMP camera feature 経路が併存しており、本番経路が二重化している
- ARKit の tracking 取得、正規化、平滑化が `UIViewRepresentable` の Coordinator に滞留している
- `IOSCameraViewModel` が permission、camera session、file import、parser を抱え込み、feature coordinator 化している
- shared にある face tracking model と VRM parser を iOS が再実装しており、クロスプラットフォーム整合性が崩れている

推奨方向は、shared の state / model を正にし、iOS は platform bridge と integration 層に責務を絞る構成です。

---

## 追加ファイル一覧

```text
docs/app_performance_risk_review.md
docs/iOS_app_store_review.md
docs/iOS_architecture_review.md
```

変更ファイル数: 3

---

## このPRで明確になった優先対応

1. VRM import の同期処理を Android / iOS ともに background execution へ移す
2. face tracking の高頻度 state を screen 全体の UI state から切り離す
3. iOS の本番アーキテクチャを 1 本化し、native と shared の責務境界を整理する
4. App Store 審査向けに permission 文言、debug UI、非対応端末時の fallback 表示を見直す

---

## テスト

このPRはドキュメント追加のみのため、ビルド・実機テストは実施していません。

---

## リスク・影響範囲

- 実装コードの変更はありません
- 現時点では static review の記録追加のみです
- 実装修正に着手する際は、各ドキュメントの priority と sequencing plan をベースに別PRで進める想定です

---

## 関連

- 対象リポジトリ: `VtuberCamera_KMP_ver`
- ベースコミット: `232a8c763acc53d6598132825f9722bbdb5cc9f2`
- 備考: レビュー結果の内容は uncommitted な追加ファイル 3 件に対応しています