### PR TITLE
Add kotlinx-coroutines-test and implement CameraViewModel unit tests with fakes

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -53,6 +53,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${libs.versions.coroutines.get()}")
             implementation(libs.turbine)
         }
     }

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
@@ -2,15 +2,26 @@ package com.example.vtubercamera_kmp_ver.camera
 
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 
 /**
  * Unit test stubs for [CameraViewModel] state-machine logic.
  *
  * # Test infrastructure note
- * These tests require a [TestCoroutineDispatcher] / [TestCoroutineScheduler] (kotlinx-coroutines-test)
- * and a fake [CameraRepository] / [PermissionRepository] to be wired up before the stubs can be
- * executed.  Until that scaffolding is added to the project, every stub is marked @Ignore so it
- * shows up as a known-pending test rather than a compilation error.
+ * This file includes both:
+ * - Executable unit tests that use a fake [CameraRepository] / [PermissionRepository] and
+ *   kotlinx-coroutines-test dispatcher control.
+ * - Pending scenarios still marked with @Ignore + TODO until dedicated fixtures are added.
  *
  * # Manual / E2E test checklist
  * The following scenarios require a real device or simulator and cannot be automated in commonTest:
@@ -27,43 +38,50 @@ import kotlin.test.Test
  *             "Don't Allow".
  *    - Expected: previewState == Error(PermissionDenied), retry button is visible.
  *
+ * 3. **前回起動時は許可済み → 次回起動時に OS 設定で拒否へ変更済み**
+ *    - Steps: app launch #1 で許可してプレビュー表示を確認 → アプリを終了 →
+ *             端末の設定画面でカメラ権限を拒否へ変更 → app launch #2。
+ *    - Expected: initialize() 直後に permissionState == Denied,
+ *                previewState == Error(PermissionDenied),
+ *                CameraRepository.startPreview は呼ばれない。
+ *
  * ## iOS fallback lens
- * 3. **Both lenses unavailable → CameraUnavailable error shown**
+ * 4. **Both lenses unavailable → CameraUnavailable error shown**
  *    - Steps: run on an iOS Simulator where AVFoundation returns no camera device for both front
  *             and back; trigger startPreview() or resolveInitialLens().
  *    - Expected: previewState == Error(CameraUnavailable), the UI shows the CameraUnavailable
  *                error message, not PreviewInitializationFailed.
  *
- * 4. **Requested lens unavailable, fallback lens succeeds → preview starts on fallback**
+ * 5. **Requested lens unavailable, fallback lens succeeds → preview starts on fallback**
  *    - Steps: request front lens on a device that has only a back camera.
  *    - Expected: preview starts on the back camera; lensFacing in uiState is updated to Back;
  *                no error is shown.
  *
- * 5. **Fallback lens resolves but session canAddInput fails → error propagates correctly**
+ * 6. **Fallback lens resolves but session canAddInput fails → error propagates correctly**
  *    - Steps: inject a stubbed IOSCameraSessionManager where canAddInput always returns false.
  *    - Expected: onPlatformPreviewError is called with the *resolved* (fallback) lens, repository
  *                guard passes, and previewState transitions to Error with the correct CameraError.
  *
  * ## Android error display differentiation
- * 6. **CameraUnavailable shows correct string, distinct from PreviewInitializationFailed**
+ * 7. **CameraUnavailable shows correct string, distinct from PreviewInitializationFailed**
  *    - Steps: trigger CameraUnavailable (e.g. hasCameraSafely returns false for all selectors)
  *             and separately trigger PreviewInitializationFailed (e.g. bindToLifecycle throws).
  *    - Expected: the two error states display different user-facing strings; neither falls back to
  *                the generic "unknown error" copy.
  *
  * ## iOS file selection
- * 7. **File selection success → avatarPreview is updated**
+ * 8. **File selection success → avatarPreview is updated**
  *    - Steps: tap the file-picker button → select a valid .vrm or .glb file.
  *    - Expected: CameraViewModel.onFilePicked(FilePickerResult.Success(...)) is called;
  *                uiState.avatarPreview is populated with the parsed metadata / thumbnail;
  *                filePickerErrorMessageRes is null.
  *
- * 8. **File selection cancelled → state unchanged**
+ * 9. **File selection cancelled → state unchanged**
  *    - Steps: tap the file-picker button → dismiss the picker without selecting a file.
  *    - Expected: CameraViewModel.onFilePicked(FilePickerResult.Cancelled) is called;
  *                uiState is unchanged (no error, no new avatarPreview).
  *
- * 9. **File selection fails (unsupported format / IO error) → error message shown**
+ * 10. **File selection fails (unsupported format / IO error) → error message shown**
  *    - Steps: tap the file-picker button → select a file that cannot be parsed as VRM/GLB.
  *    - Expected: CameraViewModel.onFilePicked(FilePickerResult.Error(...)) is called;
  *                uiState.filePickerErrorMessageRes is set to the appropriate StringResource;
@@ -71,6 +89,17 @@ import kotlin.test.Test
  */
 // Collects pending unit-test scenarios for the shared camera state machine.
 class CameraViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @kotlin.test.BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @kotlin.test.AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     // ---------------------------------------------------------------------------
     // initialize()
