### PR TITLE
Add Filament Android dependencies and JNI packaging fix

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -35,6 +35,9 @@ kotlin {
             implementation(libs.androidx.activity.compose)
             implementation(libs.androidx.exifinterface)
             implementation(libs.mlkit.face.detection)
+            implementation(libs.filament.android)
+            implementation(libs.filament.utils.android)
+            implementation(libs.gltfio.android)
         }
         commonMain.dependencies {
             implementation(libs.kotlinx.coroutines.core)
@@ -69,6 +72,9 @@ android {
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+        jniLibs {
+            pickFirsts += "**/libc++_shared.so"
         }
     }
     buildTypes {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ junit = "4.13.2"
 kotlin = "2.3.20"
 material3 = "1.11.0-alpha05"
 mlkitFaceDetection = "16.1.7"
+filament = "1.67.0"
 turbine = "1.2.1"
 
 [libraries]
@@ -46,6 +47,9 @@ compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-previ
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 mlkit-face-detection = { module = "com.google.mlkit:face-detection", version.ref = "mlkitFaceDetection" }
+filament-android = { module = "com.google.android.filament:filament-android", version.ref = "filament" }
+filament-utils-android = { module = "com.google.android.filament:filament-utils-android", version.ref = "filament" }
+gltfio-android = { module = "com.google.android.filament:gltfio-android", version.ref = "filament" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 [plugins]


### PR DESCRIPTION
### Motivation

- Enable building an Android VRM renderer host by adding Filament libraries to the project dependency catalog and Android source set.
- Prevent native STL conflicts between multiple native libraries by handling duplicate `libc++_shared.so` packaging.

### Description

- Add `filament` version (`1.67.0`) to `gradle/libs.versions.toml` and register `filament-android`, `filament-utils-android`, and `gltfio-android` in the version catalog. 
- Wire Filament artifacts into `androidMain` by adding `implementation(libs.filament.android)`, `implementation(libs.filament.utils.android)`, and `implementation(libs.gltfio.android)` in `composeApp/build.gradle.kts`. 
- Add `packaging.jniLibs.pickFirsts += "**/libc++_shared.so"` to `composeApp/build.gradle.kts` to avoid duplicate native STL collisions when packaging the APK. 

### Testing

- Ran `./gradlew :composeApp:assembleDebug`, which failed before module compilation because the plugin `org.gradle.toolchains.foojay-resolver-convention:1.0.0` could not be resolved from the configured plugin repositories, so the build did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3623c51fc8330bcb55667147ff311)