### PR TITLE
Add mobile coding convention customizations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# Project Guidelines
+
+## Code Style
+
+- Kotlin と Swift の基本的な書き方は、それぞれの公式ドキュメントと標準ガイドラインを優先する。
+- 既存コードの命名、責務分離、記法に合わせ、不要な独自流儀を増やさない。
+- ファイル末尾には空行を入れる。
+
+## UI And Architecture
+
+- UI は Android では Jetpack Compose、iOS では SwiftUI を前提に実装する。
+- アーキテクチャは MVVM を前提にする。
+- Android ではロジックを ViewModel に置き、UI は表示とイベント送出に集中させる。
+- iOS では一時的な UI state は View に置き、意味のある画面 state は ObservableObject に置く。
+
+## Strings And Resources
+
+- ユーザーに表示される文字列は直書きせず、必ずリソースから参照する。
+- ボタン文言、エラー文言、空状態メッセージ、ラベル、説明文をハードコードしない。
+
+## Null Safety And Error Handling
+
+- Kotlin の `!!` や Swift の強制アンラップは可能な限り避け、null safe な分岐、safe call、guard、default 値を優先する。
+- 非 null 前提が必要な場合は、その条件がコード上で明確になる形にする。
+- 正常系だけでなく、権限拒否、入力不正、読み込み失敗、空データ、パース失敗、依存 API 失敗などの異常系を必ず考慮する。
+- 失敗時は握りつぶさず、状態遷移、ユーザー通知、リトライ可否のいずれかを明確にする。
+
+## Responsibility Checks
+
+- Android の UI 層に業務ロジックや状態遷移を持ち込まない。
+- iOS の View に長寿命 state や画面意味を持つロジックを抱え込ませない。
+- Compose / SwiftUI では state-driven な構造を崩さず、描画コードとロジックを分離する。

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -1,0 +1,47 @@
+# Skills Overview
+
+これまでに作成したSKILLの一覧と簡単な説明です。
+
+---
+
+## VtuberCamera_KMP_ver / .github/skills
+
+### android-device-operation
+Android実機またはエミュレータをユーザ指示に従って操作するスキル。
+adbを使ったアプリ起動・画面遷移・バグ再現・権限ダイアログ対応・スクリーンショット取得など、手動テストや確認作業を一連の実行レポートとして出力する。
+
+### ios-device-operation
+iPhone実機またはiOS Simulatorをユーザ指示に従って操作するスキル。
+`xcrun simctl` / `xcrun devicectl` を使ったアプリ起動・バグ再現・権限対応・スクリーンショット取得を行い、標準CLIで不足する場合はXCTest / Appium / WebDriverAgentへの切り替え判断も行う。
+
+### implementation-branch-and-file-commit
+実装作業をmain直コミットせずに安全に進めるためのGitワークフロースキル。
+現在のブランチがmainなら `feature/<task-name>` または `fix/<task-name>` で作業ブランチを作成し、実装後は変更ファイルを1ファイルずつ整理してコミットする手順を提供する。
+
+### mobile-coding-conventions
+Android / iOS / KMP の実装時に守るコーディング規約をまとめたスキル。
+Kotlin / Swift の公式流儀、文字列リソース参照、null safe、MVVM、Android の ViewModel 分離、iOS の View と ObservableObject の state 分離、Jetpack Compose / SwiftUI、異常系考慮、末尾空行の確認を手順化する。
+
+### latent-bug-investigation
+既存コードに潜む未顕在の不具合リスクを洗い出すスキル。
+null参照・非同期競合・ライフサイクルリーク・状態不整合・例外握りつぶしなどを検出し、重大度(P0/P1/P2)・発生条件・影響範囲をセットで報告する。Android / iOS / KMP環境に対応。
+
+### mobile-architecture-review
+AndroidおよびiOSコードベースのアーキテクチャ品質をレビューするスキル。
+UI・状態管理・ドメイン・データ・プラットフォームブリッジの各層を分類したうえで、モジュール分離・依存境界・テスタビリティ・並行安全性などの観点から構造的な問題をfindingsとして出力する。
+
+### mobile-store-review-screen-check
+モバイルアプリの画面がApp Store / Google Playの審査を通過できるかをチェックするスキル。
+権限UX・未実装UI表示・privacy messaging・課金・外部遷移などの審査リスクをP0/P1/P2で整理し、画面単位の改善提案と追加実機検証項目を出力する。
+
+### performance-risk-review
+Android / iOS / KMPコードのパフォーマンスリスクを事前に検出するスキル。
+メインスレッドブロック・高頻度アロケーション・不要な再コンポーズ・カメラパイプラインのボトルネック・トラッキング遅延などを洗い出し、体感性能に効くhigh-signal問題をquick winsとともに報告する。
+
+---
+
+## ZennText / .github/skills
+
+### blog-review-feedback-to-markdown-ja
+Zenn技術記事のレビューフィードバックを生成するスキル。
+記事の構成分析・誤字脱字チェック・深掘り提案・追加削除項目・類似記事比較を行い、日本語で `docs/feedback/` 配下にMarkdownとして出力する。

