### PR TITLE
Fix Compose remember lint in camera permission controller

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -93,10 +94,13 @@ actual fun rememberCameraPermissionController(): CameraPermissionController {
         CameraPermissionController(
             isGranted = false,
             isChecking = true,
-            requestPermissionAction = {
-                requestPermissionActionState.value()
-            },
+            requestPermissionAction = {},
         )
+    }
+    SideEffect {
+        controller.updateRequestPermissionAction {
+            requestPermissionActionState.value()
+        }
     }
 
     LaunchedEffect(context) {


### PR DESCRIPTION
### Motivation
- Fix the `RememberReturnType` lint error caused by a `remember` call that could capture a `Unit`-returning lambda in `composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt`.

### Description
- Initialize `CameraPermissionController` with a no-op `requestPermissionAction` and use `SideEffect` to call `controller.updateRequestPermissionAction { requestPermissionActionState.value() }`, and add the `SideEffect` import to ensure the `remember` block does not return `Unit` while preserving `rememberUpdatedState` semantics.

### Testing
- Attempted to run `./gradlew :composeApp:lintDebug`, but the build stopped before linting due to an unresolved Gradle plugin `org.gradle.toolchains.foojay-resolver-convention:1.0.0` in the environment; no lint failures observed locally after the code change because the build could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e30b0b59ec8330a52e6c1299c37278)