### PR TITLE
[codex] Add repository guidance and device operation skills

### DIFF
--- a/.github/instructions/repository-overview.instructions.md
+++ b/.github/instructions/repository-overview.instructions.md
@@ -1,0 +1,60 @@
+---
+description: "Use when explaining the VtuberCamera_KMP_ver repository as a whole, onboarding someone to the codebase, summarizing project structure, or answering where major functionality lives. Keep repository-level explanations aligned with current implementation status, platform split, and the difference between implemented code and future plans."
+name: "Repository Overview Guidance"
+---
+# Repository Overview Guidance
+
+- リポジトリ全体を説明するときは、最初にプロダクト目的を短く示す。
+- このリポジトリは Android / iOS 向けの VTuber camera 基盤を Kotlin Multiplatform で整備しているが、現時点の中心は camera MVP であることを明示する。
+- AR、VRM、face tracking、avatar control は将来拡張の文脈で触れ、実装済みのように言わない。
+
+## Current Reality First
+
+- 説明の基準は現行コードと README を優先し、調査メモや設計 docs は計画や候補として区別する。
+- 実装済み事項と未実装事項を分けて書く。
+- 仕様書や research 文書の内容を、そのまま現在の挙動として扱わない。
+
+## Default Explanation Order
+
+1. プロダクト目的
+2. 現在の platform split
+3. 主要ディレクトリと責務
+4. 現在できること
+5. まだ未実装の主機能
+6. 必要ならビルドや確認方法
+
+## Platform Split
+
+- `composeApp` は KMP アプリ本体で、shared UI と Android 実装を含む。
+- Android の実カメラ実装は `composeApp` 側にあり、CameraX を使う。
+- iOS の実カメラ実装は現時点で `iosApp` 側にあり、SwiftUI + AVFoundation を使う。
+- `composeApp/src/iosMain` は iOS 向け KMP エントリポイントだが、現在の実カメラ実装の中心ではない。
+
+## High-Value Directories To Mention
+
+- `composeApp/src/commonMain`: 共有 UI、状態、リソース
+- `composeApp/src/androidMain`: Android の CameraX 実装と権限処理
+- `composeApp/src/iosMain`: iOS 向け shared 側の入口
+- `iosApp`: iOS ネイティブ実装と Xcode プロジェクト
+- `docs`: 実装方針、調査、設計メモ
+- `gradle/libs.versions.toml`: 主要依存関係の定義
+
+## Explanation Rules
+
+- Android と iOS で実装位置が非対称であることを隠さない。
+- 「shared でできていること」と「platform ごとに持っていること」を分けて説明する。
+- repo overview では、細部の class 名よりも責務分割と現在地を優先する。
+- README と矛盾しない要約を優先する。
+- 実装状況に不確実さがある場合は、断定せず確認前提で述べる。
+
+## If The User Asks For Current Features
+
+- Android では camera preview、権限確認、フロント / バック切替が主な実装済み要素であることを起点にする。
+- iOS でも camera preview、権限確認、フロント / バック切替、ファイル選択の流れを説明候補にする。
+- 写真撮影、保存 / 削除、フラッシュ、ズーム、AR / VRM 連携は未実装または別フェーズとして扱う。
+
+## If The User Asks For Architecture
+
+- KMP の shared UI / state と platform-specific camera 実装の分担を先に説明する。
+- iOS は完全 shared 化されていない現状を明示する。
+- face tracking や avatar control の話題に入る場合は、必要に応じて avatar-domain instructions の観点も併用する。

