### PR TITLE
Add latent-bug-investigation skill under .github/skills

### DIFF
--- a/.github/skills/latent-bug-investigation/SKILL.md
+++ b/.github/skills/latent-bug-investigation/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: latent-bug-investigation
+description: 'Investigate existing source code for latent defects that may not have surfaced yet. Use when reviewing Android/iOS/KMP code for crash risks, logic bugs, race conditions, lifecycle leaks, nullability issues, state inconsistencies, edge-case failures, and error-handling gaps before release.'
+argument-hint: '対象ファイルや機能、再現しづらい症状、重点的に見たい観点を指定してください'
+user-invocable: true
+---
+
+# Latent Bug Investigation
+
+## What This Skill Produces
+
+- 既存コードに潜む不具合リスクの洗い出し
+- 重大度 (P0/P1/P2) と再現性観点を含む findings
+- 発生条件（トリガー）と影響範囲の整理
+- 低コストで先に潰すべき修正候補
+- 必要な追加テスト観点
+
+## When to Use
+
+- 「今は動いているが将来壊れそう」な箇所を事前に見つけたいとき
+- release 前に crash / data corruption / stuck state の芽を減らしたいとき
+- 非同期処理、状態管理、ライフサイクル、例外処理の抜け漏れを点検したいとき
+- 再現が難しい不具合の原因候補を構造から推定したいとき
+
+## Investigation Principles
+
+- 見た目の style 指摘より、障害化しうる高シグナルを優先する
+- 「発生条件」「影響」「根拠コード」を必ずセットで示す
+- 確認済み事実と推定を分ける
+- Android / iOS / shared KMP の責務境界を意識する
+- 再現手順が曖昧でも、起こりうる順序競合を明示する
+
+## Procedure
+
+1. 対象範囲を確定する
+   - 対象機能、対象 OS、症状（クラッシュ、固まり、取りこぼし等）を確認
+   - 重要度の高いフロー（起動、権限、カメラ初期化、画面遷移、保存/復元）を優先
+
+2. 失敗モードを仮説化する
+   - null / 未初期化参照
+   - 非同期完了順序の逆転
+   - lifecycle 変化中の callback 競合
+   - stale state の参照
+   - 例外握りつぶしによる silent failure
+
+3. 高リスクパターンを点検する
+   - 詳細チェックは [latent-bug-checklist.md](./references/latent-bug-checklist.md) を参照
+   - 特に、UI スレッド境界、キャンセル漏れ、タイムアウト欠如、境界値、再入可能性を確認
+
+4. 各 finding を評価する
+   - 発生条件（いつ起こるか）
+   - 影響範囲（クラッシュ/データ不整合/操作不能/表示破綻）
+   - 再現性（高/中/低）
+
+5. 優先順位付きで提案する
+   - P0: 本番障害化しやすく影響が大きい
+   - P1: 条件次第で顕在化しうる主要リスク
+   - P2: すぐ障害化しないが将来の負債になる
+
+6. 修正と検証観点を提示する
+   - 防御コード、状態遷移整理、同期戦略、タイムアウト、ログ改善
+   - 追加で必要なテスト（ユニット/統合/UI/手動再現）を提示
+
+## Output Format
+
+各 finding は以下を含める。
+
+- Title: 不具合リスクの短い名前
+- Why it matters: 何が壊れるか
+- Trigger condition: どの条件で起こるか
+- Evidence: 根拠ファイルと実装上の懸念
+- Recommendation: 修正方針（最小変更を優先）
+- Platforms: Android / iOS / Shared / Both
+- Priority: P0 / P1 / P2
+- Reproducibility: High / Medium / Low
+- Suggested test: 再発防止の検証方法
+
+最後に以下を追加する。
+
+- Immediate blockers
+- Quick wins
+- 追加で確認すべきテストシナリオ
+
+## Guardrails
+
+- 断定しすぎない（不確実な点は仮説として扱う）
+- 大規模リライトより段階的改善を優先する
+- 実装されていない前提機能を勝手に仮定しない
+- 影響が軽微な style 指摘で findings を埋めない
+- 可能な限り「修正コストの低い順」で提案する
+
+## Example Prompts
+
+- `/latent-bug-investigation CameraScreen 周辺で潜在バグを洗い出して`
+- `/latent-bug-investigation 画面遷移時にまれに落ちる原因候補を調査して`
+- `/latent-bug-investigation KMP の状態更新で競合しそうな箇所を見て`

--- a/.github/skills/latent-bug-investigation/references/latent-bug-checklist.md
+++ b/.github/skills/latent-bug-investigation/references/latent-bug-checklist.md
@@ -1,0 +1,49 @@
+# Latent Bug Checklist
+
+潜在不具合の検出で優先的に見る観点です。
+
+## 1. Crash / Fatal Risk
+
+- nullable 値の強制アンラップや未検証アクセスがある
+- 初期化前オブジェクトへアクセスしている
+- 画面破棄後に UI 更新 callback が走る
+- 例外が上位に伝播してアプリ終了を招く
+
+## 2. Concurrency / Ordering
+
+- 同一 state を複数 coroutine/task が同時更新している
+- キャンセルされるべき job/task が生存し続ける
+- callback 到着順に依存した実装（遅延応答で破綻）
+- lock / mutex 不在で整合性が壊れうる
+
+## 3. Lifecycle / Resource
+
+- 画面終了時に listener, observer, stream の解除漏れ
+- camera / tracker / renderer の start-stop 対応が非対称
+- バックグラウンド移行時の一時停止・復帰が不完全
+
+## 4. Data Integrity / State Machine
+
+- 状態遷移が暗黙的で不正状態を許容している
+- エラー後に復旧不能な state が残る
+- 一部だけ更新される部分失敗で整合性を失う
+- キャッシュと実データの同期条件が曖昧
+
+## 5. Error Handling / Observability
+
+- catch で握りつぶして失敗が見えない
+- リトライ無限ループや backoff 不在
+- タイムアウト未設定で待ち続ける可能性
+- 問題調査に必要なログコンテキスト不足
+
+## 6. Boundary / Edge Cases
+
+- 空データ、巨大データ、遅い端末、低メモリ時の挙動未考慮
+- 権限拒否、オフライン、途中キャンセル、画面回転などの遷移に弱い
+- ファイル I/O やデコード失敗時の fallback がない
+
+## 7. Platform / KMP Separation
+
+- shared 層が platform 依存 API に密結合
+- Android/iOS 片側だけ例外処理や検証が欠ける
+- expect/actual で契約不一致がある


### PR DESCRIPTION
### Motivation

- Provide a reusable, promptable workflow to detect latent defects (crashes, race conditions, lifecycle/resource leaks, nullability/state issues, and edge-case failures) in Android/iOS/KMP code before release.

### Description

- Add ` .github/skills/latent-bug-investigation/SKILL.md` which defines an invocable skill with metadata, investigation principles, step-by-step procedure, output format, guardrails, and example prompts.
- Add ` .github/skills/latent-bug-investigation/references/latent-bug-checklist.md` containing practical checklist items for Crash, Concurrency, Lifecycle, Data Integrity, Error Handling, Edge Cases, and KMP boundary checks.
- Files follow existing skill metadata conventions (`name`, `description`, `argument-hint`, `user-invocable`) and are written to be used by the repository's skill tooling.

### Testing

- Ran `git diff --check` which completed successfully.
- Ran `git status --short` which showed the new skill directory as expected.
- Staged and committed the new files with `git add .github/skills/latent-bug-investigation && git commit -m "Add latent bug investigation skill"` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7549e7d448330ada63624de3c43f9)