@@ -96,10 +125,74 @@ class CameraViewModelTest {
      * [PreviewState.Error(CameraError.PermissionDenied)].
      * [CameraRepository.startPreview] must NOT be called.
      */
-    @Ignore
     @Test
-    fun initialize_whenPermissionDenied_setsPermissionDeniedErrorAndDoesNotStartPreview() {
-        TODO("Requires fake repositories + TestCoroutineScheduler")
+    fun initialize_whenPermissionDenied_setsPermissionDeniedErrorAndDoesNotStartPreview() = runTest {
+        val cameraRepository = FakeCameraRepository()
+        val permissionRepository = FakePermissionRepository(
+            checkCameraPermissionResult = PermissionState.Denied,
+        )
+        val viewModel = CameraViewModel(
+            cameraRepository = cameraRepository,
+            permissionRepository = permissionRepository,
+        )
+
+        viewModel.initialize()
+        advanceUntilIdle()
+
+        val uiState = viewModel.uiState.value
+        assertEquals(PermissionState.Denied, uiState.permissionState)
+        assertEquals(CameraError.PermissionDenied, uiState.errorState)
+        assertIs<PreviewState.Error>(uiState.previewState)
+        assertEquals(CameraError.PermissionDenied, (uiState.previewState as PreviewState.Error).error)
+        assertEquals(0, cameraRepository.startPreviewCallCount)
+    }
+
+    /**
+     * 「前回起動時は許可済みだったが、次回起動時までに OS 設定で拒否へ変更された」ケース。
+     *
+     * Given:
+     *   - previous session では [PermissionState.Granted] で運用されていた。
+     *   - app 再起動後の [PermissionRepository.checkCameraPermission] は
+     *     [PermissionState.Denied] を返す。
+     *
+     * Then:
+     *   - [CameraViewModel.initialize] は [CameraUiState.permissionState] を Denied に更新し、
+     *     [CameraUiState.errorState] / [CameraUiState.previewState] を PermissionDenied に設定する。
+     *   - [CameraRepository.startPreview] は呼び出されない。
+     */
+    @Test
+    fun initialize_whenPreviouslyGrantedButNowDenied_setsPermissionDeniedAndDoesNotStartPreview() = runTest {
+        val firstLaunchCameraRepository = FakeCameraRepository()
+        val firstLaunchPermissionRepository = FakePermissionRepository(
+            checkCameraPermissionResult = PermissionState.Granted,
+        )
+        val firstLaunchViewModel = CameraViewModel(
+            cameraRepository = firstLaunchCameraRepository,
+            permissionRepository = firstLaunchPermissionRepository,
+        )
+        firstLaunchViewModel.initialize()
+        advanceUntilIdle()
+
+        assertEquals(PermissionState.Granted, firstLaunchViewModel.uiState.value.permissionState)
+        assertEquals(1, firstLaunchCameraRepository.startPreviewCallCount)
+
+        val secondLaunchCameraRepository = FakeCameraRepository()
+        val secondLaunchPermissionRepository = FakePermissionRepository(
+            checkCameraPermissionResult = PermissionState.Denied,
+        )
+        val secondLaunchViewModel = CameraViewModel(
+            cameraRepository = secondLaunchCameraRepository,
+            permissionRepository = secondLaunchPermissionRepository,
+        )
+        secondLaunchViewModel.initialize()
+        advanceUntilIdle()
+
+        val uiState = secondLaunchViewModel.uiState.value
+        assertEquals(PermissionState.Denied, uiState.permissionState)
+        assertEquals(CameraError.PermissionDenied, uiState.errorState)
+        assertIs<PreviewState.Error>(uiState.previewState)
+        assertEquals(CameraError.PermissionDenied, (uiState.previewState as PreviewState.Error).error)
+        assertEquals(0, secondLaunchCameraRepository.startPreviewCallCount)
     }
 
     // ---------------------------------------------------------------------------
@@ -223,5 +316,54 @@ class CameraViewModelTest {
     @Test
     fun onFilePicked_error_setsFilePickerErrorMessageRes_andDismissClears() {
         TODO("Requires fake repositories + TestCoroutineScheduler")
+    }
+
+    private class FakeCameraRepository : CameraRepository {
+        private val previewState = MutableStateFlow<PreviewState>(PreviewState.Preparing)
+
+        var startPreviewCallCount: Int = 0
+            private set
+
+        override suspend fun startPreview(lensFacing: CameraLensFacing): Result<CameraLensFacing> {
+            startPreviewCallCount += 1
+            previewState.value = PreviewState.Showing
+            return Result.success(lensFacing)
+        }
+
+        override suspend fun stopPreview() {
+            previewState.value = PreviewState.Preparing
+        }
+
+        override suspend fun switchLens(current: CameraLensFacing): Result<CameraLensFacing> {
+            return Result.success(current)
+        }
+
+        override suspend fun resolveInitialLens(preferred: CameraLensFacing): Result<CameraLensFacing> {
+            return Result.success(preferred)
+        }
+
+        override fun observePreviewState(): Flow<PreviewState> {
+            return previewState.asStateFlow()
+        }
+
+        override fun onPlatformPreviewStarted(lensFacing: CameraLensFacing) {
+            previewState.value = PreviewState.Showing
+        }
+
+        override fun onPlatformPreviewError(lensFacing: CameraLensFacing, error: CameraError) {
+            previewState.value = PreviewState.Error(error)
+        }
+    }
+
+    private class FakePermissionRepository(
+        private val checkCameraPermissionResult: PermissionState,
+    ) : PermissionRepository {
+        override suspend fun checkCameraPermission(): PermissionState {
+            return checkCameraPermissionResult
+        }
+
+        override suspend fun requestCameraPermission(): PermissionState {
+            return checkCameraPermissionResult
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide deterministic coroutine scheduling for commonTest by adding `kotlinx-coroutines-test` so CameraViewModel state-machine tests can be executed. 
- Exercise permission/initialization scenarios in unit tests (including previously-granted → now-denied) and reduce the number of pending stubs. 

### Description
- Added `implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${libs.versions.coroutines.get()}")` to `commonTest.dependencies` in `composeApp/build.gradle.kts` to enable `kotlinx.coroutines.test`. 
- Implemented `CameraViewModelTest` improvements including `StandardTestDispatcher` setup/teardown (`Dispatchers.setMain` / `resetMain`) and converting a denied-permission stub into a runnable test `initialize_whenPermissionDenied_setsPermissionDeniedErrorAndDoesNotStartPreview`. 
- Added a second runnable test `initialize_whenPreviouslyGrantedButNowDenied_setsPermissionDeniedAndDoesNotStartPreview` to cover the restart/OS-settings-changed permission regression. 
- Introduced test doubles `FakeCameraRepository` and `FakePermissionRepository` that implement `CameraRepository` and `PermissionRepository` respectively to drive state and verify call counts. 

### Testing
- Ran the module test suite with `./gradlew :composeApp:check` which executes the common JVM tests, and the newly added `CameraViewModelTest` cases completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3d4094e483309365b0be8b259e1a)