### PR TITLE
Add KMP spec sync workflow

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -31,15 +31,15 @@ name: "Repository Overview Guidance"
 
 - `composeApp` は KMP アプリ本体で、shared UI と Android 実装を含む。
 - Android の実カメラ実装は `composeApp` 側にあり、CameraX を使う。
-- iOS の実カメラ実装は現時点で `iosApp` 側にあり、SwiftUI + AVFoundation を使う。
-- `composeApp/src/iosMain` は iOS 向け KMP エントリポイントだが、現在の実カメラ実装の中心ではない。
+- iOS の実カメラ実装は `composeApp/src/iosMain` 側にあり、AVFoundation + UIKitView を使う。
+- `iosApp` は Xcode のホストアプリとして `MainViewController` を起動し、Compose 画面を表示する。
 
 ## High-Value Directories To Mention
 
 - `composeApp/src/commonMain`: 共有 UI、状態、リソース
 - `composeApp/src/androidMain`: Android の CameraX 実装と権限処理
-- `composeApp/src/iosMain`: iOS 向け shared 側の入口
-- `iosApp`: iOS ネイティブ実装と Xcode プロジェクト
+- `composeApp/src/iosMain`: iOS の AVFoundation camera 実装と shared 側の入口
+- `iosApp`: Compose ホストとして動作する Xcode プロジェクト
 - `docs`: 実装方針、調査、設計メモ
 - `gradle/libs.versions.toml`: 主要依存関係の定義
 
@@ -48,7 +48,7 @@ name: "Repository Overview Guidance"
 - 共通技術としては Kotlin Multiplatform、Compose Multiplatform、Material 3、AndroidX Lifecycle Compose、Kotlin Coroutines、kotlinx.serialization を起点にする。
 - Android 技術としては CameraX、Activity Compose、ExifInterface を挙げる。
 - Android の現行 face tracking 文脈では、ML Kit Face Detection を採用済みの縦切りとして扱う。
-- iOS 技術としては SwiftUI、AVFoundation、UIKit、UniformTypeIdentifiers を挙げる。
+- iOS 技術としては AVFoundation、UIKitView、UIKit、SwiftUI を挙げる。
 - テスト文脈では `kotlin.test` と Turbine を説明候補にする。
 - 技術スタックを説明するときも、現在採用しているものと、MediaPipe、ARKit、Filament、VRM など将来候補のものを混ぜない。
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,15 +27,15 @@ name: "Repository Overview Guidance"
 
 - `composeApp` は KMP アプリ本体で、shared UI と Android 実装を含む。
 - Android の実カメラ実装は `composeApp` 側にあり、CameraX を使う。
-- iOS の実カメラ実装は現時点で `iosApp` 側にあり、SwiftUI + AVFoundation を使う。
-- `composeApp/src/iosMain` は iOS 向け KMP エントリポイントだが、現在の実カメラ実装の中心ではない。
+- iOS の実カメラ実装は `composeApp/src/iosMain` 側にあり、AVFoundation + UIKitView を使う。
+- `iosApp` は Xcode のホストアプリとして `MainViewController` を起動し、Compose 画面を表示する。
 
 ## High-Value Directories To Mention
 
 - `composeApp/src/commonMain`: 共有 UI、状態、リソース
 - `composeApp/src/androidMain`: Android の CameraX 実装と権限処理
-- `composeApp/src/iosMain`: iOS 向け shared 側の入口
-- `iosApp`: iOS ネイティブ実装と Xcode プロジェクト
+- `composeApp/src/iosMain`: iOS の AVFoundation camera 実装と shared 側の入口
+- `iosApp`: Compose ホストとして動作する Xcode プロジェクト
 - `docs`: 実装方針、調査、設計メモ
 - `gradle/libs.versions.toml`: 主要依存関係の定義
 
@@ -44,7 +44,7 @@ name: "Repository Overview Guidance"
 - 共通技術としては Kotlin Multiplatform、Compose Multiplatform、Material 3、AndroidX Lifecycle Compose、Kotlin Coroutines、kotlinx.serialization を起点にする。
 - Android 技術としては CameraX、Activity Compose、ExifInterface を挙げる。
 - Android の現行 face tracking 文脈では、ML Kit Face Detection を採用済みの縦切りとして扱う。