--- a/.github/skills/mobile-coding-conventions/SKILL.md
+++ b/.github/skills/mobile-coding-conventions/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: mobile-coding-conventions
+description: 'Guide Kotlin and Swift implementation with repo coding conventions. Use when writing Android, iOS, or KMP code and you need checks for official style, string resources, null safety, MVVM, ViewModel or ObservableObject responsibilities, Jetpack Compose, SwiftUI, error handling, and final newline.'
+argument-hint: '実装対象、Android/iOS/KMP、確認したい観点を指定してください'
+user-invocable: true
+---
+
+# Mobile Coding Conventions
+
+## What This Skill Produces
+
+- Kotlin / Swift の公式ドキュメントに沿った基本スタイルの確認
+- 文字列リソース化、null safe、異常系考慮を含む実装チェック
+- Android と iOS それぞれの MVVM 責務分離の確認
+- Jetpack Compose / SwiftUI ベースの UI 実装方針の確認
+- 実装完了前の最終チェックリスト
+
+## When to Use
+
+- Android、iOS、KMP の実装を始める前に、守るべきコーディング規約を揃えたいとき
+- UI とロジックの責務分離が崩れていないか確認したいとき
+- 文字列の直書き、`!!`、状態配置ミス、異常系漏れを防ぎたいとき
+- Jetpack Compose / SwiftUI を前提にした実装レビュー観点を使いたいとき
+
+## Decision Points
+
+1. 対象が Android / KMP 側か iOS 側か
+   - Android / KMP なら、ロジックは ViewModel に寄せ、UI は表示責務に限定する
+   - iOS なら、一時的な UI state は View に置き、意味のある画面 state は ObservableObject に置く
+
+2. 文字列が UI に表示されるか
+   - 表示されるなら、ハードコードせず必ずリソースから参照する
+   - 内部ログや一時デバッグ文言でも、ユーザー表示に転用される可能性があるならリソース化を優先する
+
+3. nullable 値を扱うか
+   - `!!` や強制アンラップに頼らず、早期 return、safe call、default 値、guard などで null safe に処理する
+   - どうしても非 null 前提が必要なら、その根拠をコード上で明確にする
+
+4. 状態をどこに置くか
+   - Android で画面の意味を持つ状態や分岐は ViewModel に置く
+   - iOS で画面全体の意味を持つ状態、ロード状態、エラー状態、選択結果などは ObservableObject に置く
+   - 一時的な開閉、入力フォーカス、短命な UI state は View 側に置く
+
+5. UI フレームワークをどう実装するか
+   - Android は Jetpack Compose を優先する
+   - iOS は SwiftUI を優先する
+   - 既存の UIKit / View ベース実装を増やす場合は、なぜ declarative UI で足りないかを説明する
+
+6. 異常系をどう扱うか
+   - 権限拒否、入力不正、読み込み失敗、パース失敗、依存 API 失敗、空データを必ず洗う
+   - 異常時に UI がどう振る舞うか、再試行可否、ユーザー向け表示を決める
+
+## Procedure
+
+1. 実装対象を整理する
+   - Android、iOS、KMP shared のどこを変更するかを明確にする
+   - UI 変更か、状態管理変更か、データ変換かを分ける
+
+2. 基本スタイルを公式ドキュメント基準で揃える
+   - Kotlin は Kotlin 公式コーディング規約に寄せる
+   - Swift は Swift API Design Guidelines と SwiftUI の標準パターンに寄せる
+   - 既存コードの命名と整形が大きく崩れないように合わせる
+
+3. 文字列を洗い出す
+   - 画面表示、エラー表示、ボタン文言、プレースホルダ、空状態の文言を確認する
+   - 直書きがあればリソース参照に置き換える
+
+4. 状態と責務を分離する
+   - Android は ViewModel に状態遷移、入力処理、ビジネスロジックを集める
+   - Compose UI は state の表示と event 発火に集中させる
+   - iOS は View に短命 state、ObservableObject に画面 state と意味のあるイベント処理を置く
+   - SwiftUI View は描画と user action の橋渡しに集中させる
+
+5. null safe と異常系を実装する
+   - `!!` や強制アンラップを避ける
+   - null、空、失敗、例外、権限拒否などの分岐を明示する
+   - 成功時だけでなく失敗時の戻り先、表示、ログを決める
+
+6. MVVM と declarative UI の前提を崩していないか確認する
+   - View がロジック過多になっていないか確認する
+   - ViewModel / ObservableObject が UI 実装詳細を持ち込みすぎていないか確認する
+   - Compose / SwiftUI らしい state-driven な構造になっているか確認する
+
+7. 仕上げを確認する
+   - ファイル末尾に空行を入れる
+   - 異常系を含む最低限のテストや確認観点を用意する
+   - 命名、責務、リソース参照、state 配置に矛盾がないか見直す
+
+## Quality Checks
+
+- Kotlin / Swift の書き方が公式ガイドラインと既存コードスタイルから大きく逸脱していない
+- ユーザー向け文字列がリソース参照になっている
+- `!!` や強制アンラップを安易に使っていない
+- Android ではロジックが ViewModel にあり、UI は表示責務に留まっている
+- iOS では一時 UI state と意味のある画面 state が適切に分離されている
+- UI が Jetpack Compose / SwiftUI ベースで実装されている
+- 異常系や失敗パスが考慮されている
+- ファイル末尾に空行がある
+
+## Guardrails
+
+- 文字列の直書きを残さない
+- `!!` や強制アンラップを常用しない
+- Android の UI 層にロジックを寄せすぎない
+- iOS View に長寿命 state や画面意味を持つロジックを抱え込ませない
+- 宣言的 UI を前提にしつつ、既存実装との整合性を壊さない
+- 正常系だけで完了扱いにしない
+
+## Output Format
+
+返答には必要に応じて以下を含める。
+
+- Target: Android / iOS / KMP のどこを実装するか
+- UI framework: Jetpack Compose / SwiftUI のどちらを使うか
+- State placement: ViewModel / ObservableObject / View の責務分担
+- Resource check: 文字列リソース化の有無
+- Null safety check: `!!` / 強制アンラップの排除方針
+- Error paths: 想定した異常系
+- Final checklist: 実装前後に確認した項目
+
+## Example Prompts
+
+- `/mobile-coding-conventions Android の Camera 画面を実装する。文字列リソース化と ViewModel 責務も見ながら進めて`
+- `/mobile-coding-conventions iOS の SwiftUI 画面で state の置き場所を確認しながら実装したい`
+- `/mobile-coding-conventions KMP で UI とロジックの分離、null safe、異常系考慮をチェックしながらコードを書いて`


### PR DESCRIPTION
## Summary
- add a reusable mobile coding conventions skill
- add a skills overview README for workspace skills
- add workspace-wide copilot instructions for Kotlin and Swift coding rules

## Testing
- not run (documentation/customization files only)