### PR TITLE
Implement VRM preview/runtime descriptor separation

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
@@ -23,6 +23,11 @@ object VrmExtensionParser {
             parseRuntimeAssetDescriptor(document).getOrThrow()
         }
 
+    fun parsePreviewAssetDescriptor(bytes: ByteArray): Result<VrmPreviewAssetDescriptor> =
+        parseDocument(bytes).mapCatching { document ->
+            parsePreviewAssetDescriptor(document).getOrThrow()
+        }
+
     internal fun parseDocument(bytes: ByteArray): Result<VrmGlbDocument> = runCatching {
         if (bytes.size < 20) {
             throw VrmAssetParseException(VrmAssetParseFailureKind.ReadFailed)
@@ -92,6 +97,16 @@ object VrmExtensionParser {
             ?: throw VrmAssetParseException(VrmAssetParseFailureKind.MetadataFailed)
 
         VrmSpecNormalizer.normalize(
+            extension = parsedExtension,
+            assetVersion = document.assetVersion,
+        )
+    }
+
+    internal fun parsePreviewAssetDescriptor(document: VrmGlbDocument): Result<VrmPreviewAssetDescriptor> = runCatching {
+        val parsedExtension = document.root.parseVrmExtension()
+            ?: throw VrmAssetParseException(VrmAssetParseFailureKind.MetadataFailed)
+
+        VrmSpecNormalizer.normalizePreview(
             extension = parsedExtension,
             assetVersion = document.assetVersion,
         )

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
@@ -103,7 +103,7 @@ object VrmExtensionParser {
     }
 
     internal fun parsePreviewAssetDescriptor(document: VrmGlbDocument): Result<VrmPreviewAssetDescriptor> = runCatching {
-        val parsedExtension = document.root.parseVrmExtension()
+        val parsedExtension = document.root.parseVrmPreviewExtension()
             ?: throw VrmAssetParseException(VrmAssetParseFailureKind.MetadataFailed)
 
         VrmSpecNormalizer.normalizePreview(
@@ -135,6 +135,37 @@ object VrmExtensionParser {
                 expressions = vrm0Extension.parseVrm0Expressions(),
                 lookAt = vrm0Extension.childObject("firstPerson")?.toParsedVrm0LookAt(),
                 firstPerson = vrm0Extension.childObject("firstPerson")?.toParsedFirstPerson(),
+            )
+        }
+
+        return null
+    }
+
+    // プレビュー表示に必要な specVersion / meta / thumbnailImageIndex のみを読み取る軽量パス。
+    // ヒューマノイドボーン・表情・LookAt・一人称設定は解析しない。
+    private fun JsonObject.parseVrmPreviewExtension(): ParsedVrmExtension? {
+        val extensions = childObject("extensions") ?: return null
+        extensions.childObject("VRMC_vrm")?.let { vrm1Extension ->
+            return ParsedVrm1Extension(
+                rawSpecVersion = vrm1Extension.string("specVersion"),
+                meta = vrm1Extension.childObject("meta").toParsedVrm1Meta(),
+                thumbnailImageIndex = vrm1Extension.childObject("meta")?.int("thumbnailImage"),
+                humanoidBones = emptyList(),
+                expressions = emptyList(),
+                lookAt = null,
+                firstPerson = null,
+            )
+        }
+
+        extensions.childObject("VRM")?.let { vrm0Extension ->
+            return ParsedVrm0Extension(
+                rawSpecVersion = null,
+                meta = vrm0Extension.childObject("meta").toParsedVrm0Meta(),
+                thumbnailImageIndex = resolveVrm0ThumbnailImageIndex(vrm0Extension),
+                humanoidBones = emptyList(),
+                expressions = emptyList(),
+                lookAt = null,
+                firstPerson = null,
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmRuntimeAssetDescriptor.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmRuntimeAssetDescriptor.kt
@@ -2,6 +2,15 @@ package com.example.vtubercamera_kmp_ver.avatar.vrm
 
 import com.example.vtubercamera_kmp_ver.avatar.mapping.VrmSpecVersion
 
+// プレビュー表示向けに必要な VRM メタ情報を保持する。
+data class VrmPreviewAssetDescriptor(
+    val specVersion: VrmSpecVersion,
+    val rawSpecVersion: String?,
+    val assetVersion: String?,
+    val meta: VrmRuntimeMeta,
+    val thumbnailImageIndex: Int?,
+)
+
 // VRM アセットから抽出した実行時利用向けの統合情報を保持する。
 data class VrmRuntimeAssetDescriptor(
     val specVersion: VrmSpecVersion,

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmSpecNormalizer.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmSpecNormalizer.kt
@@ -3,6 +3,28 @@ package com.example.vtubercamera_kmp_ver.avatar.vrm
 import com.example.vtubercamera_kmp_ver.avatar.mapping.VrmSpecVersion
 
 internal object VrmSpecNormalizer {
+    // 解析済み VRM 拡張情報をプレビュー向けの共通ディスクリプタへ正規化する。
+    fun normalizePreview(
+        extension: ParsedVrmExtension,
+        assetVersion: String?,
+    ): VrmPreviewAssetDescriptor = when (extension) {
+        is ParsedVrm0Extension -> VrmPreviewAssetDescriptor(
+            specVersion = VrmSpecVersion.Vrm0,
+            rawSpecVersion = extension.rawSpecVersion,
+            assetVersion = assetVersion,
+            meta = extension.meta.toRuntimeMeta(),
+            thumbnailImageIndex = extension.thumbnailImageIndex,
+        )
+
+        is ParsedVrm1Extension -> VrmPreviewAssetDescriptor(
+            specVersion = VrmSpecVersion.Vrm1,
+            rawSpecVersion = extension.rawSpecVersion,
+            assetVersion = assetVersion,
+            meta = extension.meta.toRuntimeMeta(),
+            thumbnailImageIndex = extension.thumbnailImageIndex,
+        )
+    }
+
     // 解析済み VRM 拡張情報を実行時利用向けの共通ディスクリプタへ正規化する。
     fun normalize(
         extension: ParsedVrmExtension,

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt
@@ -20,14 +20,14 @@ object VrmAvatarParser {
         val document = VrmExtensionParser.parseDocument(bytes).getOrElse { throwable ->
             return Result.failure(throwable.toFilePickerException())
         }
-        val descriptor = VrmExtensionParser.parseRuntimeAssetDescriptor(document).getOrElse { throwable ->
+        val previewDescriptor = VrmExtensionParser.parsePreviewAssetDescriptor(document).getOrElse { throwable ->
             return Result.failure(throwable.toFilePickerException())
         }
 
-        val avatarName = descriptor.meta.avatarName ?: fileName.substringBeforeLast('.')
-        val authorName = descriptor.meta.authors.firstOrNull()
-        val vrmVersion = descriptor.meta.version ?: descriptor.rawSpecVersion ?: descriptor.assetVersion
-        val thumbnailBytes = descriptor.thumbnailImageIndex?.let { imageIndex ->
+        val avatarName = previewDescriptor.meta.avatarName ?: fileName.substringBeforeLast('.')
+        val authorName = previewDescriptor.meta.authors.firstOrNull()
+        val vrmVersion = previewDescriptor.meta.version ?: previewDescriptor.rawSpecVersion ?: previewDescriptor.assetVersion
+        val thumbnailBytes = previewDescriptor.thumbnailImageIndex?.let { imageIndex ->
             document.extractImageBytes(imageIndex)
         }
 

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParserTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParserTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class VrmExtensionParserTest {
 
@@ -160,6 +161,40 @@ class VrmExtensionParserTest {
     }
 
     @Test
+    fun parsePreviewAssetDescriptorExtractsPreviewOnlyMetadata() {
+        val glb = createGlb(
+            json = """
+                {
+                  "asset": {"version": "2.0"},
+                  "extensions": {
+                    "VRMC_vrm": {
+                      "specVersion": "1.0",
+                      "meta": {
+                        "name": "Preview Only Avatar",
+                        "authors": ["OpenAI"],
+                        "version": "1.5.0",
+                        "thumbnailImage": 0
+                      }
+                    }
+                  },
+                  "images": [{"bufferView": 0, "mimeType": "image/png"}],
+                  "bufferViews": [{"buffer": 0, "byteOffset": 0, "byteLength": 4}]
+                }
+            """.trimIndent(),
+            binary = byteArrayOf(1, 2, 3, 4),
+        )
+
+        val descriptor = VrmExtensionParser.parsePreviewAssetDescriptor(glb).getOrThrow()
+
+        assertEquals(VrmSpecVersion.Vrm1, descriptor.specVersion)
+        assertEquals("1.0", descriptor.rawSpecVersion)
+        assertEquals("Preview Only Avatar", descriptor.meta.avatarName)
+        assertEquals(listOf("OpenAI"), descriptor.meta.authors)
+        assertEquals("1.5.0", descriptor.meta.version)
+        assertEquals(0, descriptor.thumbnailImageIndex)
+    }
+
+    @Test
     fun parseDocumentReturnsMalformedJsonAsMetadataFailed() {
         val glb = createGlb(
             json = "{ this is not valid json !!!",
@@ -169,6 +204,36 @@ class VrmExtensionParserTest {
         val result = VrmExtensionParser.parseDocument(glb)
         val exception = assertFailsWith<VrmAssetParseException> { result.getOrThrow() }
         assertEquals(VrmAssetParseFailureKind.MetadataFailed, exception.kind)
+    }
+
+    @Test
+    fun parseRuntimeAssetDescriptorAllowsMissingRuntimeData() {
+        val glb = createGlb(
+            json = """
+                {
+                  "asset": {"version": "2.0"},
+                  "extensions": {
+                    "VRM": {
+                      "meta": {
+                        "title": "Meta Only",
+                        "author": "OpenAI"
+                      }
+                    }
+                  }
+                }
+            """.trimIndent(),
+            binary = byteArrayOf(),
+        )
+
+        val descriptor = VrmExtensionParser.parseRuntimeAssetDescriptor(glb).getOrThrow()
+
+        assertEquals(VrmSpecVersion.Vrm0, descriptor.specVersion)
+        assertEquals("Meta Only", descriptor.meta.avatarName)
+        assertEquals(listOf("OpenAI"), descriptor.meta.authors)
+        assertTrue(descriptor.humanoidBones.isEmpty())
+        assertTrue(descriptor.expressions.isEmpty())
+        assertNull(descriptor.lookAt)
+        assertNull(descriptor.firstPerson)
     }
 
     private fun createGlb(json: String, binary: ByteArray): ByteArray {

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParserTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParserTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class VrmExtensionParserTest {
 


### PR DESCRIPTION
### Motivation
- Make preview extraction (thumbnail and basic meta) independent from full runtime descriptor parsing to keep preview flow lightweight and robust.
- Avoid depending on runtime-only fields when showing avatar previews and reduce unnecessary parsing work in `VrmAvatarParser`.
- Provide clearer separation of concerns between preview metadata and runtime asset data for future extensions.

### Description
- Add a new shared model `VrmPreviewAssetDescriptor` to hold minimal preview metadata (`specVersion`, `rawSpecVersion`, `assetVersion`, `meta`, `thumbnailImageIndex`).
- Add `normalizePreview` to `VrmSpecNormalizer` and `parsePreviewAssetDescriptor` to `VrmExtensionParser` to produce the preview descriptor from a GLB document.
- Switch `VrmAvatarParser` to use `parsePreviewAssetDescriptor` instead of the full runtime descriptor when constructing `AvatarPreviewData`.
- Add unit tests in `VrmExtensionParserTest` to verify preview-only metadata extraction (`parsePreviewAssetDescriptorExtractsPreviewOnlyMetadata`) and runtime parsing behavior when runtime fields are omitted (`parseRuntimeAssetDescriptorAllowsMissingRuntimeData`).

### Testing
- Executed the parser-focused Gradle test command `./gradlew :composeApp:commonTest --tests com.example.vtubercamera_kmp_ver.avatar.vrm.VrmExtensionParserTest --tests com.example.vtubercamera_kmp_ver.ComposeAppCommonTest` but the run failed because Gradle could not resolve the plugin `org.gradle.toolchains.foojay-resolver-convention:1.0.0` from configured repositories, so tests did not complete in this environment.
- No other automated test runs completed successfully in the current environment due to the above Gradle resolution error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db25d46a888330926c24eb6d0a211c)