### PR TITLE
Add UI/ViewModel separation skill and move face-tracking formatting into ViewModel

### DIFF
--- a/.github/skills/ui-viewmodel-separation/SKILL.md
+++ b/.github/skills/ui-viewmodel-separation/SKILL.md
@@ -1,0 +1,17 @@
+# UI / ViewModel Responsibility Separation Skill
+
+## Purpose
+Compose UI は表示に専念し、状態変換・フォーマット・分岐ロジックは ViewModel 側に寄せるためのレビュー/修正ガイド。
+
+## Checklist
+1. `@Composable` 内で以下を検知したら ViewModel へ移動する
+   - 数値フォーマット (`round`, `%` 化, 単位付与)
+   - UI 表示用の条件分岐が多段化している処理
+   - ドメイン状態から表示専用状態への変換
+2. ViewModel は `UiState` に表示専用モデル（label 済み文字列等）を渡す
+3. UI は `UiState` をそのまま描画し、イベントを ViewModel に委譲する
+4. 変換ロジックは ViewModel ファイル内 private 関数、または専用 mapper に集約する
+
+## Output Rules
+- 変更時は「UI から削除したロジック」と「ViewModel に移したロジック」をセットで説明する。
+- 可能なら既存テストを実行し、壊れていないことを確認する。

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -27,7 +26,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.vtubercamera_kmp_ver.theme.spacing
-import kotlin.math.roundToInt
 import org.jetbrains.compose.resources.stringResource
 import vtubercamera_kmp_ver.composeapp.generated.resources.Res
 import vtubercamera_kmp_ver.composeapp.generated.resources.avatar_error_dialog_confirm
@@ -215,34 +213,34 @@ private fun FaceTrackingOverlay(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            faceTracking.frame?.let { frame ->
+            faceTracking.display?.let { display ->
                 FaceTrackingMetricRow(
                     label = stringResource(Res.string.face_tracking_label_yaw),
-                    value = "${frame.headYawDegrees.roundToInt()} deg",
+                    value = display.headYawLabel,
                 )
                 FaceTrackingMetricRow(
                     label = stringResource(Res.string.face_tracking_label_pitch),
-                    value = "${frame.headPitchDegrees.roundToInt()} deg",
+                    value = display.headPitchLabel,
                 )
                 FaceTrackingMetricRow(
                     label = stringResource(Res.string.face_tracking_label_roll),
-                    value = "${frame.headRollDegrees.roundToInt()} deg",
+                    value = display.headRollLabel,
                 )
                 FaceTrackingMetricRow(
                     label = stringResource(Res.string.face_tracking_label_blink_left),
-                    value = frame.leftEyeBlink.asPercentLabel(),
+                    value = display.leftEyeBlinkLabel,
                 )
                 FaceTrackingMetricRow(
                     label = stringResource(Res.string.face_tracking_label_blink_right),
-                    value = frame.rightEyeBlink.asPercentLabel(),
+                    value = display.rightEyeBlinkLabel,
                 )
                 FaceTrackingMetricRow(
                     label = stringResource(Res.string.face_tracking_label_jaw),
-                    value = frame.jawOpen.asPercentLabel(),
+                    value = display.jawOpenLabel,
                 )
                 FaceTrackingMetricRow(
                     label = stringResource(Res.string.face_tracking_label_smile),
-                    value = frame.mouthSmile.asPercentLabel(),
+                    value = display.mouthSmileLabel,
                 )
             }
         }
@@ -270,7 +268,6 @@ private fun FaceTrackingMetricRow(
     }
 }
 
-private fun Float.asPercentLabel(): String = "${(coerceIn(0f, 1f) * 100).roundToInt()}%"
 
 @Composable
 private fun LoadingState() {

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
@@ -2,6 +2,7 @@ package com.example.vtubercamera_kmp_ver.camera
 
 import CameraUiState
 import androidx.lifecycle.ViewModel
+import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -41,6 +42,7 @@ class CameraViewModel : ViewModel() {
                 faceTracking = FaceTrackingUiState(
                     isTracking = frame != null,
                     frame = frame,
+                    display = frame?.toDisplayState(),
                 ),
             )
         }
@@ -67,3 +69,16 @@ class CameraViewModel : ViewModel() {
         }
     }
 }
+
+private fun NormalizedFaceFrame.toDisplayState(): FaceTrackingDisplayState =
+    FaceTrackingDisplayState(
+        headYawLabel = "${headYawDegrees.roundToInt()} deg",
+        headPitchLabel = "${headPitchDegrees.roundToInt()} deg",
+        headRollLabel = "${headRollDegrees.roundToInt()} deg",
+        leftEyeBlinkLabel = leftEyeBlink.asPercentLabel(),
+        rightEyeBlinkLabel = rightEyeBlink.asPercentLabel(),
+        jawOpenLabel = jawOpen.asPercentLabel(),
+        mouthSmileLabel = mouthSmile.asPercentLabel(),
+    )
+
+private fun Float.asPercentLabel(): String = "${(coerceIn(0f, 1f) * 100).roundToInt()}%"

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/FaceTrackingModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/FaceTrackingModels.kt
@@ -17,7 +17,19 @@ data class NormalizedFaceFrame(
 )
 
 @Immutable
+data class FaceTrackingDisplayState(
+    val headYawLabel: String,
+    val headPitchLabel: String,
+    val headRollLabel: String,
+    val leftEyeBlinkLabel: String,
+    val rightEyeBlinkLabel: String,
+    val jawOpenLabel: String,
+    val mouthSmileLabel: String,
+)
+
+@Immutable
 data class FaceTrackingUiState(
     val isTracking: Boolean = false,
     val frame: NormalizedFaceFrame? = null,
+    val display: FaceTrackingDisplayState? = null,
 )


### PR DESCRIPTION
### Motivation
- 明確に UI は表示に専念させ、表示用のフォーマット/変換ロジックを ViewModel 側に集約するための方針を追加しました。 
- 既存のフェイストラッキング表示ロジックが UI に混在していたため、責務分離で可読性とテスト容易性を高めます。

### Description
- リポジトリにスキルドキュメントを追加し、` .github/skills/ui-viewmodel-separation/SKILL.md` にチェックリストと出力ルールを記載しました。 
- 表示用モデル `FaceTrackingDisplayState` を `composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/FaceTrackingModels.kt` に追加し、`FaceTrackingUiState` に表示専用フィールド `display` を追加しました。 
- `CameraViewModel` (`CameraViewModel.kt`) にフォーマットロジック（角度の `roundToInt()`、パーセント表示の生成等）を移動し、`onFaceTrackingFrameChanged` で `display` を組み立てるようにしました。 
- `CameraScreen` (`CameraScreen.kt`) 側はフォーマット処理を削除して `faceTracking.display` のラベルをそのまま描画するように簡素化しました。 

### Testing
- 試行として `./gradlew :composeApp:compileKotlinMetadata` を実行しましたが、Gradle プラグイン `org.gradle.toolchains.foojay-resolver-convention:1.0.0` をリポジトリから解決できずビルドは失敗しました。 
- 他の自動化テストはこの実行環境では行っておらず、ビルド失敗のためコンパイル検証は未完了です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb4823fcdc83309bdc2c7a5c626edd)