### PR TITLE
Issue #22: Add avatarRenderState and map face-tracking to AvatarRenderState in CameraViewModel

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
@@ -1,5 +1,6 @@
 package com.example.vtubercamera_kmp_ver.camera
 
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
 import org.jetbrains.compose.resources.StringResource
 
 // カメラ画面で描画する共有 UI 状態をまとめて保持する。
@@ -11,6 +12,7 @@ data class CameraUiState(
     val message: CameraMessage? = null,
     val faceTracking: FaceTrackingUiState = FaceTrackingUiState(),
     val avatarPreview: AvatarPreviewData? = null,
+    val avatarRenderState: AvatarRenderState = AvatarRenderState.Neutral,
     val filePickerErrorMessageRes: StringResource? = null,
 ) {
     val isPermissionGranted: Boolean

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
@@ -2,6 +2,7 @@ package com.example.vtubercamera_kmp_ver.camera
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.vtubercamera_kmp_ver.avatar.mapping.FaceToAvatarMapper
 import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,6 +19,7 @@ class CameraViewModel(
     private val cameraRepository: CameraRepository,
     private val permissionRepository: PermissionRepository,
 ) : ViewModel() {
+    private val faceToAvatarMapper = FaceToAvatarMapper()
     private val _uiState = MutableStateFlow(CameraUiState())
     val uiState: StateFlow<CameraUiState> = _uiState.asStateFlow()
 
@@ -168,12 +170,17 @@ class CameraViewModel(
     // 顔トラッキング結果を画面表示用の状態へ変換して保持する。
     fun onFaceTrackingFrameChanged(frame: NormalizedFaceFrame?) {
         _uiState.update { currentState ->
+            val avatarRenderState = faceToAvatarMapper.map(
+                frame = frame,
+                previousState = currentState.avatarRenderState,
+            )
             currentState.copy(
                 faceTracking = FaceTrackingUiState(
                     isTracking = frame != null,
                     frame = frame,
                     display = frame?.toDisplayState(),
                 ),
+                avatarRenderState = avatarRenderState,
             )
         }
     }


### PR DESCRIPTION
### Motivation
- Centralize avatar render output in shared UI state so face-tracking frames produce a renderer-ready `AvatarRenderState` as requested by issue #22.

### Description
- Added `avatarRenderState: AvatarRenderState = AvatarRenderState.Neutral` to `CameraUiState` so the shared state holds avatar rig/expression output.
- Introduced a `FaceToAvatarMapper` instance in `CameraViewModel` and imported the mapper.
- Updated `onFaceTrackingFrameChanged` to call the mapper with the incoming `NormalizedFaceFrame` and previous `avatarRenderState`, and to update both `faceTracking` and `avatarRenderState` in the UI state.
- Minor import reordering to include `AvatarRenderState` and the mapper where needed.

### Testing
- Attempted `./gradlew :composeApp:compileKotlinMetadata`, which failed in this environment because Gradle could not resolve the plugin `org.gradle.toolchains.foojay-resolver-convention:1.0.0` (build did not complete).
- No project unit tests were executed in this environment after the change due to the build resolution failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd040c5fa88330a9e0f135c48446fe)