### PR TITLE
Add shared VRM extension parser and normalization

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
@@ -372,10 +372,17 @@ internal data class VrmGlbDocument(
             ?: return null
         val byteOffset = bufferView.int("byteOffset") ?: 0
         val byteLength = bufferView.int("byteLength") ?: return null
-        val end = byteOffset + byteLength
         val bytes = binaryChunk ?: return null
-        if (byteOffset < 0 || end > bytes.size) return null
-        return bytes.copyOfRange(byteOffset, end)
+        if (byteOffset < 0 || byteLength < 0) return null
+
+        val startLong = byteOffset.toLong()
+        val lengthLong = byteLength.toLong()
+        val endLong = startLong + lengthLong
+        if (endLong > bytes.size.toLong()) return null
+
+        val start = startLong.toInt()
+        val end = endLong.toInt()
+        return bytes.copyOfRange(start, end)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
@@ -1,0 +1,490 @@
+package com.example.vtubercamera_kmp_ver.avatar.vrm
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.floatOrNull
+import kotlinx.serialization.json.intOrNull
+
+object VrmExtensionParser {
+    private const val glbHeaderMagic = 0x46546C67
+    private const val jsonChunkType = 0x4E4F534A
+    private const val binaryChunkType = 0x004E4942
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun parseRuntimeAssetDescriptor(bytes: ByteArray): Result<VrmRuntimeAssetDescriptor> =
+        parseDocument(bytes).mapCatching { document ->
+            parseRuntimeAssetDescriptor(document).getOrThrow()
+        }
+
+    internal fun parseDocument(bytes: ByteArray): Result<VrmGlbDocument> = runCatching {
+        if (bytes.size < 20) {
+            throw VrmAssetParseException(VrmAssetParseFailureKind.ReadFailed)
+        }
+
+        val magic = bytes.readIntLE(0)
+        if (magic != glbHeaderMagic) {
+            throw VrmAssetParseException(VrmAssetParseFailureKind.InvalidFileType)
+        }
+
+        val declaredLength = bytes.readIntLE(8)
+        if (declaredLength > bytes.size || declaredLength < 20) {
+            throw VrmAssetParseException(VrmAssetParseFailureKind.InvalidFormat)
+        }
+
+        var offset = 12
+        var jsonChunk: String? = null
+        var binaryChunk: ByteArray? = null
+        while (offset + 8 <= declaredLength) {
+            val chunkLength = bytes.readIntLE(offset)
+            val chunkType = bytes.readIntLE(offset + 4)
+            val chunkStart = offset + 8
+            val chunkEnd = chunkStart + chunkLength
+            if (chunkLength < 0 || chunkEnd > declaredLength) {
+                throw VrmAssetParseException(VrmAssetParseFailureKind.InvalidFormat)
+            }
+
+            when (chunkType) {
+                jsonChunkType -> jsonChunk = bytes.decodeToString(chunkStart, chunkEnd)
+                binaryChunkType -> binaryChunk = bytes.copyOfRange(chunkStart, chunkEnd)
+            }
+            offset = chunkEnd
+        }
+
+        val root = jsonChunk
+            ?.let { chunk -> json.parseToJsonElement(chunk) as? JsonObject }
+            ?: throw VrmAssetParseException(VrmAssetParseFailureKind.MetadataFailed)
+
+        VrmGlbDocument(
+            root = root,
+            binaryChunk = binaryChunk,
+        )
+    }
+
+    internal fun parseRuntimeAssetDescriptor(document: VrmGlbDocument): Result<VrmRuntimeAssetDescriptor> = runCatching {
+        val parsedExtension = document.root.parseVrmExtension()
+            ?: throw VrmAssetParseException(VrmAssetParseFailureKind.MetadataFailed)
+
+        VrmSpecNormalizer.normalize(
+            extension = parsedExtension,
+            assetVersion = document.assetVersion,
+        )
+    }
+
+    private fun JsonObject.parseVrmExtension(): ParsedVrmExtension? {
+        val extensions = childObject("extensions") ?: return null
+        extensions.childObject("VRMC_vrm")?.let { vrm1Extension ->
+            return ParsedVrm1Extension(
+                rawSpecVersion = vrm1Extension.string("specVersion"),
+                meta = vrm1Extension.childObject("meta").toParsedVrm1Meta(),
+                thumbnailImageIndex = vrm1Extension.childObject("meta")?.int("thumbnailImage"),
+                humanoidBones = vrm1Extension.parseVrm1HumanoidBones(),
+                expressions = vrm1Extension.parseVrm1Expressions(),
+                lookAt = vrm1Extension.childObject("lookAt")?.toParsedLookAt(),
+                firstPerson = vrm1Extension.childObject("firstPerson")?.toParsedFirstPerson(),
+            )
+        }
+
+        extensions.childObject("VRM")?.let { vrm0Extension ->
+            return ParsedVrm0Extension(
+                rawSpecVersion = null,
+                meta = vrm0Extension.childObject("meta").toParsedVrm0Meta(),
+                thumbnailImageIndex = resolveVrm0ThumbnailImageIndex(vrm0Extension),
+                humanoidBones = vrm0Extension.parseVrm0HumanoidBones(),
+                expressions = vrm0Extension.parseVrm0Expressions(),
+                lookAt = vrm0Extension.childObject("firstPerson")?.toParsedVrm0LookAt(),
+                firstPerson = vrm0Extension.childObject("firstPerson")?.toParsedFirstPerson(),
+            )
+        }
+
+        return null
+    }
+
+    private fun JsonObject.resolveVrm0ThumbnailImageIndex(vrm0Extension: JsonObject): Int? {
+        val textureIndex = vrm0Extension.childObject("meta")?.int("texture") ?: return null
+        return childArray("textures")
+            ?.getOrNull(textureIndex)
+            ?.jsonObjectOrNull()
+            ?.int("source")
+    }
+
+    private fun JsonObject?.toParsedVrm0Meta(): ParsedVrmMeta {
+        val meta = this
+        return ParsedVrmMeta(
+            avatarName = meta?.string("title"),
+            authors = listOfNotNull(meta?.string("author")),
+            version = meta?.string("version"),
+        )
+    }
+
+    private fun JsonObject?.toParsedVrm1Meta(): ParsedVrmMeta {
+        val meta = this
+        return ParsedVrmMeta(
+            avatarName = meta?.string("name"),
+            authors = meta?.stringArray("authors").orEmpty(),
+            version = meta?.string("version"),
+        )
+    }
+
+    private fun JsonObject.parseVrm0HumanoidBones(): List<ParsedHumanoidBone> {
+        return childObject("humanoid")
+            ?.childArray("humanBones")
+            ?.mapNotNull { element ->
+                element.jsonObjectOrNull()?.let { boneObject ->
+                    val name = boneObject.string("bone") ?: return@let null
+                    val nodeIndex = boneObject.int("node") ?: return@let null
+                    ParsedHumanoidBone(name = name, nodeIndex = nodeIndex)
+                }
+            }
+            .orEmpty()
+    }
+
+    private fun JsonObject.parseVrm1HumanoidBones(): List<ParsedHumanoidBone> {
+        val humanBonesObject = childObject("humanoid")?.childObject("humanBones")
+        if (humanBonesObject != null) {
+            return humanBonesObject.mapNotNull { (name, value) ->
+                val nodeIndex = value.jsonObjectOrNull()?.int("node") ?: return@mapNotNull null
+                ParsedHumanoidBone(name = name, nodeIndex = nodeIndex)
+            }
+        }
+
+        return childObject("humanoid")
+            ?.childArray("humanBones")
+            ?.mapNotNull { element ->
+                element.jsonObjectOrNull()?.let { boneObject ->
+                    val name = boneObject.string("bone") ?: return@let null
+                    val nodeIndex = boneObject.int("node") ?: return@let null
+                    ParsedHumanoidBone(name = name, nodeIndex = nodeIndex)
+                }
+            }
+            .orEmpty()
+    }
+
+    private fun JsonObject.parseVrm0Expressions(): List<ParsedVrmExpression> {
+        return childObject("blendShapeMaster")
+            ?.childArray("blendShapeGroups")
+            ?.mapNotNull { element ->
+                val expressionObject = element.jsonObjectOrNull() ?: return@mapNotNull null
+                val presetName = expressionObject.string("presetName")?.normalizeExpressionName()
+                val displayName = expressionObject.string("name") ?: presetName ?: return@mapNotNull null
+                ParsedVrmExpression(
+                    runtimeName = presetName ?: displayName,
+                    displayName = displayName,
+                    presetName = presetName,
+                    isBinary = expressionObject.boolean("isBinary") ?: false,
+                    morphTargetBinds = expressionObject.parseMorphTargetBinds(
+                        bindsKey = "binds",
+                        nodeKey = "mesh",
+                        weightMultiplier = 0.01f,
+                    ),
+                    overrideBlink = null,
+                    overrideLookAt = null,
+                    overrideMouth = null,
+                )
+            }
+            .orEmpty()
+    }
+
+    private fun JsonObject.parseVrm1Expressions(): List<ParsedVrmExpression> {
+        val expressionsElement = get("expressions") ?: return emptyList()
+        expressionsElement.jsonObjectOrNull()?.let { expressionsObject ->
+            val presetExpressions = expressionsObject.childObject("preset")
+                ?.entries
+                ?.mapNotNull { (name, value) ->
+                    value.jsonObjectOrNull()?.toParsedVrm1Expression(
+                        expressionKey = name,
+                        presetName = name.normalizeExpressionName(),
+                    )
+                }
+                .orEmpty()
+            val customExpressions = expressionsObject.childObject("custom")
+                ?.entries
+                ?.mapNotNull { (name, value) ->
+                    value.jsonObjectOrNull()?.toParsedVrm1Expression(
+                        expressionKey = name,
+                        presetName = null,
+                    )
+                }
+                .orEmpty()
+            if (presetExpressions.isNotEmpty() || customExpressions.isNotEmpty()) {
+                return presetExpressions + customExpressions
+            }
+        }
+
+        return expressionsElement.jsonArrayOrNull()
+            ?.mapNotNull { element ->
+                val expressionObject = element.jsonObjectOrNull() ?: return@mapNotNull null
+                val expressionKey = expressionObject.string("name") ?: return@mapNotNull null
+                expressionObject.toParsedVrm1Expression(
+                    expressionKey = expressionKey,
+                    presetName = expressionObject.string("preset")?.normalizeExpressionName(),
+                )
+            }
+            .orEmpty()
+    }
+
+    private fun JsonObject.toParsedVrm1Expression(
+        expressionKey: String,
+        presetName: String?,
+    ): ParsedVrmExpression {
+        val normalizedKey = expressionKey.normalizeExpressionName()
+        val displayName = string("name") ?: normalizedKey
+        return ParsedVrmExpression(
+            runtimeName = presetName ?: normalizedKey,
+            displayName = displayName,
+            presetName = presetName,
+            isBinary = boolean("isBinary") ?: false,
+            morphTargetBinds = parseMorphTargetBinds(
+                bindsKey = "morphTargetBinds",
+                nodeKey = "node",
+                weightMultiplier = 1f,
+            ),
+            overrideBlink = string("overrideBlink"),
+            overrideLookAt = string("overrideLookAt"),
+            overrideMouth = string("overrideMouth"),
+        )
+    }
+
+    private fun JsonObject.parseMorphTargetBinds(
+        bindsKey: String,
+        nodeKey: String,
+        weightMultiplier: Float,
+    ): List<ParsedMorphTargetBind> {
+        return childArray(bindsKey)
+            ?.mapNotNull { element ->
+                val bindObject = element.jsonObjectOrNull() ?: return@mapNotNull null
+                val nodeIndex = bindObject.int(nodeKey) ?: return@mapNotNull null
+                val morphTargetIndex = bindObject.int("index") ?: return@mapNotNull null
+                val rawWeight = bindObject.float("weight") ?: return@mapNotNull null
+                ParsedMorphTargetBind(
+                    nodeIndex = nodeIndex,
+                    morphTargetIndex = morphTargetIndex,
+                    weight = rawWeight * weightMultiplier,
+                )
+            }
+            .orEmpty()
+    }
+
+    private fun JsonObject.toParsedVrm0LookAt(): ParsedLookAt? {
+        val lookAtType = string("lookAtTypeName")
+        val offsetFromHeadBone = childObject("firstPersonBoneOffset")?.toParsedFloat3()
+        if (lookAtType == null && offsetFromHeadBone == null) return null
+        return ParsedLookAt(
+            type = lookAtType,
+            offsetFromHeadBone = offsetFromHeadBone,
+        )
+    }
+
+    private fun JsonObject.toParsedLookAt(): ParsedLookAt? {
+        val type = string("type")
+        val offsetFromHeadBone = childObject("offsetFromHeadBone")?.toParsedFloat3()
+            ?: get("offsetFromHeadBone")?.jsonArrayOrNull()?.toParsedFloat3()
+        if (type == null && offsetFromHeadBone == null) return null
+        return ParsedLookAt(
+            type = type,
+            offsetFromHeadBone = offsetFromHeadBone,
+        )
+    }
+
+    private fun JsonObject.toParsedFirstPerson(): ParsedFirstPerson? {
+        val firstPersonBone = int("firstPersonBone")
+        val meshAnnotationIndices = childArray("meshAnnotations")
+            ?.mapNotNull { element ->
+                val annotationObject = element.jsonObjectOrNull() ?: return@mapNotNull null
+                annotationObject.int("node") ?: annotationObject.int("mesh")
+            }
+            .orEmpty()
+        if (firstPersonBone == null && meshAnnotationIndices.isEmpty()) return null
+        return ParsedFirstPerson(
+            firstPersonBone = firstPersonBone,
+            meshAnnotationIndices = meshAnnotationIndices,
+        )
+    }
+
+    private fun JsonObject.toParsedFloat3(): ParsedFloat3? {
+        val x = float("x") ?: return null
+        val y = float("y") ?: return null
+        val z = float("z") ?: return null
+        return ParsedFloat3(x = x, y = y, z = z)
+    }
+
+    private fun JsonArray.toParsedFloat3(): ParsedFloat3? {
+        if (size < 3) return null
+        val x = getOrNull(0)?.jsonPrimitiveOrNull()?.floatOrNull ?: return null
+        val y = getOrNull(1)?.jsonPrimitiveOrNull()?.floatOrNull ?: return null
+        val z = getOrNull(2)?.jsonPrimitiveOrNull()?.floatOrNull ?: return null
+        return ParsedFloat3(x = x, y = y, z = z)
+    }
+
+    private fun String.normalizeExpressionName(): String {
+        val trimmedName = trim()
+        if (trimmedName.isEmpty()) return trimmedName
+        return expressionAliases[trimmedName.lowercase()] ?: trimmedName
+    }
+
+    private val expressionAliases: Map<String, String> = mapOf(
+        "blinkleft" to "blinkLeft",
+        "blinkright" to "blinkRight",
+        "blink_l" to "blink_l",
+        "blink_r" to "blink_r",
+        "happy" to "happy",
+        "joy" to "joy",
+        "smile" to "smile",
+        "a" to "a",
+        "aa" to "aa",
+        "jawopen" to "jawOpen",
+    )
+}
+
+internal data class VrmGlbDocument(
+    val root: JsonObject,
+    val binaryChunk: ByteArray?,
+) {
+    val assetVersion: String?
+        get() = root.childObject("asset")?.string("version")
+
+    fun extractImageBytes(imageIndex: Int): ByteArray? {
+        val image = root.childArray("images")
+            ?.getOrNull(imageIndex)
+            ?.jsonObjectOrNull()
+            ?: return null
+        val bufferViewIndex = image.int("bufferView") ?: return null
+        val mimeType = image.string("mimeType") ?: return null
+        if (!mimeType.startsWith("image/")) return null
+
+        val bufferView = root.childArray("bufferViews")
+            ?.getOrNull(bufferViewIndex)
+            ?.jsonObjectOrNull()
+            ?: return null
+        val byteOffset = bufferView.int("byteOffset") ?: 0
+        val byteLength = bufferView.int("byteLength") ?: return null
+        val end = byteOffset + byteLength
+        val bytes = binaryChunk ?: return null
+        if (byteOffset < 0 || end > bytes.size) return null
+        return bytes.copyOfRange(byteOffset, end)
+    }
+}
+
+internal enum class VrmAssetParseFailureKind {
+    InvalidFileType,
+    ReadFailed,
+    InvalidFormat,
+    MetadataFailed,
+}
+
+internal class VrmAssetParseException(
+    val kind: VrmAssetParseFailureKind,
+) : IllegalArgumentException()
+
+internal sealed interface ParsedVrmExtension {
+    val rawSpecVersion: String?
+    val meta: ParsedVrmMeta
+    val thumbnailImageIndex: Int?
+    val humanoidBones: List<ParsedHumanoidBone>
+    val expressions: List<ParsedVrmExpression>
+    val lookAt: ParsedLookAt?
+    val firstPerson: ParsedFirstPerson?
+}
+
+internal data class ParsedVrm0Extension(
+    override val rawSpecVersion: String?,
+    override val meta: ParsedVrmMeta,
+    override val thumbnailImageIndex: Int?,
+    override val humanoidBones: List<ParsedHumanoidBone>,
+    override val expressions: List<ParsedVrmExpression>,
+    override val lookAt: ParsedLookAt?,
+    override val firstPerson: ParsedFirstPerson?,
+) : ParsedVrmExtension
+
+internal data class ParsedVrm1Extension(
+    override val rawSpecVersion: String?,
+    override val meta: ParsedVrmMeta,
+    override val thumbnailImageIndex: Int?,
+    override val humanoidBones: List<ParsedHumanoidBone>,
+    override val expressions: List<ParsedVrmExpression>,
+    override val lookAt: ParsedLookAt?,
+    override val firstPerson: ParsedFirstPerson?,
+) : ParsedVrmExtension
+
+internal data class ParsedVrmMeta(
+    val avatarName: String?,
+    val authors: List<String>,
+    val version: String?,
+)
+
+internal data class ParsedHumanoidBone(
+    val name: String,
+    val nodeIndex: Int,
+)
+
+internal data class ParsedVrmExpression(
+    val runtimeName: String,
+    val displayName: String,
+    val presetName: String?,
+    val isBinary: Boolean,
+    val morphTargetBinds: List<ParsedMorphTargetBind>,
+    val overrideBlink: String?,
+    val overrideLookAt: String?,
+    val overrideMouth: String?,
+)
+
+internal data class ParsedMorphTargetBind(
+    val nodeIndex: Int,
+    val morphTargetIndex: Int,
+    val weight: Float,
+)
+
+internal data class ParsedLookAt(
+    val type: String?,
+    val offsetFromHeadBone: ParsedFloat3?,
+)
+
+internal data class ParsedFirstPerson(
+    val firstPersonBone: Int?,
+    val meshAnnotationIndices: List<Int>,
+)
+
+internal data class ParsedFloat3(
+    val x: Float,
+    val y: Float,
+    val z: Float,
+)
+
+internal fun JsonObject.childObject(key: String): JsonObject? = get(key)?.jsonObjectOrNull()
+
+internal fun JsonObject.childArray(key: String): JsonArray? = get(key)?.jsonArrayOrNull()
+
+internal fun JsonObject.string(key: String): String? =
+    get(key)?.jsonPrimitiveOrNull()?.contentOrNull?.takeIf { value -> value.isNotBlank() }
+
+internal fun JsonObject.int(key: String): Int? = get(key)?.jsonPrimitiveOrNull()?.intOrNull
+
+internal fun JsonObject.float(key: String): Float? = get(key)?.jsonPrimitiveOrNull()?.floatOrNull
+
+internal fun JsonObject.boolean(key: String): Boolean? = get(key)?.jsonPrimitiveOrNull()?.booleanOrNull
+
+internal fun JsonObject.stringArray(key: String): List<String>? {
+    return childArray(key)
+        ?.mapNotNull { element ->
+            element.jsonPrimitiveOrNull()?.contentOrNull?.takeIf { value -> value.isNotBlank() }
+        }
+        ?.takeIf { values -> values.isNotEmpty() }
+}
+
+internal fun JsonElement.jsonObjectOrNull(): JsonObject? = this as? JsonObject
+
+internal fun JsonElement.jsonArrayOrNull(): JsonArray? = this as? JsonArray
+
+internal fun JsonElement.jsonPrimitiveOrNull(): JsonPrimitive? = this as? JsonPrimitive
+
+private fun ByteArray.readIntLE(offset: Int): Int {
+    return (this[offset].toInt() and 0xFF) or
+        ((this[offset + 1].toInt() and 0xFF) shl 8) or
+        ((this[offset + 2].toInt() and 0xFF) shl 16) or
+        ((this[offset + 3].toInt() and 0xFF) shl 24)
+}

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
@@ -37,21 +37,30 @@ object VrmExtensionParser {
             throw VrmAssetParseException(VrmAssetParseFailureKind.InvalidFormat)
         }
 
-        var offset = 12
+        val declaredLengthLong = declaredLength.toLong()
+        var offset = 12L
         var jsonChunk: String? = null
         var binaryChunk: ByteArray? = null
-        while (offset + 8 <= declaredLength) {
-            val chunkLength = bytes.readIntLE(offset)
-            val chunkType = bytes.readIntLE(offset + 4)
-            val chunkStart = offset + 8
-            val chunkEnd = chunkStart + chunkLength
-            if (chunkLength < 0 || chunkEnd > declaredLength) {
+        while (offset <= declaredLengthLong - 8L) {
+            val chunkHeaderOffset = offset.toInt()
+            val chunkLength = bytes.readIntLE(chunkHeaderOffset)
+            val chunkType = bytes.readIntLE(chunkHeaderOffset + 4)
+            if (chunkLength < 0) {
                 throw VrmAssetParseException(VrmAssetParseFailureKind.InvalidFormat)
             }
 
+            val chunkStart = offset + 8L
+            val chunkLengthLong = chunkLength.toLong()
+            if (chunkLengthLong > declaredLengthLong - chunkStart) {
+                throw VrmAssetParseException(VrmAssetParseFailureKind.InvalidFormat)
+            }
+            val chunkEnd = chunkStart + chunkLengthLong
+            val chunkStartInt = chunkStart.toInt()
+            val chunkEndInt = chunkEnd.toInt()
+
             when (chunkType) {
-                jsonChunkType -> jsonChunk = bytes.decodeToString(chunkStart, chunkEnd)
-                binaryChunkType -> binaryChunk = bytes.copyOfRange(chunkStart, chunkEnd)
+                jsonChunkType -> jsonChunk = bytes.decodeToString(chunkStartInt, chunkEndInt)
+                binaryChunkType -> binaryChunk = bytes.copyOfRange(chunkStartInt, chunkEndInt)
             }
             offset = chunkEnd
         }

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
@@ -1,5 +1,6 @@
 package com.example.vtubercamera_kmp_ver.avatar.vrm
 
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -65,9 +66,14 @@ object VrmExtensionParser {
             offset = chunkEnd
         }
 
-        val root = jsonChunk
-            ?.let { chunk -> json.parseToJsonElement(chunk) as? JsonObject }
-            ?: throw VrmAssetParseException(VrmAssetParseFailureKind.MetadataFailed)
+        val root = jsonChunk?.let { chunk ->
+            try {
+                json.parseToJsonElement(chunk) as? JsonObject
+                    ?: throw VrmAssetParseException(VrmAssetParseFailureKind.MetadataFailed)
+            } catch (e: SerializationException) {
+                throw VrmAssetParseException(VrmAssetParseFailureKind.MetadataFailed)
+            }
+        } ?: throw VrmAssetParseException(VrmAssetParseFailureKind.MetadataFailed)
 
         VrmGlbDocument(
             root = root,

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
@@ -330,10 +330,21 @@ object VrmExtensionParser {
         return ParsedFloat3(x = x, y = y, z = z)
     }
 
+    private fun String.lowercaseAsciiOnly(): String = buildString(length) {
+        for (char in this@lowercaseAsciiOnly) {
+            append(
+                when (char) {
+                    in 'A'..'Z' -> (char.code + ('a'.code - 'A'.code)).toChar()
+                    else -> char
+                }
+            )
+        }
+    }
+
     private fun String.normalizeExpressionName(): String {
         val trimmedName = trim()
         if (trimmedName.isEmpty()) return trimmedName
-        return expressionAliases[trimmedName.lowercase()] ?: trimmedName
+        return expressionAliases[trimmedName.lowercaseAsciiOnly()] ?: trimmedName
     }
 
     private val expressionAliases: Map<String, String> = mapOf(

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmRuntimeAssetDescriptor.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmRuntimeAssetDescriptor.kt
@@ -1,0 +1,62 @@
+package com.example.vtubercamera_kmp_ver.avatar.vrm
+
+import com.example.vtubercamera_kmp_ver.avatar.mapping.VrmSpecVersion
+
+data class VrmRuntimeAssetDescriptor(
+    val specVersion: VrmSpecVersion,
+    val rawSpecVersion: String?,
+    val assetVersion: String?,
+    val meta: VrmRuntimeMeta,
+    val thumbnailImageIndex: Int?,
+    val humanoidBones: List<VrmHumanoidBoneBinding> = emptyList(),
+    val expressions: List<VrmExpressionDescriptor> = emptyList(),
+    val lookAt: VrmLookAtDescriptor? = null,
+    val firstPerson: VrmFirstPersonDescriptor? = null,
+) {
+    val availableExpressionNames: Set<String>
+        get() = expressions.mapTo(linkedSetOf()) { expression -> expression.runtimeName }
+}
+
+data class VrmRuntimeMeta(
+    val avatarName: String?,
+    val authors: List<String> = emptyList(),
+    val version: String?,
+)
+
+data class VrmHumanoidBoneBinding(
+    val boneName: String,
+    val nodeIndex: Int,
+)
+
+data class VrmExpressionDescriptor(
+    val runtimeName: String,
+    val displayName: String,
+    val presetName: String?,
+    val isBinary: Boolean,
+    val morphTargetBinds: List<VrmMorphTargetBind> = emptyList(),
+    val overrideBlink: String? = null,
+    val overrideLookAt: String? = null,
+    val overrideMouth: String? = null,
+)
+
+data class VrmMorphTargetBind(
+    val nodeIndex: Int,
+    val morphTargetIndex: Int,
+    val weight: Float,
+)
+
+data class VrmLookAtDescriptor(
+    val type: String?,
+    val offsetFromHeadBone: VrmFloat3? = null,
+)
+
+data class VrmFirstPersonDescriptor(
+    val firstPersonBone: Int? = null,
+    val meshAnnotationIndices: List<Int> = emptyList(),
+)
+
+data class VrmFloat3(
+    val x: Float,
+    val y: Float,
+    val z: Float,
+)

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmSpecNormalizer.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmSpecNormalizer.kt
@@ -1,0 +1,112 @@
+package com.example.vtubercamera_kmp_ver.avatar.vrm
+
+import com.example.vtubercamera_kmp_ver.avatar.mapping.VrmSpecVersion
+
+internal object VrmSpecNormalizer {
+    fun normalize(
+        extension: ParsedVrmExtension,
+        assetVersion: String?,
+    ): VrmRuntimeAssetDescriptor = when (extension) {
+        is ParsedVrm0Extension -> VrmRuntimeAssetDescriptor(
+            specVersion = VrmSpecVersion.Vrm0,
+            rawSpecVersion = extension.rawSpecVersion,
+            assetVersion = assetVersion,
+            meta = extension.meta.toRuntimeMeta(),
+            thumbnailImageIndex = extension.thumbnailImageIndex,
+            humanoidBones = extension.humanoidBones.map { bone -> bone.toRuntimeBinding() },
+            expressions = extension.expressions.map { expression -> expression.toRuntimeExpression() },
+            lookAt = extension.lookAt?.toRuntimeLookAt(),
+            firstPerson = extension.firstPerson?.toRuntimeFirstPerson(),
+        )
+
+        is ParsedVrm1Extension -> VrmRuntimeAssetDescriptor(
+            specVersion = VrmSpecVersion.Vrm1,
+            rawSpecVersion = extension.rawSpecVersion,
+            assetVersion = assetVersion,
+            meta = extension.meta.toRuntimeMeta(),
+            thumbnailImageIndex = extension.thumbnailImageIndex,
+            humanoidBones = extension.humanoidBones.map { bone -> bone.toRuntimeBinding() },
+            expressions = extension.expressions.map { expression -> expression.toRuntimeExpression() },
+            lookAt = extension.lookAt?.toRuntimeLookAt(),
+            firstPerson = extension.firstPerson?.toRuntimeFirstPerson(),
+        )
+    }
+
+    private fun ParsedVrmMeta.toRuntimeMeta(): VrmRuntimeMeta = VrmRuntimeMeta(
+        avatarName = avatarName,
+        authors = authors,
+        version = version,
+    )
+
+    private fun ParsedHumanoidBone.toRuntimeBinding(): VrmHumanoidBoneBinding = VrmHumanoidBoneBinding(
+        boneName = normalizeHumanoidBoneName(name),
+        nodeIndex = nodeIndex,
+    )
+
+    private fun ParsedVrmExpression.toRuntimeExpression(): VrmExpressionDescriptor = VrmExpressionDescriptor(
+        runtimeName = runtimeName,
+        displayName = displayName,
+        presetName = presetName,
+        isBinary = isBinary,
+        morphTargetBinds = morphTargetBinds.map { bind -> bind.toRuntimeBind() },
+        overrideBlink = overrideBlink,
+        overrideLookAt = overrideLookAt,
+        overrideMouth = overrideMouth,
+    )
+
+    private fun ParsedMorphTargetBind.toRuntimeBind(): VrmMorphTargetBind = VrmMorphTargetBind(
+        nodeIndex = nodeIndex,
+        morphTargetIndex = morphTargetIndex,
+        weight = weight,
+    )
+
+    private fun ParsedLookAt.toRuntimeLookAt(): VrmLookAtDescriptor = VrmLookAtDescriptor(
+        type = type,
+        offsetFromHeadBone = offsetFromHeadBone?.toRuntimeFloat3(),
+    )
+
+    private fun ParsedFirstPerson.toRuntimeFirstPerson(): VrmFirstPersonDescriptor = VrmFirstPersonDescriptor(
+        firstPersonBone = firstPersonBone,
+        meshAnnotationIndices = meshAnnotationIndices,
+    )
+
+    private fun ParsedFloat3.toRuntimeFloat3(): VrmFloat3 = VrmFloat3(
+        x = x,
+        y = y,
+        z = z,
+    )
+
+    private fun normalizeHumanoidBoneName(rawName: String): String {
+        val trimmedName = rawName.trim()
+        if (trimmedName.isEmpty()) return trimmedName
+        return humanoidBoneAliases[trimmedName.lowercase()] ?: trimmedName.replaceFirstChar { char -> char.lowercase() }
+    }
+
+    private val humanoidBoneAliases: Map<String, String> = mapOf(
+        "hips" to "hips",
+        "spine" to "spine",
+        "chest" to "chest",
+        "upperchest" to "upperChest",
+        "neck" to "neck",
+        "head" to "head",
+        "jaw" to "jaw",
+        "lefteye" to "leftEye",
+        "righteye" to "rightEye",
+        "leftshoulder" to "leftShoulder",
+        "rightshoulder" to "rightShoulder",
+        "leftupperarm" to "leftUpperArm",
+        "rightupperarm" to "rightUpperArm",
+        "leftlowerarm" to "leftLowerArm",
+        "rightlowerarm" to "rightLowerArm",
+        "lefthand" to "leftHand",
+        "righthand" to "rightHand",
+        "leftupperleg" to "leftUpperLeg",
+        "rightupperleg" to "rightUpperLeg",
+        "leftlowerleg" to "leftLowerLeg",
+        "rightlowerleg" to "rightLowerLeg",
+        "leftfoot" to "leftFoot",
+        "rightfoot" to "rightFoot",
+        "lefttoes" to "leftToes",
+        "righttoes" to "rightToes",
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmSpecNormalizer.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmSpecNormalizer.kt
@@ -76,10 +76,29 @@ internal object VrmSpecNormalizer {
         z = z,
     )
 
+    private fun asciiLowercaseChar(char: Char): Char = when (char) {
+        in 'A'..'Z' -> (char.code + ('a'.code - 'A'.code)).toChar()
+        else -> char
+    }
+
+    private fun asciiLowercase(value: String): String = buildString(value.length) {
+        value.forEach { char -> append(asciiLowercaseChar(char)) }
+    }
+
+    private fun lowercaseAsciiFirstChar(value: String): String {
+        if (value.isEmpty()) return value
+        val firstChar = asciiLowercaseChar(value[0])
+        if (firstChar == value[0]) return value
+        return buildString(value.length) {
+            append(firstChar)
+            append(value, 1, value.length)
+        }
+    }
+
     private fun normalizeHumanoidBoneName(rawName: String): String {
         val trimmedName = rawName.trim()
         if (trimmedName.isEmpty()) return trimmedName
-        return humanoidBoneAliases[trimmedName.lowercase()] ?: trimmedName.replaceFirstChar { char -> char.lowercase() }
+        return humanoidBoneAliases[asciiLowercase(trimmedName)] ?: lowercaseAsciiFirstChar(trimmedName)
     }
 
     private val humanoidBoneAliases: Map<String, String> = mapOf(

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt
@@ -1,11 +1,8 @@
 package com.example.vtubercamera_kmp_ver.camera
 
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.intOrNull
+import com.example.vtubercamera_kmp_ver.avatar.vrm.VrmAssetParseException
+import com.example.vtubercamera_kmp_ver.avatar.vrm.VrmAssetParseFailureKind
+import com.example.vtubercamera_kmp_ver.avatar.vrm.VrmExtensionParser
 import vtubercamera_kmp_ver.composeapp.generated.resources.Res
 import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_invalid_format
 import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_metadata_parse_failed
@@ -13,69 +10,25 @@ import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_read_failed
 import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_select_file
 
 object VrmAvatarParser {
-    private const val glbHeaderMagic = 0x46546C67
-    private const val jsonChunkType = 0x4E4F534A
-    private const val binaryChunkType = 0x004E4942
     private val supportedExtensions = setOf("vrm", "glb")
-
-    private val json = Json { ignoreUnknownKeys = true }
 
     fun parse(fileName: String, bytes: ByteArray): Result<AvatarPreviewData> {
         if (!fileName.hasSupportedExtension()) {
             return Result.failure(FilePickerException(Res.string.vrm_error_select_file))
         }
-        if (bytes.size < 20) {
-            return Result.failure(FilePickerException(Res.string.vrm_error_read_failed))
+
+        val document = VrmExtensionParser.parseDocument(bytes).getOrElse { throwable ->
+            return Result.failure(throwable.toFilePickerException())
+        }
+        val descriptor = VrmExtensionParser.parseRuntimeAssetDescriptor(document).getOrElse { throwable ->
+            return Result.failure(throwable.toFilePickerException())
         }
 
-        val magic = bytes.readIntLE(0)
-        if (magic != glbHeaderMagic) {
-            return Result.failure(FilePickerException(Res.string.vrm_error_select_file))
-        }
-
-        val declaredLength = bytes.readIntLE(8)
-        if (declaredLength > bytes.size || declaredLength < 20) {
-            return Result.failure(FilePickerException(Res.string.vrm_error_invalid_format))
-        }
-
-        var offset = 12
-        var jsonChunk: String? = null
-        var binaryChunk: ByteArray? = null
-        while (offset + 8 <= declaredLength) {
-            val chunkLength = bytes.readIntLE(offset)
-            val chunkType = bytes.readIntLE(offset + 4)
-            val chunkStart = offset + 8
-            val chunkEnd = chunkStart + chunkLength
-            if (chunkLength < 0 || chunkEnd > declaredLength) {
-                return Result.failure(FilePickerException(Res.string.vrm_error_invalid_format))
-            }
-            when (chunkType) {
-                jsonChunkType -> jsonChunk = bytes.decodeToString(chunkStart, chunkEnd)
-                binaryChunkType -> binaryChunk = bytes.copyOfRange(chunkStart, chunkEnd)
-            }
-            offset = chunkEnd
-        }
-
-        val root = jsonChunk
-            ?.let { chunk ->
-                runCatching { json.parseToJsonElement(chunk) as? JsonObject }.getOrNull()
-            }
-            ?: return Result.failure(FilePickerException(Res.string.vrm_error_metadata_parse_failed))
-
-        val meta = root.vrm0Meta() ?: root.vrm1Meta()
-        val avatarName = meta?.string("title")
-            ?: meta?.string("name")
-            ?: fileName.substringBeforeLast('.')
-        val authorName = meta?.string("author") ?: meta?.stringArray("authors")?.firstOrNull()
-        val vrmVersion = meta?.string("version")
-            ?: root.childObject("extensions")?.childObject("VRMC_vrm")?.string("specVersion")
-            ?: root.childObject("asset")?.string("version")
-
-        val thumbnailIndex = root.resolveThumbnailImageIndex()
-        val thumbnailBytes = if (thumbnailIndex != null && binaryChunk != null) {
-            root.extractImageBytes(thumbnailIndex, binaryChunk)
-        } else {
-            null
+        val avatarName = descriptor.meta.avatarName ?: fileName.substringBeforeLast('.')
+        val authorName = descriptor.meta.authors.firstOrNull()
+        val vrmVersion = descriptor.meta.version ?: descriptor.rawSpecVersion ?: descriptor.assetVersion
+        val thumbnailBytes = descriptor.thumbnailImageIndex?.let { imageIndex ->
+            document.extractImageBytes(imageIndex)
         }
 
         return Result.success(
@@ -89,78 +42,22 @@ object VrmAvatarParser {
         )
     }
 
-    private fun JsonObject.vrm0Meta(): JsonObject? =
-        childObject("extensions")?.childObject("VRM")?.childObject("meta")
-
-    private fun JsonObject.vrm1Meta(): JsonObject? =
-        childObject("extensions")?.childObject("VRMC_vrm")?.childObject("meta")
-
-    private fun JsonObject.resolveThumbnailImageIndex(): Int? {
-        val vrm0Meta = vrm0Meta()
-        val vrm0TextureIndex = vrm0Meta?.int("texture")
-        if (vrm0TextureIndex != null) {
-            val imageIndex = childArray("textures")
-                ?.getOrNull(vrm0TextureIndex)
-                ?.jsonObjectOrNull()
-                ?.int("source")
-            if (imageIndex != null) return imageIndex
-        }
-
-        return vrm1Meta()?.int("thumbnailImage")
-    }
-
-    private fun JsonObject.extractImageBytes(imageIndex: Int, binaryChunk: ByteArray): ByteArray? {
-        val image = childArray("images")
-            ?.getOrNull(imageIndex)
-            ?.jsonObjectOrNull()
-            ?: return null
-        val bufferViewIndex = image.int("bufferView") ?: return null
-        val mimeType = image.string("mimeType") ?: return null
-        if (!mimeType.startsWith("image/")) return null
-
-        val bufferView = childArray("bufferViews")
-            ?.getOrNull(bufferViewIndex)
-            ?.jsonObjectOrNull()
-            ?: return null
-        val byteOffset = bufferView.int("byteOffset") ?: 0
-        val byteLength = bufferView.int("byteLength") ?: return null
-        val end = byteOffset + byteLength
-        if (byteOffset < 0 || end > binaryChunk.size) return null
-        return binaryChunk.copyOfRange(byteOffset, end)
-    }
-
-    private fun JsonObject.childObject(key: String): JsonObject? = get(key)?.jsonObjectOrNull()
-
-    private fun JsonObject.childArray(key: String): JsonArray? = get(key)?.jsonArrayOrNull()
-
-    private fun JsonObject.string(key: String): String? =
-        get(key)?.jsonPrimitiveOrNull()?.content?.takeIf { value -> value.isNotBlank() }
-
-    private fun JsonObject.int(key: String): Int? = get(key)?.jsonPrimitiveOrNull()?.intOrNull
-
-    private fun JsonObject.stringArray(key: String): List<String>? {
-        return childArray(key)
-            ?.mapNotNull { element ->
-                element.jsonPrimitiveOrNull()?.content?.takeIf { value -> value.isNotBlank() }
-            }
-            ?.takeIf { it.isNotEmpty() }
-    }
-
-    private fun JsonElement.jsonObjectOrNull(): JsonObject? = this as? JsonObject
-
-    private fun JsonElement.jsonArrayOrNull(): JsonArray? = this as? JsonArray
-
-    private fun JsonElement.jsonPrimitiveOrNull(): JsonPrimitive? = this as? JsonPrimitive
-
     private fun String.hasSupportedExtension(): Boolean {
         val extension = substringAfterLast('.', missingDelimiterValue = "")
         return extension.lowercase() in supportedExtensions
     }
 
-    private fun ByteArray.readIntLE(offset: Int): Int {
-        return (this[offset].toInt() and 0xFF) or
-            ((this[offset + 1].toInt() and 0xFF) shl 8) or
-            ((this[offset + 2].toInt() and 0xFF) shl 16) or
-            ((this[offset + 3].toInt() and 0xFF) shl 24)
+    private fun Throwable.toFilePickerException(): FilePickerException {
+        val messageRes = when (this) {
+            is VrmAssetParseException -> when (kind) {
+                VrmAssetParseFailureKind.InvalidFileType -> Res.string.vrm_error_select_file
+                VrmAssetParseFailureKind.ReadFailed -> Res.string.vrm_error_read_failed
+                VrmAssetParseFailureKind.InvalidFormat -> Res.string.vrm_error_invalid_format
+                VrmAssetParseFailureKind.MetadataFailed -> Res.string.vrm_error_metadata_parse_failed
+            }
+
+            else -> Res.string.vrm_error_read_failed
+        }
+        return FilePickerException(messageRes)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParserTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParserTest.kt
@@ -3,6 +3,7 @@ package com.example.vtubercamera_kmp_ver.avatar.vrm
 import com.example.vtubercamera_kmp_ver.avatar.mapping.VrmSpecVersion
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
 class VrmExtensionParserTest {
@@ -156,6 +157,18 @@ class VrmExtensionParserTest {
         assertEquals("expression", descriptor.lookAt?.type)
         assertNotNull(descriptor.lookAt?.offsetFromHeadBone)
         assertEquals(listOf(13), descriptor.firstPerson?.meshAnnotationIndices)
+    }
+
+    @Test
+    fun parseDocumentReturnsMalformedJsonAsMetadataFailed() {
+        val glb = createGlb(
+            json = "{ this is not valid json !!!",
+            binary = byteArrayOf(),
+        )
+
+        val result = VrmExtensionParser.parseDocument(glb)
+        val exception = assertFailsWith<VrmAssetParseException> { result.getOrThrow() }
+        assertEquals(VrmAssetParseFailureKind.MetadataFailed, exception.kind)
     }
 
     private fun createGlb(json: String, binary: ByteArray): ByteArray {

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParserTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParserTest.kt
@@ -1,0 +1,190 @@
+package com.example.vtubercamera_kmp_ver.avatar.vrm
+
+import com.example.vtubercamera_kmp_ver.avatar.mapping.VrmSpecVersion
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class VrmExtensionParserTest {
+
+    @Test
+    fun parseRuntimeAssetDescriptorNormalizesVrm0Extension() {
+        val glb = createGlb(
+            json = """
+                {
+                  "asset": {"version": "2.0"},
+                  "extensions": {
+                    "VRM": {
+                      "meta": {
+                        "title": "Preview Avatar",
+                        "author": "OpenAI",
+                        "version": "0.99",
+                        "texture": 0
+                      },
+                      "humanoid": {
+                        "humanBones": [
+                          {"bone": "head", "node": 3},
+                          {"bone": "leftupperarm", "node": 4}
+                        ]
+                      },
+                      "blendShapeMaster": {
+                        "blendShapeGroups": [
+                          {
+                            "name": "Joy",
+                            "presetName": "joy",
+                            "isBinary": false,
+                            "binds": [
+                              {"mesh": 5, "index": 1, "weight": 100}
+                            ]
+                          }
+                        ]
+                      },
+                      "firstPerson": {
+                        "firstPersonBone": 3,
+                        "lookAtTypeName": "Bone",
+                        "meshAnnotations": [
+                          {"mesh": 7}
+                        ]
+                      }
+                    }
+                  },
+                  "textures": [{"source": 0}],
+                  "images": [{"bufferView": 0, "mimeType": "image/png"}],
+                  "bufferViews": [{"buffer": 0, "byteOffset": 0, "byteLength": 4}]
+                }
+            """.trimIndent(),
+            binary = byteArrayOf(1, 2, 3, 4),
+        )
+
+        val descriptor = VrmExtensionParser.parseRuntimeAssetDescriptor(glb).getOrThrow()
+
+        assertEquals(VrmSpecVersion.Vrm0, descriptor.specVersion)
+        assertEquals("Preview Avatar", descriptor.meta.avatarName)
+        assertEquals(listOf("OpenAI"), descriptor.meta.authors)
+        assertEquals("0.99", descriptor.meta.version)
+        assertEquals(0, descriptor.thumbnailImageIndex)
+        assertEquals("head", descriptor.humanoidBones.first().boneName)
+        assertEquals("leftUpperArm", descriptor.humanoidBones[1].boneName)
+        assertEquals("joy", descriptor.expressions.single().runtimeName)
+        assertEquals(1f, descriptor.expressions.single().morphTargetBinds.single().weight)
+        assertEquals("Bone", descriptor.lookAt?.type)
+        assertEquals(3, descriptor.firstPerson?.firstPersonBone)
+        assertEquals(listOf(7), descriptor.firstPerson?.meshAnnotationIndices)
+    }
+
+    @Test
+    fun parseRuntimeAssetDescriptorNormalizesVrm1Extension() {
+        val glb = createGlb(
+            json = """
+                {
+                  "asset": {"version": "2.0"},
+                  "extensions": {
+                    "VRMC_vrm": {
+                      "specVersion": "1.0",
+                      "meta": {
+                        "name": "Runtime Avatar",
+                        "authors": ["OpenAI", "Copilot"],
+                        "version": "1.2.3",
+                        "thumbnailImage": 1
+                      },
+                      "humanoid": {
+                        "humanBones": {
+                          "head": {"node": 8},
+                          "neck": {"node": 9}
+                        }
+                      },
+                      "expressions": {
+                        "preset": {
+                          "happy": {
+                            "isBinary": false,
+                            "morphTargetBinds": [
+                              {"node": 10, "index": 2, "weight": 0.75}
+                            ],
+                            "overrideBlink": "blend"
+                          },
+                          "blinkLeft": {
+                            "isBinary": true,
+                            "morphTargetBinds": [
+                              {"node": 11, "index": 3, "weight": 1.0}
+                            ]
+                          }
+                        },
+                        "custom": {
+                          "surprisedCustom": {
+                            "name": "Surprised",
+                            "morphTargetBinds": [
+                              {"node": 12, "index": 4, "weight": 0.5}
+                            ]
+                          }
+                        }
+                      },
+                      "lookAt": {
+                        "type": "expression",
+                        "offsetFromHeadBone": {"x": 0.0, "y": 0.2, "z": 0.1}
+                      },
+                      "firstPerson": {
+                        "meshAnnotations": [
+                          {"node": 13}
+                        ]
+                      }
+                    }
+                  },
+                  "images": [
+                    {"bufferView": 0, "mimeType": "image/png"},
+                    {"bufferView": 1, "mimeType": "image/png"}
+                  ],
+                  "bufferViews": [
+                    {"buffer": 0, "byteOffset": 0, "byteLength": 4},
+                    {"buffer": 0, "byteOffset": 4, "byteLength": 4}
+                  ]
+                }
+            """.trimIndent(),
+            binary = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8),
+        )
+
+        val descriptor = VrmExtensionParser.parseRuntimeAssetDescriptor(glb).getOrThrow()
+
+        assertEquals(VrmSpecVersion.Vrm1, descriptor.specVersion)
+        assertEquals("1.0", descriptor.rawSpecVersion)
+        assertEquals("Runtime Avatar", descriptor.meta.avatarName)
+        assertEquals(listOf("OpenAI", "Copilot"), descriptor.meta.authors)
+        assertEquals(1, descriptor.thumbnailImageIndex)
+        assertEquals(setOf("happy", "blinkLeft", "surprisedCustom"), descriptor.availableExpressionNames)
+        assertEquals("happy", descriptor.expressions.first().runtimeName)
+        assertEquals(0.75f, descriptor.expressions.first().morphTargetBinds.single().weight)
+        assertEquals("blend", descriptor.expressions.first().overrideBlink)
+        assertEquals("expression", descriptor.lookAt?.type)
+        assertNotNull(descriptor.lookAt?.offsetFromHeadBone)
+        assertEquals(listOf(13), descriptor.firstPerson?.meshAnnotationIndices)
+    }
+
+    private fun createGlb(json: String, binary: ByteArray): ByteArray {
+        val jsonBytes = json.encodeToByteArray().padTo4Bytes(0x20)
+        val binaryBytes = binary.padTo4Bytes(0x00)
+        val totalLength = 12 + 8 + jsonBytes.size + 8 + binaryBytes.size
+        return buildList<Byte> {
+            addIntLE(0x46546C67)
+            addIntLE(2)
+            addIntLE(totalLength)
+            addIntLE(jsonBytes.size)
+            addIntLE(0x4E4F534A)
+            addAll(jsonBytes.toList())
+            addIntLE(binaryBytes.size)
+            addIntLE(0x004E4942)
+            addAll(binaryBytes.toList())
+        }.toByteArray()
+    }
+
+    private fun ByteArray.padTo4Bytes(paddingByte: Int): ByteArray {
+        val padding = (4 - size % 4) % 4
+        if (padding == 0) return this
+        return this + ByteArray(padding) { paddingByte.toByte() }
+    }
+
+    private fun MutableList<Byte>.addIntLE(value: Int) {
+        add((value and 0xFF).toByte())
+        add(((value ushr 8) and 0xFF).toByte())
+        add(((value ushr 16) and 0xFF).toByte())
+        add(((value ushr 24) and 0xFF).toByte())
+    }
+}


### PR DESCRIPTION
## Summary

- add a shared VRM extension parser that supports both VRM 0.x and VRM 1.0 for runtime and preview flows
- add normalization and a shared runtime asset descriptor so downstream rendering can consume a consistent model
- refactor `VrmAvatarParser` to delegate preview parsing to the shared parser and add parser/normalizer tests

## Why

The VRM parsing logic was split across runtime and preview paths, which made 0.x/1.0 support harder to extend and verify consistently. This change centralizes parsing and normalization so both flows use the same behavior.

## Impact

- reduces duplicated VRM extension parsing logic
- makes runtime and preview asset extraction consistent across VRM spec versions
- adds regression coverage for the shared parsing and normalization path

## Validation

- `./gradlew :composeApp:allTests`
