### PR TITLE
Add cross-platform shared color tokens for Compose and SwiftUI

### DIFF
--- a/.github/skills/cross-platform-color-palette/SKILL.md
+++ b/.github/skills/cross-platform-color-palette/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: cross-platform-color-palette
+description: 'Define and apply a shared app color palette for Jetpack Compose and SwiftUI. Use when replacing hard-coded UI colors with project-level constants/tokens and wiring those tokens into themes/components.'
+argument-hint: '対象画面、置換したい色、Compose と SwiftUI のどちらを対象にするかを指定してください'
+user-invocable: true
+---
+
+# Cross Platform Color Palette
+
+## What This Skill Produces
+
+- Jetpack Compose と SwiftUI で再利用できる色トークンの導入方針
+- ハードコード色をプロジェクト共通定義へ置換する実装手順
+- Theme / ColorScheme へ色トークンを接続する最小変更
+- 実装後に確認すべき UI 一貫性チェック項目
+
+## When to Use
+
+- `Color(...)` や `.white` / `.black` / `.secondary` などの直書きを整理したいとき
+- Compose 側の `Color.kt` と SwiftUI 側の色定義を揃えたいとき
+- 画面ごとに色がばらついていて、横断的に統一したいとき
+- ダークテーマ中心のカメラ UI で視認性を担保したいとき
+
+## Procedure
+
+1. 既存の色使用箇所を抽出する
+   - Compose: `Color(`, `MaterialTheme.colorScheme`, `background` 付近を確認する
+   - SwiftUI: `Color.`, `.foregroundStyle`, `.background`, `.fill` を確認する
+
+2. プロジェクト共通色を定義する
+   - Compose は `theme/Color.kt` に色トークンを定義する
+   - SwiftUI は `AppColors`（enum / struct）を定義して再利用可能にする
+
+3. Theme に接続する
+   - Compose は `AppTheme.kt` の `darkColorScheme` / `lightColorScheme` にトークンを渡す
+   - SwiftUI は View 内の色直書きを `AppColors.*` 参照へ置換する
+
+4. 画面コンポーネントを置換する
+   - 優先度: 背景色、カード背景、補助テキスト色、プレースホルダー色
+   - 既存デザイン意図（透明度やコントラスト）は維持する
+
+5. 影響範囲を検証する
+   - 表示コントラスト
+   - ダーク背景上の可読性
+   - 画像未読込時プレースホルダーの視認性
+
+## Guardrails
+
+- 色値を複数ファイルへ重複定義しない
+- 色置換でレイアウトや文言ロジックを変更しない
+- Material / SwiftUI の標準スタイルを壊さない範囲で置換する
+- 既存機能と無関係なリファクタリングを混在させない
+
+## Output Format
+
+- Token definitions: 追加・更新した色トークン一覧
+- Replaced usages: どの画面のどの色直書きを置換したか
+- Theme integration: Theme/ColorScheme 側の反映内容
+- Validation notes: 目視確認ポイントと未確認事項
+
+## Example Prompts
+
+- `/cross-platform-color-palette Camera 画面の色を Compose と SwiftUI で共通化して`
+- `/cross-platform-color-palette Color 直書きをやめて Color.kt 相当の定義へ統一して`
+- `/cross-platform-color-palette iOS の placeholder 色と Compose の overlay 色をトークン化して`

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/theme/AppTheme.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/theme/AppTheme.kt
@@ -1,6 +1,7 @@
 package com.example.vtubercamera_kmp_ver.theme
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
@@ -8,6 +9,13 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+
+private val AppColorScheme = darkColorScheme(
+    background = AppColors.Background,
+    surface = AppColors.OverlaySurface,
+    onSurfaceVariant = AppColors.OverlayTextSecondary,
+    scrim = AppColors.Background,
+)
 
 @Immutable
 data class AppSpacing(
@@ -27,7 +35,9 @@ val MaterialTheme.spacing: AppSpacing
 
 @Composable
 fun VtuberCameraTheme(content: @Composable () -> Unit) {
-    MaterialTheme {
+    MaterialTheme(
+        colorScheme = AppColorScheme,
+    ) {
         CompositionLocalProvider(
             LocalAppSpacing provides AppSpacing(),
             content = content,

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/theme/Color.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/theme/Color.kt
@@ -1,0 +1,9 @@
+package com.example.vtubercamera_kmp_ver.theme
+
+import androidx.compose.ui.graphics.Color
+
+object AppColors {
+    val Background = Color(0xFF000000)
+    val OverlaySurface = Color(0xE61A1A1A)
+    val OverlayTextSecondary = Color(0xFFB9B9BF)
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -6,6 +6,15 @@ import UniformTypeIdentifiers
 import UIKit
 import SceneKit
 
+
+private enum AppColors {
+    static let background = Color.black
+    static let textSecondary = Color.secondary
+    static let avatarFallbackFill = Color.white.opacity(0.12)
+    static let avatarBodyFallbackFill = Color.white.opacity(0.24)
+    static let avatarFallbackText = Color.white
+}
+
 struct ContentView: View {
     @StateObject private var viewModel = IOSCameraViewModel()
     @State private var isFileImporterPresented = false
@@ -71,7 +80,7 @@ struct ContentView: View {
                 }
             }
         }
-        .background(Color.black.ignoresSafeArea())
+        .background(AppColors.background.ignoresSafeArea())
         .fileImporter(
             isPresented: $isFileImporterPresented,
             allowedContentTypes: [.item],
@@ -115,7 +124,7 @@ private struct PermissionPromptView: View {
                 Text(descriptionText(for: texts))
                     .font(.body)
                     .multilineTextAlignment(.center)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(AppColors.textSecondary)
                 Button(primaryButtonTitle(for: texts), action: onPrimaryAction)
                     .buttonStyle(.borderedProminent)
             }
@@ -374,7 +383,7 @@ private struct FaceTrackingDebugOverlay: View {
                 .font(.headline)
             Text(statusText)
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(AppColors.textSecondary)
 
             if let frame {
                 FaceTrackingMetricRow(label: "Yaw", value: degreesLabel(frame.headYawDegrees))
@@ -408,7 +417,7 @@ private struct FaceTrackingMetricRow: View {
     var body: some View {
         HStack {
             Text(label)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(AppColors.textSecondary)
             Spacer(minLength: 12)
             Text(value)
         }
@@ -429,10 +438,10 @@ private struct IOSAvatarPreviewCard: View {
                 } else {
                     ZStack {
                         RoundedRectangle(cornerRadius: 16)
-                            .fill(Color.white.opacity(0.12))
+                            .fill(AppColors.avatarFallbackFill)
                         Text("VRM")
                             .font(.headline.weight(.bold))
-                            .foregroundStyle(.white)
+                            .foregroundStyle(AppColors.avatarFallbackText)
                     }
                 }
             }
@@ -444,7 +453,7 @@ private struct IOSAvatarPreviewCard: View {
                     .font(.headline)
                 Text(avatarPreview.fileName)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(AppColors.textSecondary)
                 if let authorName = avatarPreview.authorName {
                     Text("Author: \(authorName)")
                         .font(.subheadline)
@@ -474,11 +483,11 @@ private struct IOSAvatarBodyView: View {
             } else {
                 ZStack {
                     RoundedRectangle(cornerRadius: 28)
-                        .fill(Color.white.opacity(0.24))
+                        .fill(AppColors.avatarBodyFallbackFill)
                     Text(avatarPreview.avatarName)
                         .font(.title2.weight(.bold))
                         .multilineTextAlignment(.center)
-                        .foregroundStyle(.white)
+                        .foregroundStyle(AppColors.avatarFallbackText)
                         .padding(24)
                 }
             }


### PR DESCRIPTION
### Motivation
- Introduce a project-level color token approach so Compose and SwiftUI use the same app colors instead of scattered hard-coded values.
- Provide a reusable GitHub skill documenting the workflow for replacing color literals across platforms to ensure consistent theming.

### Description
- Add a new skill at `.github/skills/cross-platform-color-palette/SKILL.md` describing procedure, guardrails, and outputs for tokenizing colors across Jetpack Compose and SwiftUI.
- Add Compose color tokens in `composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/theme/Color.kt` as `AppColors` with `Background`, `OverlaySurface`, and `OverlayTextSecondary` tokens.
- Wire the tokens into the Compose theme by updating `AppTheme.kt` to use a `darkColorScheme` (`AppColorScheme`) that maps `background`, `surface`, `onSurfaceVariant`, and `scrim` to `AppColors` values.
- Replace hard-coded SwiftUI colors in `iosApp/iosApp/ContentView.swift` by adding an `AppColors` enum and switching usages (background, secondary text, avatar placeholders) to the new constants.

### Testing
- Attempted to run `./gradlew :composeApp:compileKotlinMetadata`, which failed due to the environment being unable to resolve the Gradle plugin `org.gradle.toolchains.foojay-resolver-convention:1.0.0` from configured repositories, so no successful build verification could be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb314da7448330813fb5b18c473681)