### PR TITLE
test: add FaceToAvatarMapper and VrmSpecNormalizer unit tests (Issue #24)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
@@ -36,7 +36,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -85,7 +84,7 @@ actual fun rememberCameraPermissionController(): CameraPermissionController {
     ) { granted ->
         permissionGranted = granted
     }
-    val controller = remember<CameraPermissionController> {
+    val controller = remember {
         CameraPermissionController(
             isGranted = false,
             isChecking = true,
@@ -104,10 +103,8 @@ actual fun rememberCameraPermissionController(): CameraPermissionController {
         )
     }
 
-    SideEffect {
-        controller.updateRequestPermissionAction {
-            permissionLauncher.launch(Manifest.permission.CAMERA)
-        }
+    controller.updateRequestPermissionAction {
+        permissionLauncher.launch(Manifest.permission.CAMERA)
     }
     return controller
 }

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -84,7 +85,7 @@ actual fun rememberCameraPermissionController(): CameraPermissionController {
     ) { granted ->
         permissionGranted = granted
     }
-    val controller = remember {
+    val controller = remember<CameraPermissionController> {
         CameraPermissionController(
             isGranted = false,
             isChecking = true,
@@ -103,8 +104,10 @@ actual fun rememberCameraPermissionController(): CameraPermissionController {
         )
     }
 
-    controller.updateRequestPermissionAction {
-        permissionLauncher.launch(Manifest.permission.CAMERA)
+    SideEffect {
+        controller.updateRequestPermissionAction {
+            permissionLauncher.launch(Manifest.permission.CAMERA)
+        }
     }
     return controller
 }

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/FaceToAvatarMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/FaceToAvatarMapperTest.kt
@@ -1,5 +1,7 @@
 package com.example.vtubercamera_kmp_ver.avatar.mapping
 
+import com.example.vtubercamera_kmp_ver.avatar.model.AvatarExpressionWeights
+import com.example.vtubercamera_kmp_ver.avatar.model.AvatarRigState
 import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
 import com.example.vtubercamera_kmp_ver.avatar.state.AvatarTrackingStatus
 import com.example.vtubercamera_kmp_ver.camera.NormalizedFaceFrame
@@ -29,7 +31,7 @@ class FaceToAvatarMapperTest {
                 leftEyeBlink = 1.5f,
                 rightEyeBlink = -0.2f,
                 jawOpen = 0.4f,
-                mouthSmile = 0.6f,
+                mouthSmile = 1.2f,
             ),
             previousState = AvatarRenderState.Neutral,
         )
@@ -41,6 +43,7 @@ class FaceToAvatarMapperTest {
         assertEquals(1f, mapped.expressions.leftEyeBlink)
         assertEquals(0f, mapped.expressions.rightEyeBlink)
         assertEquals(0.4f, mapped.expressions.jawOpen)
+        assertEquals(1f, mapped.expressions.mouthSmile)
         assertEquals(100L, mapped.sourceTimestampMillis)
     }
 
@@ -58,8 +61,16 @@ class FaceToAvatarMapperTest {
 
         val previous = AvatarRenderState(
             trackingStatus = AvatarTrackingStatus.Tracking,
-            rig = com.example.vtubercamera_kmp_ver.avatar.model.AvatarRigState(headYawDegrees = 20f),
-            expressions = com.example.vtubercamera_kmp_ver.avatar.model.AvatarExpressionWeights(jawOpen = 0.8f),
+            rig = AvatarRigState(
+                headYawDegrees = 20f,
+                headPitchDegrees = -10f,
+            ),
+            expressions = AvatarExpressionWeights(
+                leftEyeBlink = 0.6f,
+                rightEyeBlink = 0.2f,
+                jawOpen = 0.8f,
+                mouthSmile = 0.5f,
+            ),
             sourceTimestampMillis = 50L,
             trackingConfidence = 1f,
         )
@@ -81,7 +92,11 @@ class FaceToAvatarMapperTest {
 
         assertEquals(AvatarTrackingStatus.Lost, mapped.trackingStatus)
         assertEquals(10f, mapped.rig.headYawDegrees)
+        assertEquals(-5f, mapped.rig.headPitchDegrees)
+        assertEquals(0.3f, mapped.expressions.leftEyeBlink)
+        assertEquals(0.1f, mapped.expressions.rightEyeBlink)
         assertEquals(0.4f, mapped.expressions.jawOpen)
+        assertEquals(0.25f, mapped.expressions.mouthSmile)
         assertEquals(120L, mapped.sourceTimestampMillis)
     }
 
@@ -98,8 +113,15 @@ class FaceToAvatarMapperTest {
 
         val previous = AvatarRenderState(
             trackingStatus = AvatarTrackingStatus.Lost,
-            rig = com.example.vtubercamera_kmp_ver.avatar.model.AvatarRigState(headRollDegrees = 12f),
-            expressions = com.example.vtubercamera_kmp_ver.avatar.model.AvatarExpressionWeights(mouthSmile = 0.8f),
+            rig = AvatarRigState(
+                headYawDegrees = 8f,
+                headRollDegrees = 12f,
+            ),
+            expressions = AvatarExpressionWeights(
+                leftEyeBlink = 0.5f,
+                jawOpen = 0.4f,
+                mouthSmile = 0.8f,
+            ),
             sourceTimestampMillis = 777L,
             trackingConfidence = 0.2f,
         )
@@ -107,7 +129,10 @@ class FaceToAvatarMapperTest {
         val mapped = mapper.map(frame = null, previousState = previous)
 
         assertEquals(AvatarTrackingStatus.NotTracked, mapped.trackingStatus)
+        assertEquals(6f, mapped.rig.headYawDegrees)
         assertEquals(9f, mapped.rig.headRollDegrees)
+        assertEquals(0.375f, mapped.expressions.leftEyeBlink)
+        assertEquals(0.3f, mapped.expressions.jawOpen)
         assertEquals(0.6f, mapped.expressions.mouthSmile)
         assertEquals(777L, mapped.sourceTimestampMillis)
         assertEquals(0f, mapped.trackingConfidence)

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmSpecNormalizerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmSpecNormalizerTest.kt
@@ -1,0 +1,126 @@
+package com.example.vtubercamera_kmp_ver.avatar.vrm
+
+import com.example.vtubercamera_kmp_ver.avatar.mapping.VrmSpecVersion
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class VrmSpecNormalizerTest {
+
+    @Test
+    fun normalizeVrm0MapsRuntimeDescriptorAndExpressionOverrides() {
+        val descriptor = VrmSpecNormalizer.normalize(
+            extension = ParsedVrm0Extension(
+                rawSpecVersion = "0.0",
+                meta = ParsedVrmMeta(
+                    avatarName = "Avatar 0",
+                    authors = listOf("Author 0"),
+                    version = "0.99",
+                ),
+                thumbnailImageIndex = 2,
+                humanoidBones = listOf(
+                    ParsedHumanoidBone(name = "leftupperarm", nodeIndex = 4),
+                ),
+                expressions = listOf(
+                    ParsedVrmExpression(
+                        runtimeName = "joy",
+                        displayName = "Joy",
+                        presetName = "joy",
+                        isBinary = false,
+                        morphTargetBinds = listOf(
+                            ParsedMorphTargetBind(nodeIndex = 5, morphTargetIndex = 1, weight = 1f),
+                        ),
+                        overrideBlink = "blend",
+                        overrideLookAt = "none",
+                        overrideMouth = "block",
+                    ),
+                ),
+                lookAt = null,
+                firstPerson = null,
+            ),
+            assetVersion = "2.0",
+        )
+
+        assertEquals(VrmSpecVersion.Vrm0, descriptor.specVersion)
+        assertEquals("0.0", descriptor.rawSpecVersion)
+        assertEquals("Avatar 0", descriptor.meta.avatarName)
+        assertEquals("leftUpperArm", descriptor.humanoidBones.single().boneName)
+
+        val expression = descriptor.expressions.single()
+        assertEquals("joy", expression.runtimeName)
+        assertEquals("Joy", expression.displayName)
+        assertEquals("joy", expression.presetName)
+        assertEquals("blend", expression.overrideBlink)
+        assertEquals("none", expression.overrideLookAt)
+        assertEquals("block", expression.overrideMouth)
+        assertEquals(1f, expression.morphTargetBinds.single().weight)
+    }
+
+    @Test
+    fun normalizeVrm1MapsRuntimeDescriptorAndRetainsExpressionNames() {
+        val descriptor = VrmSpecNormalizer.normalize(
+            extension = ParsedVrm1Extension(
+                rawSpecVersion = "1.0",
+                meta = ParsedVrmMeta(
+                    avatarName = "Avatar 1",
+                    authors = listOf("Author 1", "Author 2"),
+                    version = "1.2.3",
+                ),
+                thumbnailImageIndex = 6,
+                humanoidBones = listOf(
+                    ParsedHumanoidBone(name = "Head", nodeIndex = 8),
+                ),
+                expressions = listOf(
+                    ParsedVrmExpression(
+                        runtimeName = "happy",
+                        displayName = "Happy",
+                        presetName = "happy",
+                        isBinary = false,
+                        morphTargetBinds = listOf(
+                            ParsedMorphTargetBind(nodeIndex = 10, morphTargetIndex = 2, weight = 0.75f),
+                        ),
+                        overrideBlink = null,
+                        overrideLookAt = null,
+                        overrideMouth = null,
+                    ),
+                    ParsedVrmExpression(
+                        runtimeName = "surprisedCustom",
+                        displayName = "Surprised",
+                        presetName = null,
+                        isBinary = true,
+                        morphTargetBinds = listOf(
+                            ParsedMorphTargetBind(nodeIndex = 12, morphTargetIndex = 4, weight = 0.5f),
+                        ),
+                        overrideBlink = "none",
+                        overrideLookAt = "blend",
+                        overrideMouth = "block",
+                    ),
+                ),
+                lookAt = ParsedLookAt(
+                    type = "expression",
+                    offsetFromHeadBone = ParsedFloat3(0f, 0.2f, 0.1f),
+                ),
+                firstPerson = ParsedFirstPerson(
+                    firstPersonBone = 3,
+                    meshAnnotationIndices = listOf(13),
+                ),
+            ),
+            assetVersion = "2.0",
+        )
+
+        assertEquals(VrmSpecVersion.Vrm1, descriptor.specVersion)
+        assertEquals("head", descriptor.humanoidBones.single().boneName)
+        assertEquals(setOf("happy", "surprisedCustom"), descriptor.availableExpressionNames)
+
+        val customExpression = descriptor.expressions[1]
+        assertEquals("surprisedCustom", customExpression.runtimeName)
+        assertNull(customExpression.presetName)
+        assertEquals("none", customExpression.overrideBlink)
+        assertEquals("blend", customExpression.overrideLookAt)
+        assertEquals("block", customExpression.overrideMouth)
+        assertEquals(0.5f, customExpression.morphTargetBinds.single().weight)
+
+        assertEquals("expression", descriptor.lookAt?.type)
+        assertEquals(13, descriptor.firstPerson?.meshAnnotationIndices?.single())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmSpecNormalizerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmSpecNormalizerTest.kt
@@ -112,8 +112,7 @@ class VrmSpecNormalizerTest {
         assertEquals("head", descriptor.humanoidBones.single().boneName)
         assertEquals(setOf("happy", "surprisedCustom"), descriptor.availableExpressionNames)
 
-        val customExpression = descriptor.expressions[1]
-        assertEquals("surprisedCustom", customExpression.runtimeName)
+        val customExpression = descriptor.expressions.single { it.runtimeName == "surprisedCustom" }
         assertNull(customExpression.presetName)
         assertEquals("none", customExpression.overrideBlink)
         assertEquals("blend", customExpression.overrideLookAt)


### PR DESCRIPTION
### Motivation

- Add regression coverage for face-to-avatar mapping and VRM spec normalization to prevent regressions described in `Issue #24`.

### Description

- Expand `composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/FaceToAvatarMapperTest.kt` to assert head pose clamping, blink/jaw/mouth smile clamping, and decay behavior for `Lost` and `NotTracked` transitions using `FaceToAvatarMapper` and `AvatarMotionSmoothingConfig`.
- Add a new `composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmSpecNormalizerTest.kt` that verifies `VrmSpecNormalizer.normalize` for both VRM 0.x and VRM 1.0 paths, including humanoid bone name normalization, expression names/presets/overrides, morph weights, and `lookAt`/`firstPerson` fields.
- Tests exercise the public mapping/normalization behavior via `NormalizedFaceFrame`, `ParsedVrm0Extension` / `ParsedVrm1Extension`, and assert expected `AvatarRenderState` and `VrmRuntimeAssetDescriptor`/`VrmPreviewAssetDescriptor` outcomes.

### Testing

- Ran the targeted common tests with `./gradlew :composeApp:commonTest --tests "com.example.vtubercamera_kmp_ver.avatar.mapping.FaceToAvatarMapperTest" --tests "com.example.vtubercamera_kmp_ver.avatar.vrm.VrmSpecNormalizerTest"` which failed to execute in this environment due to plugin resolution error for `org.gradle.toolchains.foojay-resolver-convention:1.0.0` (Gradle plugin artifact could not be resolved from repositories).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2d32424f883309b09d99d05618085)