--- a/.github/skills/android-device-operation/SKILL.md
+++ b/.github/skills/android-device-operation/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: android-device-operation
+description: 'Operate an Android physical device or emulator according to user instructions. Use when launching apps, tapping through flows, reproducing bugs, handling permission dialogs, taking screenshots, inspecting UI state, checking logcat, collecting observations, or executing manual test steps over adb.'
+argument-hint: '対象アプリ、対象端末、やりたい操作、期待結果、報告粒度を指定してください'
+user-invocable: true
+---
+
+# Android Device Operation
+
+## What This Skill Produces
+
+- ユーザ指示に従った Android 実機またはエミュレータの具体的な操作
+- 実施した手順、観察結果、失敗箇所、未実施事項を含む実行レポート
+- 必要に応じてスクリーンショット、画面状態確認、logcat 取得の提案
+- 再現確認や手動テストで使える操作ログ
+
+## When to Use
+
+- Android 実機やエミュレータをユーザの指示どおりに操作したいとき
+- アプリ起動、画面遷移、権限ダイアログ対応、再現手順の実行をしたいとき
+- バグ再現、QA 手順、確認作業、簡易 E2E 操作を adb ベースで進めたいとき
+- スクリーンショット取得や実行観察を伴う手動検証をしたいとき
+
+## Preconditions
+
+- `adb` が利用可能であること
+- 少なくとも 1 台の Android 実機またはエミュレータが接続されていること
+- 対象アプリの package 名、起動方法、または操作対象が分かること
+- 破壊的な操作、課金、個人情報入力、外部送信を伴う場合は、ユーザの明示指示があること
+
+## Operating Principles
+
+- ユーザ指示をそのまま曖昧に実行せず、必要なら操作可能な adb コマンドへ分解する
+- 複数端末がある場合は、対象シリアルを確定してから進める
+- 画面状態が不明なまま座標タップを連打しない
+- 各重要ステップ後に、現在画面や結果を確認し、必要な証拠を残す
+- 失敗時は無言で別解を乱発せず、何が確認済みで何が不明かを切り分ける
+- ユーザの意図を超える操作はしない
+
+## Procedure
+
+1. 依頼内容を具体化する
+   - 対象アプリ、操作対象画面、期待結果、報告粒度を整理する
+   - 指示が曖昧なら、少なくとも以下を確認する
+     - 対象端末: 実機 / エミュレータ / 指定シリアル
+     - 対象アプリ: package 名、activity 名、または起動経路
+     - ゴール: ただ操作するのか、再現確認なのか、結果報告まで必要か
+
+2. 端末接続を確認する
+   - `adb devices` で接続端末を確認する
+   - 複数端末がある場合は、以後のコマンドで対象シリアルを固定する
+   - `offline`、`unauthorized`、未接続なら先に解消する
+
+3. 初期状態を整える
+   - 必要なら対象アプリのインストール有無を確認する
+   - ユーザ指示に応じてアプリを起動、再起動、force-stop、またはホーム画面へ戻す
+   - 再現性が必要なら、開始状態を明示する
+
+4. 操作手順を adb 操作へ変換する
+   - 使う候補:
+     - `adb shell am start`
+     - `adb shell input tap`
+     - `adb shell input text`
+     - `adb shell input keyevent`
+     - `adb shell input swipe`
+     - `adb exec-out screencap -p`
+   - 文字入力、戻る、ホーム、通知展開、スクロール、権限許可などを具体的な操作列へ落とす
+
+5. 1 ステップずつ実行し、要所で検証と証拠取得を行う
+   - 画面遷移や重要アクションの後は、現在画面を確認する
+   - 確認方法は、状況に応じてスクリーンショット、UI 階層取得、logcat、またはアプリ状態確認を使い分ける
+   - 再現確認や不具合調査では、少なくとも 1 つは証拠を残す
+   - 権限ダイアログや想定外のモーダルが出たら、ユーザ意図に沿う選択肢のみ実行する
+
+6. 分岐を処理する
+   - 複数端末が見つかった場合:
+     - ユーザ指定がなければ対象端末を確認する
+   - package 名や起動方法が不明な場合:
+     - ワークスペース内の設定や manifest を探索して特定する
+   - 座標が不明な場合:
+     - まず画面確認手段を使い、必要なら座標操作に落とす
+   - 操作結果が期待と違う場合:
+     - どの時点でずれたか、確認済み事実と未確認事項を分けて報告する
+
+7. 実行結果をまとめる
+   - 実施した操作を順番に列挙する
+   - 実際に確認できた結果と、確認できていない点を分ける
+   - 再現失敗時は、失敗ではなく「未再現」「前提不足」「画面差異」など原因に近い言葉で整理する
+
+## Output Format
+
+以下の形式で返す。
+
+- Target: 対象端末、シリアル、アプリ
+- Goal: ユーザが求めた操作または確認内容
+- Actions executed: 実行した操作を時系列で列挙
+- Observed result: 実際に観察した結果
+- Evidence: スクリーンショット、画面状態、logcat、補足観察
+- Blockers: 実行を妨げた要因
+- Unverified: まだ確認できていない点
+- Next step: 続けるなら何をするか
+
+## Guardrails
+
+- package 名、activity 名、端末シリアルが不明なまま決め打ちしない
+- 危険な shell 操作、データ削除、設定変更、課金、送信操作は明示指示なしに行わない
+- UI が見えていない状態で推測タップを続けない
+- 実行したコマンドと観察結果を混同しない
+- ユーザが期待結果を述べていても、観察結果は別に記録する
+
+## Example Prompts
+
+- `/android-device-operation Android エミュレータでアプリを起動して、カメラ権限ダイアログが出たら許可し、その後の画面状態を報告して`
+- `/android-device-operation 実機 serial を指定して、ログイン画面まで遷移し、途中で詰まった場所を教えて`
+- `/android-device-operation このアプリの再現手順どおりに操作して、期待結果と実結果の差分をレポートして`