-- iOS 技術としては SwiftUI、AVFoundation、UIKit、UniformTypeIdentifiers を挙げる。
+- iOS 技術としては AVFoundation、UIKitView、UIKit、SwiftUI を挙げる。
 - テスト文脈では `kotlin.test` と Turbine を説明候補にする。
 - 技術スタックを説明するときも、現在採用しているものと、MediaPipe、ARKit、Filament、VRM など将来候補のものを混ぜない。
 

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -1,0 +1,46 @@
+name: Spec Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: Fail when non-accepted warnings are found
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # Monday 06:00 JST.
+    - cron: '0 21 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  spec-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run spec sync report
+        run: |
+          set -o pipefail
+          mkdir -p build/reports
+          if [[ "${{ inputs.strict }}" == "true" ]]; then
+            python3 scripts/spec_sync_check.py --strict --format markdown | tee build/reports/spec-sync-report.md
+          else
+            python3 scripts/spec_sync_check.py --format markdown | tee build/reports/spec-sync-report.md
+          fi
+
+      - name: Add report to job summary
+        if: always()
+        run: cat build/reports/spec-sync-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: spec-sync-report
+          path: build/reports/spec-sync-report.md

--- a/docs/spec-sync-exceptions.yaml
+++ b/docs/spec-sync-exceptions.yaml
@@ -1,0 +1,85 @@
+version: 1
+updated: 2026-04-19
+
+exceptions:
+  - id: IOS_FACE_TRACKING_NOT_IMPLEMENTED
+    category: Intentional platform asymmetry
+    status: active
+    severity: info
+    scope:
+      - ios
+      - face_tracking
+    reason: Android has ML Kit face tracking and shared UI state, while iOS currently clears tracking state and does not run a native face analyzer.
+    evidence:
+      - README.md: iOS face tracking is documented as not implemented.
+      - composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidFaceTrackingAnalyzer.kt
+      - composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
+    reevaluate_when: iOS adds Vision, ARKit, ML Kit, or another face tracking analyzer.
+
+  - id: PHOTO_CAPTURE_AND_SAVE_PLANNED
+    category: Spec ahead of code
+    status: active
+    severity: info
+    scope:
+      - photo_capture
+      - image_save
+    reason: Photo capture and image save are MVP roadmap items, but README and spec mark them as not implemented.
+    evidence:
+      - README.md: photo capture and image save are listed under not implemented features.
+      - docs/KMP_IMPLEMENTATION_SPEC.ja.md: photo capture and image save are listed under planned work.
+    reevaluate_when: CameraX ImageCapture, AVFoundation photo output, MediaStore, or Photos save code is added.
+
+  - id: FLASH_ZOOM_PLANNED
+    category: Spec ahead of code
+    status: active
+    severity: info
+    scope:
+      - flash
+      - zoom
+    reason: Flash and zoom are planned camera controls and are not part of the current confirmed implementation.
+    evidence:
+      - README.md: flash and zoom are listed under not implemented features.
+      - docs/KMP_IMPLEMENTATION_SPEC.ja.md: flash and zoom are listed under planned work.
+    reevaluate_when: CameraX flash / zoom or AVFoundation torch / zoom controls are added.
+
+  - id: README_AVATAR_RENDERING_SUMMARY
+    category: Code ahead of spec
+    status: active
+    severity: info
+    scope:
+      - avatar_renderer
+      - readme_summary
+    reason: Android renderer dependencies and host code exist, but README intentionally keeps the current-status section short and treats full AR / VRM / Filament integration as not complete.
+    evidence:
+      - composeApp/build.gradle.kts: Android Filament and gltfio dependencies.
+      - composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render
+      - README.md: AR / VRM / Filament integration is still listed as not implemented.
+    reevaluate_when: README needs finer-grained shipped status for avatar renderer layer.
+
+  - id: GITHUB_ACTIONS_ANDROID_ONLY_BITRISE_IOS
+    category: Intentional platform asymmetry
+    status: active
+    severity: info
+    scope:
+      - ci
+      - github_actions
+      - bitrise
+    reason: GitHub Actions currently verifies Android, while Bitrise contains Android and iOS build workflows.
+    evidence:
+      - .github/workflows/android-ci.yml
+      - bitrise.yml
+    reevaluate_when: GitHub Actions adds an iOS simulator build or Bitrise is removed.
+
+  - id: IOS_PHOTO_LIBRARY_PERMISSION_PLANNED
+    category: Spec ahead of code
+    status: active
+    severity: info
+    scope:
+      - ios
+      - image_save
+      - permissions
+    reason: iOS only needs Photos add-library permission when image save is implemented; current camera preview only requires camera permission.
+    evidence:
+      - iosApp/iosApp/Info.plist: NSCameraUsageDescription exists.
+      - README.md: image save is listed as not implemented.
+    reevaluate_when: iOS image save code is added.

