### PR TITLE
Extract shared face-to-avatar mapper, smoothing and VRM expression aliasing

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/AvatarMotionSmoother.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/AvatarMotionSmoother.kt
@@ -1,0 +1,62 @@
+package com.example.vtubercamera_kmp_ver.avatar.mapping
+
+import com.example.vtubercamera_kmp_ver.avatar.model.AvatarExpressionWeights
+import com.example.vtubercamera_kmp_ver.avatar.model.AvatarRigState
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Shared smoothing strategy used by mapper.
+ *
+ * `trackingAlpha` is used while tracking is stable, `lostAlpha` while decaying to neutral.
+ */
+data class AvatarMotionSmoothingConfig(
+    val trackingAlpha: Float = 0.45f,
+    val lostAlpha: Float = 0.15f,
+)
+
+object AvatarMotionSmoother {
+    fun smooth(
+        previous: AvatarRenderState,
+        target: AvatarRenderState,
+        config: AvatarMotionSmoothingConfig,
+    ): AvatarRenderState {
+        val alpha = when (target.trackingStatus) {
+            com.example.vtubercamera_kmp_ver.avatar.state.AvatarTrackingStatus.Tracking -> config.trackingAlpha
+            com.example.vtubercamera_kmp_ver.avatar.state.AvatarTrackingStatus.Lost,
+            com.example.vtubercamera_kmp_ver.avatar.state.AvatarTrackingStatus.NotTracked,
+            -> config.lostAlpha
+        }.coerceIn(0f, 1f)
+
+        return target.copy(
+            rig = smoothRig(previous.rig, target.rig, alpha),
+            expressions = smoothExpressions(previous.expressions, target.expressions, alpha),
+        )
+    }
+
+    private fun smoothRig(
+        previous: AvatarRigState,
+        target: AvatarRigState,
+        alpha: Float,
+    ): AvatarRigState = AvatarRigState(
+        headYawDegrees = lerp(previous.headYawDegrees, target.headYawDegrees, alpha),
+        headPitchDegrees = lerp(previous.headPitchDegrees, target.headPitchDegrees, alpha),
+        headRollDegrees = lerp(previous.headRollDegrees, target.headRollDegrees, alpha),
+    )
+
+    private fun smoothExpressions(
+        previous: AvatarExpressionWeights,
+        target: AvatarExpressionWeights,
+        alpha: Float,
+    ): AvatarExpressionWeights = AvatarExpressionWeights(
+        leftEyeBlink = lerp(previous.leftEyeBlink, target.leftEyeBlink, alpha),
+        rightEyeBlink = lerp(previous.rightEyeBlink, target.rightEyeBlink, alpha),
+        jawOpen = lerp(previous.jawOpen, target.jawOpen, alpha),
+        mouthSmile = lerp(previous.mouthSmile, target.mouthSmile, alpha),
+    )
+
+    private fun lerp(from: Float, to: Float, alpha: Float): Float = from + (to - from) * alpha
+}
+
+internal fun Float.clamp(minValue: Float, maxValue: Float): Float = max(minValue, min(this, maxValue))

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/FaceToAvatarMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/FaceToAvatarMapper.kt
@@ -1,0 +1,101 @@
+package com.example.vtubercamera_kmp_ver.avatar.mapping
+
+import com.example.vtubercamera_kmp_ver.avatar.model.AvatarExpressionWeights
+import com.example.vtubercamera_kmp_ver.avatar.model.AvatarRigState
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarTrackingStatus
+import com.example.vtubercamera_kmp_ver.camera.NormalizedFaceFrame
+
+/**
+ * Clamp policy for raw tracker values to avoid invalid avatar outputs.
+ */
+data class AvatarMappingClampConfig(
+    val yawRangeDegrees: ClosedFloatingPointRange<Float> = -40f..40f,
+    val pitchRangeDegrees: ClosedFloatingPointRange<Float> = -25f..25f,
+    val rollRangeDegrees: ClosedFloatingPointRange<Float> = -30f..30f,
+    val expressionRange: ClosedFloatingPointRange<Float> = 0f..1f,
+)
+
+data class FaceToAvatarMapperConfig(
+    val trackingConfidenceThreshold: Float = 0.5f,
+    val clamp: AvatarMappingClampConfig = AvatarMappingClampConfig(),
+    val smoothing: AvatarMotionSmoothingConfig = AvatarMotionSmoothingConfig(),
+)
+
+/**
+ * Pure shared mapper that translates face-tracking frame data into [AvatarRenderState].
+ */
+class FaceToAvatarMapper(
+    private val config: FaceToAvatarMapperConfig = FaceToAvatarMapperConfig(),
+) {
+    fun map(
+        frame: NormalizedFaceFrame?,
+        previousState: AvatarRenderState = AvatarRenderState.Neutral,
+    ): AvatarRenderState {
+        val target = when {
+            frame == null -> buildDecayState(previousState, AvatarTrackingStatus.NotTracked)
+            frame.trackingConfidence >= config.trackingConfidenceThreshold -> buildTrackingState(frame)
+            else -> buildDecayState(
+                previousState = previousState,
+                status = AvatarTrackingStatus.Lost,
+                frame = frame,
+            )
+        }
+
+        return AvatarMotionSmoother.smooth(
+            previous = previousState,
+            target = target,
+            config = config.smoothing,
+        )
+    }
+
+    private fun buildTrackingState(frame: NormalizedFaceFrame): AvatarRenderState = AvatarRenderState(
+        rig = AvatarRigState(
+            headYawDegrees = frame.headYawDegrees.clamp(
+                minValue = config.clamp.yawRangeDegrees.start,
+                maxValue = config.clamp.yawRangeDegrees.endInclusive,
+            ),
+            headPitchDegrees = frame.headPitchDegrees.clamp(
+                minValue = config.clamp.pitchRangeDegrees.start,
+                maxValue = config.clamp.pitchRangeDegrees.endInclusive,
+            ),
+            headRollDegrees = frame.headRollDegrees.clamp(
+                minValue = config.clamp.rollRangeDegrees.start,
+                maxValue = config.clamp.rollRangeDegrees.endInclusive,
+            ),
+        ),
+        expressions = AvatarExpressionWeights(
+            leftEyeBlink = frame.leftEyeBlink.clamp(
+                minValue = config.clamp.expressionRange.start,
+                maxValue = config.clamp.expressionRange.endInclusive,
+            ),
+            rightEyeBlink = frame.rightEyeBlink.clamp(
+                minValue = config.clamp.expressionRange.start,
+                maxValue = config.clamp.expressionRange.endInclusive,
+            ),
+            jawOpen = frame.jawOpen.clamp(
+                minValue = config.clamp.expressionRange.start,
+                maxValue = config.clamp.expressionRange.endInclusive,
+            ),
+            mouthSmile = frame.mouthSmile.clamp(
+                minValue = config.clamp.expressionRange.start,
+                maxValue = config.clamp.expressionRange.endInclusive,
+            ),
+        ),
+        trackingStatus = AvatarTrackingStatus.Tracking,
+        trackingConfidence = frame.trackingConfidence.clamp(0f, 1f),
+        sourceTimestampMillis = frame.timestampMillis,
+    )
+
+    private fun buildDecayState(
+        previousState: AvatarRenderState,
+        status: AvatarTrackingStatus,
+        frame: NormalizedFaceFrame? = null,
+    ): AvatarRenderState = AvatarRenderState(
+        rig = AvatarRigState(),
+        expressions = AvatarExpressionWeights(),
+        trackingStatus = status,
+        trackingConfidence = frame?.trackingConfidence?.clamp(0f, 1f) ?: 0f,
+        sourceTimestampMillis = frame?.timestampMillis ?: previousState.sourceTimestampMillis,
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/VrmExpressionMap.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/VrmExpressionMap.kt
@@ -30,7 +30,9 @@ object VrmExpressionMap {
 
     /**
      * Resolves the best runtime expression name from a model's supported names.
-     * First match wins so callers should keep [availableNames] ordered by their engine preference.
+     * [availableNames] is treated as an unordered membership set; priority is determined solely
+     * by the alias list order returned by [aliasesFor] — the first alias that is present in
+     * [availableNames] wins.
      */
     fun resolve(
         expression: AvatarExpressionId,

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/VrmExpressionMap.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/VrmExpressionMap.kt
@@ -1,0 +1,56 @@
+package com.example.vtubercamera_kmp_ver.avatar.mapping
+
+/**
+ * Canonical expression ids used by shared mapper.
+ */
+enum class AvatarExpressionId {
+    BlinkLeft,
+    BlinkRight,
+    JawOpen,
+    Smile,
+}
+
+enum class VrmSpecVersion {
+    Vrm0,
+    Vrm1,
+}
+
+/**
+ * VRM 0.x and 1.0 have different naming conventions; this map keeps renderer integration simple
+ * by exposing a canonical id and ordered aliases.
+ */
+object VrmExpressionMap {
+    fun aliasesFor(
+        expression: AvatarExpressionId,
+        specVersion: VrmSpecVersion,
+    ): List<String> = when (specVersion) {
+        VrmSpecVersion.Vrm0 -> vrm0Aliases.getValue(expression)
+        VrmSpecVersion.Vrm1 -> vrm1Aliases.getValue(expression)
+    }
+
+    /**
+     * Resolves the best runtime expression name from a model's supported names.
+     * First match wins so callers should keep [availableNames] ordered by their engine preference.
+     */
+    fun resolve(
+        expression: AvatarExpressionId,
+        specVersion: VrmSpecVersion,
+        availableNames: Set<String>,
+    ): String? = aliasesFor(expression, specVersion).firstOrNull { alias ->
+        alias in availableNames
+    }
+
+    private val vrm0Aliases: Map<AvatarExpressionId, List<String>> = mapOf(
+        AvatarExpressionId.BlinkLeft to listOf("blink_l", "blinkLeft", "Blink_L"),
+        AvatarExpressionId.BlinkRight to listOf("blink_r", "blinkRight", "Blink_R"),
+        AvatarExpressionId.JawOpen to listOf("a", "aa", "jawOpen"),
+        AvatarExpressionId.Smile to listOf("joy", "smile", "happy"),
+    )
+
+    private val vrm1Aliases: Map<AvatarExpressionId, List<String>> = mapOf(
+        AvatarExpressionId.BlinkLeft to listOf("blinkLeft", "blink_l", "BlinkLeft"),
+        AvatarExpressionId.BlinkRight to listOf("blinkRight", "blink_r", "BlinkRight"),
+        AvatarExpressionId.JawOpen to listOf("aa", "a", "jawOpen"),
+        AvatarExpressionId.Smile to listOf("happy", "smile", "joy"),
+    )
+}

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/FaceToAvatarMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/FaceToAvatarMapperTest.kt
@@ -1,0 +1,115 @@
+package com.example.vtubercamera_kmp_ver.avatar.mapping
+
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarTrackingStatus
+import com.example.vtubercamera_kmp_ver.camera.NormalizedFaceFrame
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FaceToAvatarMapperTest {
+
+    @Test
+    fun mapTrackingFrameClampsAndSmoothsToRigAndExpressions() {
+        val mapper = FaceToAvatarMapper(
+            FaceToAvatarMapperConfig(
+                smoothing = AvatarMotionSmoothingConfig(
+                    trackingAlpha = 1f,
+                    lostAlpha = 1f,
+                ),
+            ),
+        )
+
+        val mapped = mapper.map(
+            frame = NormalizedFaceFrame(
+                timestampMillis = 100L,
+                trackingConfidence = 0.95f,
+                headYawDegrees = 120f,
+                headPitchDegrees = -40f,
+                headRollDegrees = 35f,
+                leftEyeBlink = 1.5f,
+                rightEyeBlink = -0.2f,
+                jawOpen = 0.4f,
+                mouthSmile = 0.6f,
+            ),
+            previousState = AvatarRenderState.Neutral,
+        )
+
+        assertEquals(AvatarTrackingStatus.Tracking, mapped.trackingStatus)
+        assertEquals(40f, mapped.rig.headYawDegrees)
+        assertEquals(-25f, mapped.rig.headPitchDegrees)
+        assertEquals(30f, mapped.rig.headRollDegrees)
+        assertEquals(1f, mapped.expressions.leftEyeBlink)
+        assertEquals(0f, mapped.expressions.rightEyeBlink)
+        assertEquals(0.4f, mapped.expressions.jawOpen)
+        assertEquals(100L, mapped.sourceTimestampMillis)
+    }
+
+    @Test
+    fun lowConfidenceFrameMovesToLostAndDecaysTowardNeutral() {
+        val mapper = FaceToAvatarMapper(
+            FaceToAvatarMapperConfig(
+                trackingConfidenceThreshold = 0.7f,
+                smoothing = AvatarMotionSmoothingConfig(
+                    trackingAlpha = 1f,
+                    lostAlpha = 0.5f,
+                ),
+            ),
+        )
+
+        val previous = AvatarRenderState(
+            trackingStatus = AvatarTrackingStatus.Tracking,
+            rig = com.example.vtubercamera_kmp_ver.avatar.model.AvatarRigState(headYawDegrees = 20f),
+            expressions = com.example.vtubercamera_kmp_ver.avatar.model.AvatarExpressionWeights(jawOpen = 0.8f),
+            sourceTimestampMillis = 50L,
+            trackingConfidence = 1f,
+        )
+
+        val mapped = mapper.map(
+            frame = NormalizedFaceFrame(
+                timestampMillis = 120L,
+                trackingConfidence = 0.3f,
+                headYawDegrees = 15f,
+                headPitchDegrees = 10f,
+                headRollDegrees = 4f,
+                leftEyeBlink = 0.1f,
+                rightEyeBlink = 0.2f,
+                jawOpen = 0.7f,
+                mouthSmile = 0.4f,
+            ),
+            previousState = previous,
+        )
+
+        assertEquals(AvatarTrackingStatus.Lost, mapped.trackingStatus)
+        assertEquals(10f, mapped.rig.headYawDegrees)
+        assertEquals(0.4f, mapped.expressions.jawOpen)
+        assertEquals(120L, mapped.sourceTimestampMillis)
+    }
+
+    @Test
+    fun nullFrameTransitionsToNotTrackedAndContinuesDecay() {
+        val mapper = FaceToAvatarMapper(
+            FaceToAvatarMapperConfig(
+                smoothing = AvatarMotionSmoothingConfig(
+                    trackingAlpha = 1f,
+                    lostAlpha = 0.25f,
+                ),
+            ),
+        )
+
+        val previous = AvatarRenderState(
+            trackingStatus = AvatarTrackingStatus.Lost,
+            rig = com.example.vtubercamera_kmp_ver.avatar.model.AvatarRigState(headRollDegrees = 12f),
+            expressions = com.example.vtubercamera_kmp_ver.avatar.model.AvatarExpressionWeights(mouthSmile = 0.8f),
+            sourceTimestampMillis = 777L,
+            trackingConfidence = 0.2f,
+        )
+
+        val mapped = mapper.map(frame = null, previousState = previous)
+
+        assertEquals(AvatarTrackingStatus.NotTracked, mapped.trackingStatus)
+        assertEquals(9f, mapped.rig.headRollDegrees)
+        assertEquals(0.6f, mapped.expressions.mouthSmile)
+        assertEquals(777L, mapped.sourceTimestampMillis)
+        assertEquals(0f, mapped.trackingConfidence)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/VrmExpressionMapTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/VrmExpressionMapTest.kt
@@ -1,0 +1,24 @@
+package com.example.vtubercamera_kmp_ver.avatar.mapping
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class VrmExpressionMapTest {
+
+    @Test
+    fun resolveUsesVersionAwareAliasPriority() {
+        val vrm0 = VrmExpressionMap.resolve(
+            expression = AvatarExpressionId.Smile,
+            specVersion = VrmSpecVersion.Vrm0,
+            availableNames = setOf("happy", "joy"),
+        )
+        val vrm1 = VrmExpressionMap.resolve(
+            expression = AvatarExpressionId.Smile,
+            specVersion = VrmSpecVersion.Vrm1,
+            availableNames = setOf("happy", "joy"),
+        )
+
+        assertEquals("joy", vrm0)
+        assertEquals("happy", vrm1)
+    }
+}


### PR DESCRIPTION
### Motivation
- 抽出した純粋な mapper でカメラの顔追跡フレームから `AvatarRenderState` を生成し、レンダラ実装からマッピングロジックを独立させるため。 
- yaw/pitch/roll をアバターの rig に写像し、blink/jaw/smile を expression weight に写像する明確な方針を導入するため。 
- 値の clamp とスムージング（追跡中とロストで別の係数）および VRM 0.x/1.0 の expression 名差分吸収のポリシーを共有化するため。 

### Description
- 追加した `FaceToAvatarMapper` は `NormalizedFaceFrame` を受け取り `AvatarRenderState` を返す純粋 mapper を実装し、confidence 閾値で `Tracking`/`Lost`/`NotTracked` を決定します (`composeApp/src/commonMain/.../FaceToAvatarMapper.kt`).
- 入力 clamp ポリシーは `AvatarMappingClampConfig` で定義し、yaw/pitch/roll と expression の範囲を制限します (`FaceToAvatarMapper.kt`).
- スムージングは `AvatarMotionSmoother` に分離され、`AvatarMotionSmoothingConfig` によって `trackingAlpha` と `lostAlpha` を切り替えます (`composeApp/src/commonMain/.../AvatarMotionSmoother.kt`).
- VRM 0.x と 1.0 の命名差分を吸収する `VrmExpressionMap` を追加し、canonical expression id と優先順エイリアスで実行時名を解決します (`composeApp/src/commonMain/.../VrmExpressionMap.kt`).
- マッパー挙動と VRM alias 解決の単体テスト `FaceToAvatarMapperTest` と `VrmExpressionMapTest` を追加しました (`composeApp/src/commonTest/...`).

### Testing
- 単体テストを追加し、`FaceToAvatarMapperTest` と `VrmExpressionMapTest` を作成しました but they were not fully executed in CI here. 
- 実行コマンド `./gradlew :composeApp:commonTest` をこの環境で実行したところ、`org.gradle.toolchains.foojay-resolver-convention:1.0.0` プラグインが解決できずビルドが失敗しました。 
- テストはローカル/CI で Gradle プラグイン解決が成功する環境で通ることを想定しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c900180bf08330a33df15310aae2b5)