### PR TITLE
Add Android Filament avatar renderer host

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarHost.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarHost.kt
@@ -1,0 +1,47 @@
+package com.example.vtubercamera_kmp_ver.avatar.render
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
+import kotlinx.coroutines.isActive
+
+@Composable
+fun AndroidFilamentAvatarHost(
+    avatarRenderState: AvatarRenderState,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val renderer = remember(context) {
+        AndroidFilamentAvatarRenderer(context)
+    }
+    val latestRenderState = rememberUpdatedState(avatarRenderState)
+
+    AndroidView(
+        modifier = modifier,
+        factory = { renderer.hostView },
+        update = {
+            renderer.updateRenderState(latestRenderState.value)
+        },
+    )
+
+    LaunchedEffect(renderer) {
+        while (isActive) {
+            withFrameNanos { frameTimeNanos ->
+                renderer.render(frameTimeNanos)
+            }
+        }
+    }
+
+    DisposableEffect(renderer) {
+        onDispose {
+            renderer.destroy()
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
@@ -1,0 +1,176 @@
+package com.example.vtubercamera_kmp_ver.avatar.render
+
+import android.content.Context
+import android.graphics.PixelFormat
+import android.view.Surface
+import android.view.SurfaceView
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
+import com.google.android.filament.Camera
+import com.google.android.filament.Engine
+import com.google.android.filament.EntityManager
+import com.google.android.filament.Filament
+import com.google.android.filament.Renderer
+import com.google.android.filament.Scene
+import com.google.android.filament.SwapChain
+import com.google.android.filament.Viewport
+import com.google.android.filament.android.DisplayHelper
+import com.google.android.filament.android.UiHelper
+import android.view.View as AndroidView
+import com.google.android.filament.View as FilamentView
+
+class AndroidFilamentAvatarRenderer(
+    context: Context,
+) {
+    val hostView: AndroidView
+
+    private val surfaceView: SurfaceView
+    private val engine: Engine
+    private val renderer: Renderer
+    private val scene: Scene
+    private val view: FilamentView
+    private val cameraEntity: Int
+    private val camera: Camera
+    private val uiHelper: UiHelper
+    private val displayHelper: DisplayHelper
+    private var swapChain: SwapChain? = null
+    private var renderState: AvatarRenderState = AvatarRenderState.Neutral
+    private var destroyed = false
+
+    init {
+        Filament.init()
+
+        surfaceView = SurfaceView(context).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+            holder.setFormat(PixelFormat.TRANSLUCENT)
+        }
+        hostView = FrameLayout(context).apply {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+            clipChildren = false
+            clipToPadding = false
+            addView(surfaceView)
+        }
+
+        engine = Engine.create()
+        renderer = engine.createRenderer()
+        scene = engine.createScene()
+        view = engine.createView()
+        cameraEntity = EntityManager.get().create()
+        camera = engine.createCamera(cameraEntity)
+        uiHelper = UiHelper(UiHelper.ContextErrorPolicy.DONT_CHECK)
+        displayHelper = DisplayHelper(context)
+
+        configureRenderer()
+        configureView()
+        configureSurface()
+    }
+
+    fun updateRenderState(nextRenderState: AvatarRenderState) {
+        renderState = nextRenderState
+    }
+
+    fun render(frameTimeNanos: Long) {
+        val currentSwapChain = swapChain ?: return
+        if (destroyed || !uiHelper.isReadyToRender) {
+            return
+        }
+
+        if (renderer.beginFrame(currentSwapChain, frameTimeNanos)) {
+            renderer.render(view)
+            renderer.endFrame()
+        }
+    }
+
+    fun destroy() {
+        if (destroyed) {
+            return
+        }
+
+        destroyed = true
+        uiHelper.detach()
+        displayHelper.detach()
+        destroySwapChain()
+        engine.destroyRenderer(renderer)
+        engine.destroyView(view)
+        engine.destroyScene(scene)
+        engine.destroyCameraComponent(cameraEntity)
+        EntityManager.get().destroy(cameraEntity)
+        engine.destroy()
+    }
+
+    private fun configureRenderer() {
+        renderer.clearOptions = renderer.clearOptions.apply {
+            clear = true
+            clearColor = floatArrayOf(0f, 0f, 0f, 0f)
+        }
+    }
+
+    private fun configureView() {
+        view.scene = scene
+        view.camera = camera
+        view.blendMode = FilamentView.BlendMode.TRANSLUCENT
+        camera.lookAt(
+            0.0,
+            0.0,
+            4.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+        )
+    }
+
+    private fun configureSurface() {
+        uiHelper.isOpaque = false
+        uiHelper.isMediaOverlay = true
+        uiHelper.renderCallback = object : UiHelper.RendererCallback {
+            override fun onNativeWindowChanged(surface: Surface) {
+                destroySwapChain()
+                swapChain = engine.createSwapChain(surface, uiHelper.swapChainFlags)
+                displayHelper.attach(renderer, surfaceView.display)
+            }
+
+            override fun onDetachedFromSurface() {
+                displayHelper.detach()
+                destroySwapChain()
+                engine.flushAndWait()
+            }
+
+            override fun onResized(width: Int, height: Int) {
+                resize(width, height)
+            }
+        }
+        uiHelper.attachTo(surfaceView)
+    }
+
+    private fun resize(width: Int, height: Int) {
+        val safeWidth = width.coerceAtLeast(1)
+        val safeHeight = height.coerceAtLeast(1)
+        val aspect = safeWidth.toDouble() / safeHeight.toDouble()
+
+        view.viewport = Viewport(0, 0, safeWidth, safeHeight)
+        camera.setProjection(
+            45.0,
+            aspect,
+            0.1,
+            100.0,
+            Camera.Fov.VERTICAL,
+        )
+    }
+
+    private fun destroySwapChain() {
+        swapChain?.let { currentSwapChain ->
+            engine.destroySwapChain(currentSwapChain)
+            swapChain = null
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
@@ -37,6 +37,7 @@ class AndroidFilamentAvatarRenderer(
     private val displayHelper: DisplayHelper
     private var swapChain: SwapChain? = null
     private var renderState: AvatarRenderState = AvatarRenderState.Neutral
+    private var appliedRenderState: AvatarRenderState? = null
     private var destroyed = false
 
     init {
@@ -121,7 +122,7 @@ class AndroidFilamentAvatarRenderer(
         camera.lookAt(
             0.0,
             0.0,
-            4.0,
+            CAMERA_DISTANCE,
             0.0,
             0.0,
             0.0,
@@ -132,18 +133,26 @@ class AndroidFilamentAvatarRenderer(
     }
 
     private fun applyRenderState() {
+        if (renderState == appliedRenderState) {
+            return
+        }
         val trackingInfluence = if (renderState.isTracking) {
             renderState.trackingConfidence.coerceIn(0f, 1f).toDouble()
         } else {
             0.0
         }
-        val yawRadians = Math.toRadians(renderState.rig.headYawDegrees.coerceIn(-45f, 45f).toDouble())
-        val pitchRadians = Math.toRadians(renderState.rig.headPitchDegrees.coerceIn(-30f, 30f).toDouble())
+        val yawRadians = Math.toRadians(
+            renderState.rig.headYawDegrees.toDouble().coerceIn(-MAX_YAW_DEGREES, MAX_YAW_DEGREES),
+        )
+        val pitchRadians = Math.toRadians(
+            renderState.rig.headPitchDegrees.toDouble().coerceIn(-MAX_PITCH_DEGREES, MAX_PITCH_DEGREES),
+        )
 
+        // Keep Z fixed and only nudge the camera on X/Y so early MVP rendering stays stable.
         camera.lookAt(
-            sin(yawRadians) * 0.8 * trackingInfluence,
-            sin(pitchRadians) * 0.45 * trackingInfluence,
-            4.0,
+            sin(yawRadians) * CAMERA_YAW_OFFSET_SCALE * trackingInfluence,
+            sin(pitchRadians) * CAMERA_PITCH_OFFSET_SCALE * trackingInfluence,
+            CAMERA_DISTANCE,
             0.0,
             0.0,
             0.0,
@@ -151,6 +160,7 @@ class AndroidFilamentAvatarRenderer(
             1.0,
             0.0,
         )
+        appliedRenderState = renderState
     }
 
     private fun configureSurface() {
@@ -196,5 +206,16 @@ class AndroidFilamentAvatarRenderer(
             engine.destroySwapChain(currentSwapChain)
             swapChain = null
         }
+    }
+
+    private companion object {
+        // Default camera distance for the transparent overlay avatar host.
+        private const val CAMERA_DISTANCE = 4.0
+        // Small eye offsets that map tracked head yaw/pitch into camera parallax.
+        private const val CAMERA_YAW_OFFSET_SCALE = 0.8
+        private const val CAMERA_PITCH_OFFSET_SCALE = 0.45
+        // Conservative clamps to avoid aggressive camera motion from noisy tracking input.
+        private const val MAX_YAW_DEGREES = 45.0
+        private const val MAX_PITCH_DEGREES = 30.0
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
@@ -17,6 +17,7 @@ import com.google.android.filament.SwapChain
 import com.google.android.filament.Viewport
 import com.google.android.filament.android.DisplayHelper
 import com.google.android.filament.android.UiHelper
+import kotlin.math.sin
 import android.view.View as AndroidView
 import com.google.android.filament.View as FilamentView
 
@@ -82,6 +83,7 @@ class AndroidFilamentAvatarRenderer(
             return
         }
 
+        applyRenderState()
         if (renderer.beginFrame(currentSwapChain, frameTimeNanos)) {
             renderer.render(view)
             renderer.endFrame()
@@ -119,6 +121,28 @@ class AndroidFilamentAvatarRenderer(
         camera.lookAt(
             0.0,
             0.0,
+            4.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+        )
+    }
+
+    private fun applyRenderState() {
+        val trackingInfluence = if (renderState.isTracking) {
+            renderState.trackingConfidence.coerceIn(0f, 1f).toDouble()
+        } else {
+            0.0
+        }
+        val yawRadians = Math.toRadians(renderState.rig.headYawDegrees.coerceIn(-45f, 45f).toDouble())
+        val pitchRadians = Math.toRadians(renderState.rig.headPitchDegrees.coerceIn(-30f, 30f).toDouble())
+
+        camera.lookAt(
+            sin(yawRadians) * 0.8 * trackingInfluence,
+            sin(pitchRadians) * 0.45 * trackingInfluence,
             4.0,
             0.0,
             0.0,

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
@@ -4,9 +4,6 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.BitmapFactory
-import android.view.TextureView
-import android.view.ViewGroup
-import android.widget.FrameLayout
 import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -55,6 +52,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.example.vtubercamera_kmp_ver.avatar.render.AndroidFilamentAvatarHost
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
 import com.example.vtubercamera_kmp_ver.theme.spacing
 import com.google.common.util.concurrent.ListenableFuture
 import kotlin.coroutines.resume
@@ -330,6 +329,7 @@ actual fun AvatarPreviewOverlay(
 @Composable
 actual fun AvatarBodyOverlay(
     avatarPreview: AvatarPreviewData,
+    avatarRenderState: AvatarRenderState,
     modifier: Modifier,
 ) {
     Box(
@@ -364,6 +364,7 @@ actual fun AvatarBodyOverlay(
                     ),
             ) {
                 AvatarRendererHostView(
+                    avatarRenderState = avatarRenderState,
                     modifier = Modifier.fillMaxSize(),
                 )
 
@@ -418,27 +419,13 @@ actual fun AvatarBodyOverlay(
 }
 
 @Composable
-private fun AvatarRendererHostView(modifier: Modifier = Modifier) {
-    AndroidView(
+private fun AvatarRendererHostView(
+    avatarRenderState: AvatarRenderState,
+    modifier: Modifier = Modifier,
+) {
+    AndroidFilamentAvatarHost(
+        avatarRenderState = avatarRenderState,
         modifier = modifier,
-        factory = { context ->
-            FrameLayout(context).apply {
-                layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                )
-                addView(
-                    TextureView(context).apply {
-                        layoutParams = FrameLayout.LayoutParams(
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                        )
-                        isOpaque = false
-                        alpha = 0f
-                    },
-                )
-            }
-        },
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraPermissionController.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraPermissionController.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
 import org.jetbrains.compose.resources.StringResource
 
 // 最新のカメラ権限状態を保持し、この画面での権限リクエストを仲介する。
@@ -118,5 +119,6 @@ expect fun AvatarPreviewOverlay(
 @Composable
 expect fun AvatarBodyOverlay(
     avatarPreview: AvatarPreviewData,
+    avatarRenderState: AvatarRenderState,
     modifier: Modifier = Modifier,
 )

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
@@ -296,6 +296,7 @@ private fun DefaultAvatarRendererHost(
 ) {
     AvatarBodyOverlay(
         avatarPreview = state.avatarPreview,
+        avatarRenderState = state.avatarRenderState,
         modifier = state.modifier,
     )
 }

--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
@@ -205,6 +205,7 @@ actual fun AvatarPreviewOverlay(
 
 @Composable
 // カメラ画面の下部にアバター本体用のオーバーレイを表示する。
+@Suppress("UNUSED_PARAMETER")
 actual fun AvatarBodyOverlay(
     avatarPreview: AvatarPreviewData,
     avatarRenderState: AvatarRenderState,

--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.UIKitView
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
 import com.example.vtubercamera_kmp_ver.theme.spacing
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.readValue
@@ -206,6 +207,7 @@ actual fun AvatarPreviewOverlay(
 // カメラ画面の下部にアバター本体用のオーバーレイを表示する。
 actual fun AvatarBodyOverlay(
     avatarPreview: AvatarPreviewData,
+    avatarRenderState: AvatarRenderState,
     modifier: Modifier,
 ) {
     Box(


### PR DESCRIPTION
## Summary
- Add an Android `AndroidView`-based host for Filament avatar rendering.
- Initialize Filament `Engine`, `Scene`, `View`, `Camera`, `Renderer`, and a transparent surface pipeline.
- Thread `AvatarRenderState` through the shared camera overlay contract so the renderer host can consume it.

## Testing
- `ANDROID_HOME=/Users/j____takumi/Library/Android/sdk ./gradlew :composeApp:compileDebugKotlinAndroid`
- `./gradlew :composeApp:compileKotlinIosSimulatorArm64`
- `ANDROID_HOME=/Users/j____takumi/Library/Android/sdk ./gradlew :composeApp:testDebugUnitTest`