--- a/docs/spec-sync-rules.md
+++ b/docs/spec-sync-rules.md
@@ -1,0 +1,128 @@
+# KMP spec sync rules
+
+この文書は `VtuberCamera_KMP_ver` の README、実装仕様、KMP / Android / iOS 実装、CI 設定を同期確認するための運用ルールです。
+
+`docs/KMP_IMPLEMENTATION_SPEC.ja.md` は future-facing な設計意図を含むため、実装済みの証拠として単独では扱いません。present tense の説明は README と現行コードで確認します。
+
+## 現行基準
+
+自動確認の既定基準は、チェックを実行した checkout の `HEAD` です。
+
+release tag、TestFlight build、Android / iOS で実機検証済み commit を基準にしたい場合は、実行前にその commit を checkout してから `/sync-spec` を実行します。レポートには `git rev-parse --short HEAD` の結果を記録します。
+
+## 比較対象
+
+次の順番で読みます。present-tense の説明と依存関係を先に固定し、その後に shared / platform 実装へ進みます。
+
+1. `README.md`
+2. `docs/KMP_IMPLEMENTATION_SPEC.ja.md`
+3. `composeApp/build.gradle.kts`
+4. `gradle/libs.versions.toml`
+5. `composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/*`
+6. `composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/*`
+7. `composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/*`
+8. `iosApp/iosApp/Info.plist`
+9. `composeApp/src/androidMain/AndroidManifest.xml`
+10. `bitrise.yml`
+11. `.github/workflows/*`
+12. `.github/skills/kmp-spec-sync/SKILL.md`
+13. `.codex/AGENTS.md` and `.github/copilot-instructions.md`
+
+## 差分分類
+
+差分は必ず 1 つだけに分類します。
+
+| Category | Meaning | Default action |
+| --- | --- | --- |
+| Spec ahead of code | 仕様書が未実装の動作を present tense に近い形で説明している | planned / not implemented を明記する |
+| Code ahead of spec | コードにある動作が README / spec に十分書かれていない | docs を現行コードに合わせる |
+| README/spec mismatch | README と spec の現在地説明が食い違っている | 現行コードを確認して両方を更新する |
+| Intentional platform asymmetry | Android / iOS の差が意図的または段階的なもの | 不具合扱いせず、例外台帳で理由を残す |
+| Unverifiable claim | コードから確認できない説明がある | human confirmation が必要と明記する |
+
+## 観点表
+
+1 機能 1 判定にし、複数の事実を 1 つの大きな「カメラ実装済み」にまとめません。
+
+| Feature | Present evidence | Planned / missing evidence | Notes |
+| --- | --- | --- | --- |
+| 権限確認 | Android manifest / permission controller、iOS `NSCameraUsageDescription` / AVFoundation authorization | 写真保存権限は保存実装まで planned | iOS Photos 権限を camera preview の証拠にしない |
+| カメラプレビュー | Android CameraX、iOS AVFoundation `CameraPreviewHost` | なし | `iosApp` は Compose host として扱う |
+| レンズ切替 | shared `CameraViewModel`、platform preview host の resolved lens 反映 | なし | platform ごとの fallback を確認する |
+| face tracking | Android ML Kit analyzer、shared UI state | iOS face tracking は未実装 | platform asymmetry として扱う |
+| avatar preview | file picker result、shared avatar preview UI、platform picker | なし | renderer と preview を分けて判定する |
+| avatar renderer | Android Filament / gltfio dependencies and renderer host | iOS full renderer は別途確認 | README の簡略表現は例外台帳で管理する |
+| file picker | Android `OpenDocument`、iOS `UIDocumentPickerViewController` | なし | 読み込み失敗時の UI message も確認対象 |
+| 写真撮影 | `ImageCapture` / `takePicture` など | 未実装 | 実装されたら README の未実装欄を更新する |
+| 画像保存 | MediaStore / Photos add permission など | 未実装 | iOS `NSPhotoLibraryAddUsageDescription` は保存時に必要 |
+| フラッシュ | CameraX flash / AVFoundation torch など | 未実装 | レンズ切替と混同しない |
+| ズーム | zoom ratio / pinch zoom など | 未実装 | UI state と platform API の両方を見る |
+| iOS Info.plist 権限 | `NSCameraUsageDescription` | Photos 権限は planned | planned 権限を未実装の不具合扱いしない |
+| Android / iOS CI build | GitHub Actions Android、Bitrise Android / iOS | GitHub Actions iOS は未整備 | 運用意図がある場合は例外化する |
+| 依存ライブラリ | Version catalog and Gradle dependencies | なし | 依存だけで機能実装済みとは判断しない |
+
+## 例外台帳
+
+意図的なズレや段階的な未実装は `docs/spec-sync-exceptions.yaml` に残します。例外は「検知しない」ためではなく、「毎回同じズレを不具合として扱わない」ためのものです。
+
+例外には次を含めます。
+
+- stable な `id`
+- `category`
+- `status` (`active`, `review`, `expired`)
+- affected scope
+- reason
+- evidence
+- reevaluate condition
+
+`status: active` の例外だけを自動チェックで accepted として扱います。期限切れや確認中の例外は warning に戻します。
+
+## `/sync-spec` 手順
+
+1. 基準 commit を決める。通常は現在の `HEAD`。
+2. `.github/skills/kmp-spec-sync/SKILL.md` を読む。
+3. この文書と `docs/spec-sync-exceptions.yaml` を読む。
+4. `python3 scripts/spec_sync_check.py --format markdown` を実行する。
+5. warning が出た場合は、次のいずれかに振り分ける。
+   - docs を現行コードに合わせる
+   - spec を planned wording にする
+   - 実装 Issue にする
+   - 例外台帳へ追加する
+   - human confirmation に回す
+6. CI で失敗させたい場合だけ `--strict` を付ける。
+
+## Issue template
+
+```markdown
+### Title
+[Spec Sync] <area>: <short problem>
+
+### Labels
+docs, android, ios, shared, mvp, needs-confirmation から必要なもののみ
+
+### Background
+- Why the mismatch exists now
+- Why this should be tracked
+
+### Confirmed evidence
+- README says: ...
+- Spec says: ...
+- Code shows: ...
+
+### Scope
+- What must change
+- Which platform(s) are affected
+
+### Acceptance criteria
+- [ ] README present-tense status matches code
+- [ ] Spec marks planned items as planned
+- [ ] Android / iOS ownership is explicit
+- [ ] Future-only features are not described as shipped
+
+### Out of scope
+- ...
+```
+
+## CI policy
+
+`.github/workflows/spec-sync.yml` は週次と手動実行で report-only として動かします。手動実行時に strict を選んだ場合だけ、accepted ではない warning を失敗扱いにします。

