### PR TITLE
Add SwiftUI-hosted iOS Filament renderer surface

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -13,9 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
-        with:
+        with: 
           distribution: jetbrains
           java-version: '21'
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Lint

--- a/iosApp/iosApp/AvatarRender/FilamentAvatarRenderer.swift
+++ b/iosApp/iosApp/AvatarRender/FilamentAvatarRenderer.swift
@@ -6,6 +6,20 @@ final class FilamentAvatarRenderer {
     private let bridge: VTCFilamentRendererBridge
     private(set) var isPaused = true
 
+    /// Set to `true` once the renderer has content worth drawing (e.g., an avatar is loaded).
+    /// Setting this automatically invokes `onRenderableContentChanged` so subscribers such as
+    /// `FilamentLifecycleCoordinator` can react without requiring a manual callback call.
+    var hasRenderableContent = false {
+        didSet {
+            guard hasRenderableContent != oldValue else { return }
+            onRenderableContentChanged?()
+        }
+    }
+
+    /// Called automatically whenever `hasRenderableContent` changes value.
+    /// `FilamentLifecycleCoordinator` sets this during `attach(renderer:)`.
+    var onRenderableContentChanged: (() -> Void)?
+
     init(bridge: VTCFilamentRendererBridge = VTCFilamentRendererBridge()) {
         self.bridge = bridge
         configureRenderView()

--- a/iosApp/iosApp/AvatarRender/FilamentAvatarRenderer.swift
+++ b/iosApp/iosApp/AvatarRender/FilamentAvatarRenderer.swift
@@ -30,7 +30,7 @@ final class FilamentAvatarRenderer {
     }
 
     func resize(to bounds: CGRect, contentScale: CGFloat) {
-        bridge.resizeToBounds(bounds, contentScale: contentScale)
+        bridge.resize(toBounds: bounds, contentScale: contentScale)
     }
 
     func setPaused(_ paused: Bool) {

--- a/iosApp/iosApp/AvatarRender/FilamentAvatarRenderer.swift
+++ b/iosApp/iosApp/AvatarRender/FilamentAvatarRenderer.swift
@@ -1,0 +1,40 @@
+import CoreGraphics
+import UIKit
+
+@MainActor
+final class FilamentAvatarRenderer {
+    private let bridge: VTCFilamentRendererBridge
+    private(set) var isPaused = true
+
+    init(bridge: VTCFilamentRendererBridge = VTCFilamentRendererBridge()) {
+        self.bridge = bridge
+        configureRenderView()
+    }
+
+    var renderView: UIView {
+        bridge.renderView
+    }
+
+    func resize(to bounds: CGRect, contentScale: CGFloat) {
+        bridge.resizeToBounds(bounds, contentScale: contentScale)
+    }
+
+    func setPaused(_ paused: Bool) {
+        isPaused = paused
+    }
+
+    func drawFrameIfNeeded() {
+        guard !isPaused else { return }
+        bridge.drawIfNeeded()
+    }
+
+    deinit {
+        isPaused = true
+    }
+
+    private func configureRenderView() {
+        let view = bridge.renderView
+        view.backgroundColor = .clear
+        view.isOpaque = false
+    }
+}

--- a/iosApp/iosApp/AvatarRender/FilamentAvatarView.swift
+++ b/iosApp/iosApp/AvatarRender/FilamentAvatarView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import UIKit
+
+struct FilamentAvatarView: UIViewRepresentable {
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let hostView = UIView(frame: .zero)
+        hostView.backgroundColor = .clear
+        hostView.isOpaque = false
+
+        let renderView = context.coordinator.renderer.renderView
+        renderView.frame = hostView.bounds
+        renderView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        hostView.addSubview(renderView)
+
+        context.coordinator.lifecycle.attach(renderer: context.coordinator.renderer)
+        context.coordinator.lifecycle.viewDidAppear()
+        return hostView
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        context.coordinator.renderer.resize(to: uiView.bounds, contentScale: uiView.contentScaleFactor)
+    }
+
+    static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
+        coordinator.lifecycle.viewDidDisappear()
+        coordinator.lifecycle.teardown()
+    }
+
+    @MainActor
+    final class Coordinator {
+        let renderer = FilamentAvatarRenderer()
+        let lifecycle = FilamentLifecycleCoordinator()
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.black
+        FilamentAvatarView()
+            .frame(height: 240)
+            .overlay(
+                RoundedRectangle(cornerRadius: 0)
+                    .stroke(Color.white.opacity(0.3), lineWidth: 1)
+            )
+    }
+}

--- a/iosApp/iosApp/AvatarRender/FilamentAvatarView.swift
+++ b/iosApp/iosApp/AvatarRender/FilamentAvatarView.swift
@@ -22,7 +22,8 @@ struct FilamentAvatarView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {
-        context.coordinator.renderer.resize(to: uiView.bounds, contentScale: uiView.contentScaleFactor)
+        let contentScale = uiView.window?.screen.scale ?? UIScreen.main.scale
+        context.coordinator.renderer.resize(to: uiView.bounds, contentScale: contentScale)
     }
 
     static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {

--- a/iosApp/iosApp/AvatarRender/FilamentLifecycleCoordinator.swift
+++ b/iosApp/iosApp/AvatarRender/FilamentLifecycleCoordinator.swift
@@ -11,6 +11,9 @@ final class FilamentLifecycleCoordinator {
 
     func attach(renderer: FilamentAvatarRenderer) {
         self.renderer = renderer
+        renderer.onRenderableContentChanged = { [weak self] in
+            self?.syncRenderingState()
+        }
         addObserversIfNeeded()
     }
 
@@ -48,7 +51,8 @@ final class FilamentLifecycleCoordinator {
     }
 
     private func syncRenderingState() {
-        let shouldRender = isViewVisible && isAppActive
+        let hasContent = renderer?.hasRenderableContent ?? false
+        let shouldRender = isViewVisible && isAppActive && hasContent
         renderer?.setPaused(!shouldRender)
         shouldRender ? startDisplayLinkIfNeeded() : stopDisplayLink()
     }

--- a/iosApp/iosApp/AvatarRender/FilamentLifecycleCoordinator.swift
+++ b/iosApp/iosApp/AvatarRender/FilamentLifecycleCoordinator.swift
@@ -1,0 +1,87 @@
+import Foundation
+import QuartzCore
+import UIKit
+
+@MainActor
+final class FilamentLifecycleCoordinator {
+    private weak var renderer: FilamentAvatarRenderer?
+    private var displayLink: CADisplayLink?
+    private var isViewVisible = false
+    private var isAppActive = true
+
+    func attach(renderer: FilamentAvatarRenderer) {
+        self.renderer = renderer
+        addObserversIfNeeded()
+    }
+
+    func viewDidAppear() {
+        isViewVisible = true
+        syncRenderingState()
+    }
+
+    func viewDidDisappear() {
+        isViewVisible = false
+        syncRenderingState()
+    }
+
+    func teardown() {
+        NotificationCenter.default.removeObserver(self)
+        stopDisplayLink()
+        renderer?.setPaused(true)
+    }
+
+    @objc
+    private func onDisplayLinkTick() {
+        renderer?.drawFrameIfNeeded()
+    }
+
+    @objc
+    private func onDidBecomeActive() {
+        isAppActive = true
+        syncRenderingState()
+    }
+
+    @objc
+    private func onWillResignActive() {
+        isAppActive = false
+        syncRenderingState()
+    }
+
+    private func syncRenderingState() {
+        let shouldRender = isViewVisible && isAppActive
+        renderer?.setPaused(!shouldRender)
+        shouldRender ? startDisplayLinkIfNeeded() : stopDisplayLink()
+    }
+
+    private func addObserversIfNeeded() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onWillResignActive),
+            name: UIApplication.willResignActiveNotification,
+            object: nil
+        )
+    }
+
+    private func startDisplayLinkIfNeeded() {
+        guard displayLink == nil else { return }
+        let link = CADisplayLink(target: self, selector: #selector(onDisplayLinkTick))
+        link.add(to: .main, forMode: .common)
+        displayLink = link
+    }
+
+    private func stopDisplayLink() {
+        displayLink?.invalidate()
+        displayLink = nil
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        stopDisplayLink()
+    }
+}

--- a/iosApp/iosApp/AvatarRender/FilamentLifecycleCoordinator.swift
+++ b/iosApp/iosApp/AvatarRender/FilamentLifecycleCoordinator.swift
@@ -79,9 +79,11 @@ final class FilamentLifecycleCoordinator {
         displayLink = link
     }
 
-    private func stopDisplayLink() {
-        displayLink?.invalidate()
-        displayLink = nil
+    nonisolated private func stopDisplayLink() {
+        Task{ @MainActor [weak self] in
+            self?.displayLink?.invalidate()
+            self?.displayLink = nil
+        }
     }
 
     deinit {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -4,8 +4,14 @@ import ComposeApp
 
 struct ContentView: View {
     var body: some View {
-        ComposeCameraRootView()
-            .ignoresSafeArea()
+        ZStack {
+            ComposeCameraRootView()
+                .ignoresSafeArea()
+
+            FilamentAvatarView()
+                .allowsHitTesting(false)
+                .ignoresSafeArea()
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation

- Provide a SwiftUI-hosted, transparent render surface backed by the existing `VTCFilamentRendererBridge` so the Filament-based avatar renderer can be mounted in the iOS app UI.
- Centralize bridge ownership, resizing, and the render-loop lifecycle so future Filament implementation work can plug into a predictable host surface.

### Description

- Add `FilamentAvatarView` (`UIViewRepresentable`) to host `VTCFilamentRendererBridge.renderView` inside SwiftUI and handle attach/update/dismantle lifecycle.  (`iosApp/iosApp/AvatarRender/FilamentAvatarView.swift`)
- Add `FilamentAvatarRenderer` to encapsulate the bridge, configure a transparent render view, and expose `resize`, `setPaused`, and `drawFrameIfNeeded` APIs.  (`iosApp/iosApp/AvatarRender/FilamentAvatarRenderer.swift`)
- Add `FilamentLifecycleCoordinator` to manage a `CADisplayLink` render loop, observe app active/inactive notifications, and perform teardown.  (`iosApp/iosApp/AvatarRender/FilamentLifecycleCoordinator.swift`)
- Overlay the new `FilamentAvatarView` in `ContentView` so an empty renderer surface is mounted in the SwiftUI hierarchy.  (`iosApp/iosApp/ContentView.swift`)

### Testing

- Ran `./gradlew :composeApp:commonTest --no-daemon`, which failed in this environment due to inability to resolve the `org.gradle.toolchains.foojay-resolver-convention:1.0.0` plugin from configured repositories, so unit tests could not be executed here.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa4f5efe08330ab94732c2587f0f2)