--- a/.github/skills/implementation-branch-and-file-commit/SKILL.md
+++ b/.github/skills/implementation-branch-and-file-commit/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: implementation-branch-and-file-commit
+description: 'Guide implementation work with a git safety workflow. Use when starting coding, feature implementation, bug fixes, or refactors and you want to avoid committing directly on main: if the current branch is main, create a new branch before editing; after implementation, review changed files and commit each changed file one by one.'
+argument-hint: '実装対象、feature か fix か、タスク名を指定してください'
+user-invocable: true
+---
+
+# Implementation Branch And File Commit
+
+## What This Skill Produces
+
+- 実装前に main 直作業を避けるためのブランチ確認と分岐判断
+- feature/<task-name> または fix/<task-name> の固定命名で作業ブランチを決める手順
+- 実装後に変更ファイルを 1 ファイルずつ整理してコミットする手順
+- 1 ファイル 1 コミットの例外を許可する条件と確認ポイント
+- 最終的な未コミットファイルとコミット済みファイルの確認
+
+## When to Use
+
+- 実装開始前に、今いるブランチのまま作業してよいか確認したいとき
+- main ブランチでの直接実装を避けたいとき
+- 変更履歴を細かく追えるように、ファイル単位でコミットしたいとき
+- 小さめの修正を積み上げながら、安全に実装を進めたいとき
+
+## Decision Points
+
+1. 現在のブランチが main か
+   - main なら、新しい作業ブランチを作成してから実装に入る
+   - main 以外なら、そのブランチ名が今回の作業目的に合っているか確認して続行する
+
+2. 新規ブランチ名をどう付けるか
+   - 新機能や通常の実装なら feature/<task-name> を使う
+   - バグ修正なら fix/<task-name> を使う
+   - <task-name> は作業内容が短く分かる英小文字の kebab-case を使う
+
+3. 変更ファイルを本当に 1 ファイルずつコミットできるか
+   - できるなら、そのままファイル単位でコミットする
+   - 密結合で同時反映が必要な複数ファイルがあるなら、例外としてまとめてよい
+   - 例外コミットにする場合は、なぜ分割できないかを先に明示する
+
+4. 生成物や一時ファイルをコミット対象に含めるか
+   - 明示的に必要な成果物だけを含める
+   - build 出力や一時ファイルは通常コミットしない
+
+## Procedure
+
+1. 作業開始前に対象タスクを確認する
+   - 何を実装するか、どのリポジトリで作業するかを明確にする
+   - 新機能なら feature/<task-name>、バグ修正なら fix/<task-name> を前提に task-name を決める
+
+2. 現在の git 状態を確認する
+   - 現在のブランチ名を確認する
+   - 未コミット変更が残っていないか確認する
+   - すでに他作業の差分が混ざっている場合は、今回の実装と分離できるかを見る
+
+3. main ブランチ判定を行う
+   - 現在のブランチが main なら、新しいブランチを作成して切り替える
+   - ブランチ名は feature/<task-name> または fix/<task-name> の固定ルールに従う
+   - main でなければ、そのまま作業を継続してよいかを判断する
+
+4. 実装を進める
+   - 必要なコード変更、テスト、ドキュメント更新を行う
+   - 変更は今回のタスクに必要な範囲に絞る
+
+5. 実装後に差分をファイル単位で整理する
+   - 変更されたファイル一覧を確認する
+   - 各ファイルが単独コミットとして意味を持つか確認する
+   - 意味の薄いノイズ変更や不要差分を除外する
+
+6. 1 ファイルずつコミットする
+   - 各ファイルについて内容を確認する
+   - そのファイルだけをステージする
+   - そのファイルの変更内容を説明するコミットメッセージでコミットする
+   - 次のファイルへ進む前に、想定外の差分が混ざっていないか確認する
+
+7. 例外コミットを扱う
+   - 複数ファイルが密結合で、分割するとレビュー性や動作整合性が落ちる場合は例外を許可する
+   - 例外時は、どのファイル群をなぜまとめるかを明示する
+   - 例外コミットでも、無関係な差分は含めない
+
+8. 最終確認を行う
+   - すべての対象ファイルがコミット済みか確認する
+   - 未コミット変更が残っている場合は、意図したものか確認する
+   - 必要なら最後に変更履歴を見て、コミット粒度が妥当か点検する
+
+## Quality Checks
+
+- 実装開始前に main 直作業を避けられている
+- ブランチ名が feature/<task-name> または fix/<task-name> で作業内容と対応している
+- 各コミットが 1 ファイルに限定されている、または例外理由が明確である
+- 各コミットメッセージがそのファイルの意図を説明している
+- 不要な生成物や無関係な差分が含まれていない
+
+## Guardrails
+
+- main 上での直接実装は避ける
+- ブランチ名は feature/<task-name> または fix/<task-name> を使う
+- 1 ファイル 1 コミットを優先するが、整合性を壊すなら例外を許可する
+- 複数ファイルを同時にコミットしないと意味が崩れる場合は、例外理由を明示して確認する
+- ユーザーが求めていない git 履歴改変や destructive な操作はしない
+- 既存の未コミット変更が今回の作業と無関係なら巻き込まない
+
+## Output Format
+
+返答には必要に応じて以下を含める。
+
+- Current branch: 現在のブランチ名
+- Branch action: main から新規ブランチを作成したか、そのまま継続したか
+- Branch name: feature/<task-name> または fix/<task-name>
+- Implementation scope: 今回の実装対象
+- File commit plan: どのファイルをどの順でコミットするか
+- Exceptions: 1 ファイル 1 コミットを崩す必要がある箇所
+- Final status: 未コミット差分の有無
+
+## Example Prompts
+
+- `/implementation-branch-and-file-commit この修正に入る前に main なら新しいブランチを切って、終わったらファイルごとにコミットして進めて`
+- `/implementation-branch-and-file-commit CameraScreen の実装を始める。main だったら分岐して、変更ファイルは1つずつコミットしたい`
+- `/implementation-branch-and-file-commit このタスクを安全な git 運用で進めたい。ブランチ確認からファイル単位コミットまでやって`