--- a/scripts/spec_sync_check.py
+++ b/scripts/spec_sync_check.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+"""Check KMP spec/docs drift without external dependencies."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclasses.dataclass(frozen=True)
+class Finding:
+    check_id: str
+    title: str
+    category: str
+    status: str
+    evidence: tuple[str, ...]
+    recommendation: str
+    exception_id: str | None = None
+
+
+def read_text(relative_path: str) -> str:
+    path = ROOT / relative_path
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def path_exists(relative_path: str) -> bool:
+    return (ROOT / relative_path).exists()
+
+
+def any_file_contains(relative_paths: Iterable[str], needles: Iterable[str]) -> bool:
+    expected = tuple(needles)
+    for relative_path in relative_paths:
+        haystack = read_text(relative_path)
+        if any(needle in haystack for needle in expected):
+            return True
+    return False
+
+
+def all_in(text: str, needles: Iterable[str]) -> bool:
+    return all(needle in text for needle in needles)
+
+
+def git_head() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=ROOT,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def load_active_exception_ids() -> set[str]:
+    """Read the repo-local exception ledger.
+
+    The ledger is intentionally simple YAML. This parser only needs stable ids
+    and status values, so the script does not depend on PyYAML in CI.
+    """
+    text = read_text("docs/spec-sync-exceptions.yaml")
+    active_ids: set[str] = set()
+    current_id: str | None = None
+    current_status: str | None = None
+
+    def flush_current() -> None:
+        if current_id and current_status == "active":
+            active_ids.add(current_id)
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("- id:"):
+            flush_current()
+            current_id = line.split(":", 1)[1].strip()
+            current_status = None
+        elif line.startswith("status:"):
+            current_status = line.split(":", 1)[1].strip()
+    flush_current()
+    return active_ids
+
+
+def accepted_status(default_status: str, exception_id: str | None, active_exceptions: set[str]) -> str:
+    if exception_id and exception_id in active_exceptions:
+        return "accepted"
+    return default_status
+
+
+def make_finding(
+    *,
+    check_id: str,
+    title: str,
+    category: str,
+    ok: bool,
+    ok_evidence: Iterable[str],
+    problem_evidence: Iterable[str],
+    recommendation: str,
+    exception_id: str | None = None,
+    active_exceptions: set[str],
+) -> Finding:
+    status = "ok" if ok else accepted_status("warning", exception_id, active_exceptions)
+    return Finding(
+        check_id=check_id,
+        title=title,
+        category=category,
+        status=status,
+        evidence=tuple(ok_evidence if ok else problem_evidence),
+        recommendation=recommendation,
+        exception_id=exception_id,
+    )
+
+
+def run_checks(active_exceptions: set[str]) -> list[Finding]:
+    readme = read_text("README.md")
+    spec = read_text("docs/KMP_IMPLEMENTATION_SPEC.ja.md")
+    rules = read_text("docs/spec-sync-rules.md")
+    exceptions = read_text("docs/spec-sync-exceptions.yaml")
+    build_gradle = read_text("composeApp/build.gradle.kts")
+    versions = read_text("gradle/libs.versions.toml")
+    manifest = read_text("composeApp/src/androidMain/AndroidManifest.xml")
+    plist = read_text("iosApp/iosApp/Info.plist")
+    android_preview = read_text("composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt")
+    ios_preview = read_text("composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt")
+    ios_content_view = read_text("iosApp/iosApp/ContentView.swift")
+    camera_screen = read_text("composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt")
+    camera_view_model = read_text("composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt")
+    agents = read_text(".codex/AGENTS.md")
+    copilot = read_text(".github/copilot-instructions.md")
+    bitrise = read_text("bitrise.yml")
+    android_ci = read_text(".github/workflows/android-ci.yml")
+
+    findings: list[Finding] = []
+
+    findings.append(
+        make_finding(
+            check_id="sync_docs_present",
+            title="Spec sync rules and exceptions are present",
+            category="Unverifiable claim",
+            ok=bool(rules and exceptions),
+            ok_evidence=("docs/spec-sync-rules.md", "docs/spec-sync-exceptions.yaml"),
+            problem_evidence=("Missing docs/spec-sync-rules.md or docs/spec-sync-exceptions.yaml",),
+            recommendation="Add the spec sync rulebook and exception ledger before running automated checks.",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    findings.append(
+        make_finding(
+            check_id="readme_present_planned_split",
+            title="README separates implemented and not implemented features",
+            category="README/spec mismatch",
+            ok=all_in(readme, ("## 現在の実装状況", "### まだ未実装の主な機能")),
+            ok_evidence=("README has current implementation and not-implemented sections.",),
+            problem_evidence=("README does not clearly separate present and planned status.",),
+            recommendation="Keep README present-tense status separate from roadmap items.",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    findings.append(
+        make_finding(
+            check_id="spec_present_planned_split",
+            title="Implementation spec separates confirmed implementation and plans",
+            category="Spec ahead of code",
+            ok=all_in(spec, ("## 1. 現在の確定実装", "## 2. 未実装 / 計画中")),
+            ok_evidence=("docs/KMP_IMPLEMENTATION_SPEC.ja.md separates confirmed implementation and planned work.",),
+            problem_evidence=("Spec does not clearly separate confirmed implementation from future-facing scope.",),
+            recommendation="Move future-only behavior into planned wording.",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    readme_points_to_ios_main = (
+        "iOS の実カメラ実装は `composeApp/src/iosMain`" in readme
+        or "iOS の実カメラ表示は `composeApp/src/iosMain`" in readme
+        or "`composeApp/src/iosMain` の AVFoundation 実装" in readme
+    )
+    ios_ownership_ok = (
+        readme_points_to_ios_main
+        and ("AVFoundation 実装" in spec or "AVFoundation + UIKitView" in spec)
+        and "iosApp` は Compose のホスト" in spec
+        and "iOS の実カメラ実装は `composeApp/src/iosMain`" in agents
+        and "iOS の実カメラ実装は `composeApp/src/iosMain`" in copilot
+    )
+    findings.append(
+        make_finding(
+            check_id="ios_camera_ownership",
+            title="iOS camera ownership is documented as iosMain plus iosApp host",
+            category="README/spec mismatch",
+            ok=ios_ownership_ok,
+            ok_evidence=(
+                "README, spec, .codex/AGENTS.md, and .github/copilot-instructions.md point to composeApp/src/iosMain for iOS camera implementation.",
+                "iosApp is documented as the Compose host.",
+            ),
+            problem_evidence=(
+                "One or more docs still imply iosApp owns the real iOS camera implementation.",
+                "composeApp/src/iosMain/kotlin/.../IOSCameraPreview.kt contains AVFoundation CameraPreviewHost.",
+            ),
+            recommendation="Update repo guidance so iosMain owns AVFoundation camera preview and iosApp is the host app.",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    findings.append(
+        make_finding(
+            check_id="android_camera_permission",
+            title="Android camera permission is backed by manifest and permission controller",
+            category="Code ahead of spec",
+            ok="android.permission.CAMERA" in manifest and "RequestPermission" in android_preview,
+            ok_evidence=(
+                "composeApp/src/androidMain/AndroidManifest.xml contains android.permission.CAMERA.",
+                "AndroidCameraPreview.kt uses ActivityResultContracts.RequestPermission.",
+            ),
+            problem_evidence=("Android camera permission docs are not backed by manifest and permission request code.",),
+            recommendation="Align README/spec with actual Android permission handling.",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    findings.append(
+        make_finding(
+            check_id="ios_camera_permission",
+            title="iOS camera permission is backed by Info.plist and AVFoundation authorization",
+            category="Code ahead of spec",
+            ok="NSCameraUsageDescription" in plist and "authorizationStatusForMediaType" in ios_preview,
+            ok_evidence=(
+                "iosApp/iosApp/Info.plist contains NSCameraUsageDescription.",
+                "IOSCameraPreview.kt checks AVFoundation authorization status.",
+            ),
+            problem_evidence=("iOS camera permission docs are not backed by Info.plist and authorization code.",),
+            recommendation="Add missing Info.plist or AVFoundation authorization evidence before claiming iOS camera permission support.",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    findings.append(
+        make_finding(
+            check_id="ios_photo_permission_planned",
+            title="iOS Photos add permission remains tied to planned image save",
+            category="Spec ahead of code",
+            ok="NSPhotoLibraryAddUsageDescription" not in plist and "撮影画像の保存 / 削除" in readme,
+            ok_evidence=(
+                "Info.plist does not include NSPhotoLibraryAddUsageDescription.",
+                "README marks image save/delete as not implemented.",
+            ),
+            problem_evidence=("Photos add-library permission or image save wording may be out of sync.",),
+            recommendation="Only add or require Photos permission when iOS image save is implemented.",
+            exception_id="IOS_PHOTO_LIBRARY_PERMISSION_PLANNED",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    findings.append(
+        make_finding(
+            check_id="android_camera_preview",
+            title="Android camera preview is backed by CameraX",
+            category="Code ahead of spec",
+            ok=all_in(build_gradle, ("androidx.camera.core", "androidx.camera.view")) and all_in(android_preview, ("ProcessCameraProvider", "PreviewView")),
+            ok_evidence=(
+                "composeApp/build.gradle.kts has CameraX dependencies.",
+                "AndroidCameraPreview.kt uses ProcessCameraProvider and PreviewView.",
+            ),
+            problem_evidence=("Android preview docs are not backed by CameraX dependencies and host code.",),
+            recommendation="Do not claim Android CameraX preview unless both dependencies and preview host are present.",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    findings.append(
+        make_finding(
+            check_id="ios_camera_preview",
+            title="iOS camera preview is backed by AVFoundation in iosMain",
+            category="Code ahead of spec",
+            ok=all_in(ios_preview, ("AVCaptureSession", "AVCaptureVideoPreviewLayer", "UIKitView")),
+            ok_evidence=("IOSCameraPreview.kt uses AVFoundation capture session, preview layer, and UIKitView.",),
+            problem_evidence=("iOS preview docs are not backed by iosMain AVFoundation preview code.",),
+            recommendation="Do not claim iOS native preview unless IOSCameraPreview.kt contains AVFoundation preview code.",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    findings.append(
+        make_finding(
+            check_id="lens_toggle",
+            title="Lens toggle is backed by shared state and platform preview hosts",
+            category="Code ahead of spec",
+            ok=all_in(camera_view_model, ("onToggleLensFacing", "switchLens")) and "lensFacing" in android_preview and "lensFacing" in ios_preview,
+            ok_evidence=(
+                "CameraViewModel.kt has onToggleLensFacing and switchLens flow.",
+                "Android and iOS preview hosts accept lensFacing.",
+            ),
+            problem_evidence=("Lens toggle wording is not backed by shared state and platform preview host evidence.",),
+            recommendation="Keep lens toggle status grounded in both shared ViewModel and platform host code.",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    findings.append(
+        make_finding(
+            check_id="android_face_tracking",
+            title="Android face tracking is backed by ML Kit analyzer and shared UI state",
+            category="Code ahead of spec",
+            ok=(
+                "mlkit.face.detection" in build_gradle
+                and path_exists("composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidFaceTrackingAnalyzer.kt")
+                and "onFaceTrackingFrameChanged" in camera_view_model
+                and "FaceTrackingUiState" in camera_view_model
+            ),
+            ok_evidence=(
+                "composeApp/build.gradle.kts has ML Kit Face Detection.",
+                "AndroidFaceTrackingAnalyzer.kt exists.",
+                "CameraViewModel.kt maps frames into FaceTrackingUiState.",
+            ),
+            problem_evidence=("Android face tracking docs are not backed by analyzer, dependency, and shared state evidence.",),
+            recommendation="Confirm ML Kit analyzer and shared state before documenting Android face tracking as implemented.",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    ios_host_routes_to_compose = "MainViewControllerKt.MainViewController()" in ios_content_view
+    ios_face_tracking_present = any_file_contains(
+        ("composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt",),
+        ("VNDetectFace", "Vision", "ARFace", "MLKFace", "onFaceFrame"),
+    ) or (
+        not ios_host_routes_to_compose
+        and any_file_contains(
+            (
+                "iosApp/iosApp/ContentView.swift",
+                "iosApp/iosApp/IOSCameraViewModel.swift",
+            ),
+            ("VNDetectFace", "Vision", "ARFace", "MLKFace", "onFaceFrame"),
+        )
+    )
+    ios_face_tracking_documented_missing = "iOS の face tracking は未実装" in readme or "iOS 側の face tracking 実装" in spec
+    findings.append(
+        make_finding(
+            check_id="ios_face_tracking_asymmetry",
+            title="iOS face tracking gap is documented as intentional current asymmetry",
+            category="Intentional platform asymmetry",
+            ok=not ios_face_tracking_present and ios_face_tracking_documented_missing,
+            ok_evidence=(
+                "No iOS face analyzer evidence was found.",
+                "README/spec document iOS face tracking as not implemented.",
+            ),
+            problem_evidence=("iOS face tracking implementation or docs changed; reclassify the platform asymmetry.",),
+            recommendation="If iOS face tracking is implemented, update README/spec and expire IOS_FACE_TRACKING_NOT_IMPLEMENTED.",
+            exception_id="IOS_FACE_TRACKING_NOT_IMPLEMENTED",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    findings.append(
+        make_finding(
+            check_id="file_picker",
+            title="File picker is backed on Android and iOS",
+            category="Code ahead of spec",
+            ok="OpenDocument" in android_preview and "UIDocumentPickerViewController" in ios_preview and "onFilePicked" in camera_view_model,
+            ok_evidence=(
+                "AndroidCameraPreview.kt uses ActivityResultContracts.OpenDocument.",
+                "IOSCameraPreview.kt uses UIDocumentPickerViewController.",
+                "CameraViewModel.kt handles FilePickerResult.",
+            ),
+            problem_evidence=("File picker docs are not backed by both platform launchers and shared result handling.",),
+            recommendation="Keep file picker status platform-aware and tied to shared result handling.",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    findings.append(
+        make_finding(
+            check_id="avatar_renderer_summary",
+            title="Avatar renderer status remains intentionally finer-grained than README summary",
+            category="Code ahead of spec",
+            ok=(
+                "filament.android" in build_gradle
+                and "gltfio.android" in build_gradle
+                and path_exists("composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarHost.kt")
+                and "AR / VRM / Filament 連携" in readme
+            ),
+            ok_evidence=(
+                "Android Filament/gltfio dependencies and renderer host exist.",
+                "README still treats full AR / VRM / Filament integration as not implemented.",
+            ),
+            problem_evidence=("Avatar renderer code and README wording need reclassification.",),
+            recommendation="Either document the renderer layer in more detail or keep README simplification under an active exception.",
+            exception_id="README_AVATAR_RENDERING_SUMMARY",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    camera_sources = "\n".join(
+        read_text(path)
+        for path in (
+            "composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt",
+            "composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt",
+            "composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt",
+            "composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt",
+        )
+    )
+    capture_tokens = ("ImageCapture", "takePicture", "AVCapturePhotoOutput", "MediaStore", "PHPhotoLibrary")
+    flash_zoom_tokens = ("FLASH_MODE", "enableTorch", "torchMode", "zoomRatio", "linearZoom", "videoZoomFactor")
+    findings.append(
+        make_finding(
+            check_id="capture_save_planned",
+            title="Photo capture and image save are still planned, not shipped",
+            category="Spec ahead of code",
+            ok=not any(token in camera_sources for token in capture_tokens) and all_in(readme, ("写真撮影", "撮影画像の保存 / 削除")),
+            ok_evidence=(
+                "No capture/save implementation tokens were found in camera sources.",
+                "README marks photo capture and image save/delete as not implemented.",
+            ),
+            problem_evidence=("Capture/save implementation tokens or docs changed; update README/spec or exception ledger.",),
+            recommendation="When capture/save code lands, remove the not-implemented wording and expire PHOTO_CAPTURE_AND_SAVE_PLANNED.",
+            exception_id="PHOTO_CAPTURE_AND_SAVE_PLANNED",
+            active_exceptions=active_exceptions,
+        )
+    )
+    findings.append(
+        make_finding(
+            check_id="flash_zoom_planned",
+            title="Flash and zoom controls are still planned, not shipped",
+            category="Spec ahead of code",
+            ok=not any(token in camera_sources for token in flash_zoom_tokens) and all_in(readme, ("フラッシュ制御", "ズーム制御")),
+            ok_evidence=(
+                "No flash/zoom implementation tokens were found in camera sources.",
+                "README marks flash and zoom as not implemented.",
+            ),
+            problem_evidence=("Flash/zoom implementation tokens or docs changed; update README/spec or exception ledger.",),
+            recommendation="When flash or zoom lands, update README/spec and expire FLASH_ZOOM_PLANNED as needed.",
+            exception_id="FLASH_ZOOM_PLANNED",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    findings.append(
+        make_finding(
+            check_id="ci_android_github_bitrise_ios",
+            title="CI ownership is explicit: GitHub Actions Android, Bitrise Android/iOS",
+            category="Intentional platform asymmetry",
+            ok=(
+                "assembleDebug" in android_ci
+                and "testDebugUnitTest" in android_ci
+                and "xcodebuild" in bitrise
+                and "Assemble Android debug app" in bitrise
+            ),
+            ok_evidence=(
+                ".github/workflows/android-ci.yml runs Android lint, unit tests, and assemble.",
+                "bitrise.yml has Android and iOS debug workflows.",
+            ),
+            problem_evidence=("CI build ownership changed or is not documented by the current files.",),
+            recommendation="If GitHub Actions gains iOS build coverage, expire GITHUB_ACTIONS_ANDROID_ONLY_BITRISE_IOS.",
+            exception_id="GITHUB_ACTIONS_ANDROID_ONLY_BITRISE_IOS",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    findings.append(
+        make_finding(
+            check_id="dependency_catalog",
+            title="Dependency claims are backed by Version Catalog and Gradle usage",
+            category="Unverifiable claim",
+            ok=all_in(versions, ("cameraX", "mlkitFaceDetection", "filament")) and all_in(build_gradle, ("libs.mlkit.face.detection", "libs.filament.android", "libs.gltfio.android")),
+            ok_evidence=(
+                "gradle/libs.versions.toml defines CameraX, ML Kit, and Filament versions.",
+                "composeApp/build.gradle.kts consumes the matching aliases.",
+            ),
+            problem_evidence=("Dependency documentation is not backed by Version Catalog and Gradle usage.",),
+            recommendation="Only mention dependencies that are present in the catalog and consumed by Gradle.",
+            active_exceptions=active_exceptions,
+        )
+    )
+
+    return findings
+
+
+def render_markdown(findings: list[Finding], strict: bool) -> str:
+    generated_at = dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat()
+    counts = {status: sum(1 for finding in findings if finding.status == status) for status in ("ok", "accepted", "warning")}
+    lines = [
+        "# KMP Spec Sync Report",
+        "",
+        f"- Generated: {generated_at}",
+        f"- Baseline: `{git_head()}`",
+        f"- Mode: {'strict' if strict else 'report-only'}",
+        f"- Summary: {counts['ok']} ok, {counts['accepted']} accepted, {counts['warning']} warning",
+        "",
+        "## Findings",
+        "",
+    ]
+    for finding in findings:
+        exception = f" (exception: `{finding.exception_id}`)" if finding.exception_id else ""
+        lines.extend(
+            [
+                f"### {finding.status.upper()}: {finding.title}",
+                "",
+                f"- Check: `{finding.check_id}`",
+                f"- Category: {finding.category}{exception}",
+                "- Evidence:",
+            ]
+        )
+        lines.extend(f"  - {item}" for item in finding.evidence)
+        lines.extend(
+            [
+                f"- Recommendation: {finding.recommendation}",
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def render_json(findings: list[Finding], strict: bool) -> str:
+    payload = {
+        "generated": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat(),
+        "baseline": git_head(),
+        "mode": "strict" if strict else "report-only",
+        "findings": [dataclasses.asdict(finding) for finding in findings],
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check KMP docs/spec drift.")
+    parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    parser.add_argument("--strict", action="store_true", help="Exit non-zero on non-accepted warnings.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    active_exceptions = load_active_exception_ids()
+    findings = run_checks(active_exceptions)
+    report = render_json(findings, args.strict) if args.format == "json" else render_markdown(findings, args.strict)
+    print(report)
+
+    has_warning = any(finding.status == "warning" for finding in findings)
+    if args.strict and has_warning:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add repo-local spec sync rules, exception ledger, and a Python checker for README/spec/implementation drift.
- Add a GitHub Actions workflow for manual and weekly report-only runs, with optional strict mode.
- Update repo guidance to reflect `composeApp/src/iosMain` as the iOS camera implementation and `iosApp` as the host app.

## Testing
- `python3 -m py_compile scripts/spec_sync_check.py`
- `./scripts/spec_sync_check.py --strict --format markdown`