### PR TITLE
Fix Compose remember lint error in Android camera permission controller

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -84,7 +85,7 @@ actual fun rememberCameraPermissionController(): CameraPermissionController {
     ) { granted ->
         permissionGranted = granted
     }
-    val controller = remember {
+    val controller = remember<CameraPermissionController> {
         CameraPermissionController(
             isGranted = false,
             isChecking = true,
@@ -103,8 +104,10 @@ actual fun rememberCameraPermissionController(): CameraPermissionController {
         )
     }
 
-    controller.updateRequestPermissionAction {
-        permissionLauncher.launch(Manifest.permission.CAMERA)
+    SideEffect {
+        controller.updateRequestPermissionAction {
+            permissionLauncher.launch(Manifest.permission.CAMERA)
+        }
     }
     return controller
 }


### PR DESCRIPTION
### Motivation
- Fix the Compose lint `RememberReturnType` failure caused by a `remember` call potentially inferring `Unit` in `composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt` so lint no longer aborts `:composeApp:lintDebug`.

### Description
- Add an explicit generic to `remember` when creating the `CameraPermissionController`, move `updateRequestPermissionAction` into a `SideEffect`, and add the `SideEffect` import so the `remember` call no longer returns `Unit` (`AndroidCameraPreview.kt`).

### Testing
- Attempted to run `./gradlew :composeApp:lintDebug` locally but execution failed due to an unresolved Gradle plugin (`org.gradle.toolchains.foojay-resolver-convention:1.0.0`), so please verify lint in CI where the plugin can be resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3090d1c448330bb7f3a4d7f7416e6)