--- a/.github/skills/ios-device-operation/SKILL.md
+++ b/.github/skills/ios-device-operation/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: ios-device-operation
+description: 'Operate an iPhone real device or iOS Simulator according to user instructions. Use when launching apps, reproducing flows, handling permission dialogs, capturing screenshots, checking device state, or executing manual verification steps on iOS with xcrun simctl or xcrun devicectl.'
+argument-hint: '対象アプリ、対象端末、やりたい操作、期待結果、報告粒度を指定してください'
+user-invocable: true
+---
+
+# iOS Device Operation
+
+## What This Skill Produces
+
+- ユーザ指示に従った iPhone 実機または iOS Simulator の具体的な操作
+- 実施した手順、観察結果、失敗箇所、未実施事項を含む実行レポート
+- 必要に応じてスクリーンショット、端末状態確認、補助ログ取得の提案
+- 標準 CLI で不足する場合に、XCTest、Appium、WebDriverAgent などの代替操作手段を使うべきかどうかの判断
+- 再現確認や手動テストで使える操作ログ
+
+## When to Use
+
+- iPhone 実機や iOS Simulator をユーザの指示どおりに操作したいとき
+- アプリ起動、画面遷移、権限ダイアログ対応、再現手順の実行をしたいとき
+- バグ再現、QA 手順、確認作業、簡易 E2E 操作を iOS 側で進めたいとき
+- 標準 CLI だけでは足りず、XCTest、Appium、WebDriverAgent のような UI 自動化手段へ切り替えるべきか判断したいとき
+- スクリーンショット取得や実行観察を伴う手動検証をしたいとき
+
+## Preconditions
+
+- `xcrun` が利用可能であること
+- 対象が iOS Simulator の場合は `xcrun simctl`、iPhone 実機の場合は `xcrun devicectl` が利用可能であること
+- 少なくとも 1 台の iPhone 実機または iOS Simulator が利用可能であること
+- 対象アプリの bundle identifier、起動方法、または操作対象が分かること
+- 実機を扱う場合は、端末が接続済みでロック解除、信頼済み、必要なら Developer Mode 有効であること
+- 破壊的な操作、課金、個人情報入力、外部送信を伴う場合は、ユーザの明示指示があること
+
+## Operating Principles
+
+- ユーザ指示をそのまま曖昧に実行せず、まず実機か Simulator かを確定する
+- 複数端末がある場合は、対象 UDID、名前、または識別子を確定してから進める
+- iOS では実機と Simulator で使える操作コマンドが異なるため、同一手順として扱わない
+- 標準 CLI で不可能な UI タップや文字入力を、見えていないまま推測で実行しない
+- 各重要ステップ後に、現在画面や結果を確認し、必要な証拠を残す
+- 失敗時は無言で別解を乱発せず、何が確認済みで何が不明かを切り分ける
+- ユーザの意図を超える操作はしない
+
+## Procedure
+
+1. 依頼内容を具体化する
+   - 対象アプリ、操作対象画面、期待結果、報告粒度を整理する
+   - 指示が曖昧なら、少なくとも以下を確認する
+     - 対象端末: iPhone 実機 / iOS Simulator / 指定 UDID
+     - 対象アプリ: bundle identifier、Xcode target、起動経路、または deeplink
+     - ゴール: ただ操作するのか、再現確認なのか、結果報告まで必要か
+
+2. 対象端末の利用可否を確認する
+   - iOS Simulator は `xcrun simctl list devices` で確認する
+   - iPhone 実機は `xcrun devicectl list devices` で確認する
+   - 複数端末がある場合は、以後のコマンドで対象 UDID や device identifier を固定する
+   - 実機が未接続、未信頼、ロック中なら先に解消する
+
+3. 初期状態を整える
+   - 必要なら対象アプリのインストール有無を確認する
+   - iOS Simulator の場合は必要に応じて `xcrun simctl boot <device>` で起動する
+   - ユーザ指示に応じてアプリを起動、再起動、終了、またはホーム相当の開始状態へ揃える
+   - 再現性が必要なら、開始状態を明示する
+
+4. 操作手順を iOS の操作手段へ変換する
+   - iOS Simulator で使う候補:
+     - `xcrun simctl launch <device> <bundle-id>`
+     - `xcrun simctl terminate <device> <bundle-id>`
+     - `xcrun simctl openurl <device> <url>`
+     - `xcrun simctl privacy <device> ...`
+     - `xcrun simctl io <device> screenshot <path>`
+     - `xcrun simctl spawn <device> ...`
+   - iPhone 実機で使う候補:
+     - `xcrun devicectl device process launch --device <id> <bundle-id>`
+     - `xcrun devicectl device process terminate --device <id> <bundle-id-or-pid>`
+     - `xcrun devicectl device info apps --device <id>`
+     - `xcrun devicectl device info processes --device <id>`
+     - `xcrun devicectl device info details --device <id>`
+     - `xcrun devicectl device orientation --device <id> ...`
+   - 任意の画面タップや文字入力が必要な場合は、まず既存の UI テスト基盤、Appium / WebDriverAgent、または別の操作手段があるかを確認する
+   - 標準 CLI だけでは扱えない操作を無理に決め打ちせず、可能な操作と不可能な操作を分ける
+
+5. 1 ステップずつ実行し、要所で検証と証拠取得を行う
+   - 画面遷移や重要アクションの後は、現在画面や端末状態を確認する
+   - iOS Simulator では `xcrun simctl io ... screenshot` を優先して証跡を残す
+   - 実機ではアプリ一覧、プロセス一覧、端末詳細、必要なら Xcode 側の補助手段を使って状態を確認する
+   - 再現確認や不具合調査では、少なくとも 1 つは証拠を残す
+   - 権限ダイアログや想定外のモーダルが出たら、ユーザ意図に沿う選択肢のみ実行する
+
+6. 分岐を処理する
+   - 複数端末が見つかった場合:
+     - ユーザ指定がなければ対象端末を確認する
+   - bundle identifier や起動方法が不明な場合:
+     - ワークスペース内の Xcode 設定、Info.plist、またはビルド設定を探索して特定する
+   - 任意 UI 操作が必要だが標準 CLI で実行できない場合:
+     - 既存 UI テスト資産の有無を確認する
+     - ない場合は、どこまで自動化できてどこからが未対応かを明示して報告する
+   - 操作結果が期待と違う場合:
+     - どの時点でずれたか、確認済み事実と未確認事項を分けて報告する
+
+7. 実行結果をまとめる
+   - 実施した操作を順番に列挙する
+   - 実際に確認できた結果と、確認できていない点を分ける
+   - 再現失敗時は、失敗ではなく「未再現」「前提不足」「画面差異」「CLI 制約」など原因に近い言葉で整理する
+
+## Output Format
+
+以下の形式で返す。
+
+- Target: 対象端末、UDID または識別子、アプリ
+- Goal: ユーザが求めた操作または確認内容
+- Actions executed: 実行した操作を時系列で列挙
+- Observed result: 実際に観察した結果
+- Evidence: スクリーンショット、端末状態、補足ログ、補足観察
+- Blockers: 実行を妨げた要因
+- Unverified: まだ確認できていない点
+- Next step: 続けるなら何をするか
+
+## Guardrails
+
+- bundle identifier、端末識別子、対象環境が不明なまま決め打ちしない
+- 危険な shell 操作、データ削除、設定変更、課金、送信操作は明示指示なしに行わない
+- UI が見えていない状態で推測タップを続けない
+- 標準 CLI で不可能な操作を、できる前提で案内しない
+- 実行したコマンドと観察結果を混同しない
+- ユーザが期待結果を述べていても、観察結果は別に記録する
+
+## Example Prompts
+
+- `/ios-device-operation iOS Simulator でアプリを起動して、カメラ権限状態を確認し、スクリーンショット付きで報告して`
+- `/ios-device-operation 接続中の iPhone 実機で bundle id を指定してアプリを起動し、起動できたかを報告して`
+- `/ios-device-operation この iOS アプリの再現手順どおりに進められるところまで進めて、CLI 制約で止まる場合はその地点を含めてレポートして`


### PR DESCRIPTION
## What changed
- add repository overview guidance for explaining the current KMP camera app structure
- add Android device operation skill for adb-based manual app/device workflows
- add iOS device operation skill for simulator and real-device workflows via `simctl` and `devicectl`
- add implementation branch and file commit skill for safer git workflow guidance

## Why
- make repository-level explanations consistent with the current implementation status
- provide reusable operator skills for Android and iOS device-driven verification work
- document a safer implementation workflow for branch creation and file-by-file commits

## Impact
- improves `.github` instructions and skill coverage for future Codex-assisted work
- gives contributors clearer guidance for repository onboarding, manual device operations, and git safety practices

## Validation
- reviewed branch diff against `main`
- confirmed branch `create-checkOut-skill` is already pushed to `origin`
- left unrelated untracked docs files out of the PR scope