### PR TITLE
Add VRM parser coverage for failure paths and metadata fallbacks

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt
@@ -28,7 +28,7 @@ object VrmAvatarParser {
         }
 
         val avatarName = previewDescriptor.meta.avatarName ?: fileName.substringBeforeLast('.')
-        val authorName = previewDescriptor.meta.authors.firstOrNull()
+        val authorName = previewDescriptor.meta.authors.firstOrNull { it.isNotBlank() }
         val vrmVersion = previewDescriptor.meta.version ?: previewDescriptor.rawSpecVersion ?: previewDescriptor.assetVersion
         val thumbnailBytes = previewDescriptor.thumbnailImageIndex?.let { imageIndex ->
             document.extractImageBytes(imageIndex)

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
@@ -11,10 +11,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import vtubercamera_kmp_ver.composeapp.generated.resources.Res
-import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_invalid_format
-import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_metadata_parse_failed
-import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_read_failed
-import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_select_file
 
 class ComposeAppCommonTest {
 

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
@@ -11,16 +11,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import vtubercamera_kmp_ver.composeapp.generated.resources.Res
-<<<<<<< HEAD
-<<<<<<< ours
-import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_invalid_format
-import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_metadata_parse_failed
-import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_read_failed
-import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_select_file
-=======
->>>>>>> theirs
-=======
->>>>>>> 3895eb9c2fa3908d404abed407db584d25537d3e
 
 class ComposeAppCommonTest {
 

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
@@ -11,10 +11,13 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import vtubercamera_kmp_ver.composeapp.generated.resources.Res
+<<<<<<< ours
 import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_invalid_format
 import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_metadata_parse_failed
 import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_read_failed
 import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_select_file
+=======
+>>>>>>> theirs
 
 class ComposeAppCommonTest {
 

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
@@ -2,13 +2,18 @@ package com.example.vtubercamera_kmp_ver
 
 import com.example.vtubercamera_kmp_ver.avatar.mapping.VrmSpecVersion
 import com.example.vtubercamera_kmp_ver.camera.AvatarAssetStore
+import com.example.vtubercamera_kmp_ver.camera.FilePickerException
 import com.example.vtubercamera_kmp_ver.camera.VrmAvatarParser
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import vtubercamera_kmp_ver.composeapp.generated.resources.Res
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_invalid_format
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_metadata_parse_failed
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_read_failed
 import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_select_file
 
 class ComposeAppCommonTest {
@@ -104,21 +109,270 @@ class ComposeAppCommonTest {
         val exception = VrmAvatarParser.parse("image.png", glb).exceptionOrNull()
 
         assertNotNull(exception)
-        val filePickerException = assertIs<com.example.vtubercamera_kmp_ver.camera.FilePickerException>(exception)
+        val filePickerException = assertIs<FilePickerException>(exception)
         assertEquals(Res.string.vrm_error_select_file, filePickerException.messageRes)
     }
 
-    private fun createGlb(json: String, binary: ByteArray): ByteArray {
+    @Test
+    fun parseAvatarAcceptsUpperCaseExtensionsAndRejectsExtensionlessName() {
+        val validGlb = createGlb(
+            json = """
+                {
+                  "asset": {"version": "2.0"},
+                  "extensions": {
+                    "VRMC_vrm": {
+                      "specVersion": "1.0",
+                      "meta": {"name": "Uppercase", "authors": ["OpenAI"]}
+                    }
+                  }
+                }
+            """.trimIndent(),
+            binary = byteArrayOf(),
+        )
+
+        val vrmResult = VrmAvatarParser.parse("UPPER.VRM", validGlb).getOrThrow()
+        val glbResult = VrmAvatarParser.parse("UPPER.GLB", validGlb).getOrThrow()
+
+        try {
+            assertEquals("Uppercase", vrmResult.preview.avatarName)
+            assertEquals("Uppercase", glbResult.preview.avatarName)
+        } finally {
+            AvatarAssetStore.remove(vrmResult.assetHandle)
+            AvatarAssetStore.remove(glbResult.assetHandle)
+        }
+
+        assertFilePickerErrorRes(
+            fileName = "extensionless",
+            bytes = validGlb,
+            expectedMessageRes = Res.string.vrm_error_select_file,
+        )
+    }
+
+    @Test
+    fun parseAvatarMapsBrokenGlbCasesToPickerErrors() {
+        assertFilePickerErrorRes(
+            fileName = "broken.vrm",
+            bytes = ByteArray(19),
+            expectedMessageRes = Res.string.vrm_error_read_failed,
+        )
+        assertFilePickerErrorRes(
+            fileName = "broken.vrm",
+            bytes = createGlb(
+                json = """{"asset":{"version":"2.0"}}""",
+                binary = byteArrayOf(),
+                magic = 0x00000000,
+            ),
+            expectedMessageRes = Res.string.vrm_error_select_file,
+        )
+        assertFilePickerErrorRes(
+            fileName = "broken.vrm",
+            bytes = createGlb(
+                json = """{"asset":{"version":"2.0"}}""",
+                binary = byteArrayOf(),
+                declaredLengthOverride = 999_999,
+            ),
+            expectedMessageRes = Res.string.vrm_error_invalid_format,
+        )
+        assertFilePickerErrorRes(
+            fileName = "broken.vrm",
+            bytes = createGlbWithoutJsonChunk(binary = byteArrayOf()),
+            expectedMessageRes = Res.string.vrm_error_metadata_parse_failed,
+        )
+    }
+
+    @Test
+    fun parseAvatarTreatsGlbWithoutVrmExtensionAsMetadataFailure() {
+        val glbWithoutVrmExtension = createGlb(
+            json = """
+                {
+                  "asset": {"version": "2.0"},
+                  "nodes": [{"name": "No VRM Extension"}]
+                }
+            """.trimIndent(),
+            binary = byteArrayOf(),
+        )
+
+        assertFilePickerErrorRes(
+            fileName = "plain.glb",
+            bytes = glbWithoutVrmExtension,
+            expectedMessageRes = Res.string.vrm_error_metadata_parse_failed,
+        )
+    }
+
+    @Test
+    fun parseAvatarReturnsNullThumbnailWhenThumbnailSourceIsInvalid() {
+        val outOfRangeThumbnail = createGlb(
+            json = """
+                {
+                  "asset": {"version": "2.0"},
+                  "extensions": {
+                    "VRMC_vrm": {
+                      "specVersion": "1.0",
+                      "meta": {
+                        "name": "Out Of Range Thumbnail",
+                        "authors": ["OpenAI"],
+                        "thumbnailImage": 99
+                      }
+                    }
+                  },
+                  "images": [{"bufferView": 0, "mimeType": "image/png"}],
+                  "bufferViews": [{"buffer": 0, "byteOffset": 0, "byteLength": 4}]
+                }
+            """.trimIndent(),
+            binary = byteArrayOf(1, 2, 3, 4),
+        )
+        val nonImageMimeTypeThumbnail = createGlb(
+            json = """
+                {
+                  "asset": {"version": "2.0"},
+                  "extensions": {
+                    "VRMC_vrm": {
+                      "specVersion": "1.0",
+                      "meta": {
+                        "name": "Non Image Thumbnail",
+                        "authors": ["OpenAI"],
+                        "thumbnailImage": 0
+                      }
+                    }
+                  },
+                  "images": [{"bufferView": 0, "mimeType": "application/octet-stream"}],
+                  "bufferViews": [{"buffer": 0, "byteOffset": 0, "byteLength": 4}]
+                }
+            """.trimIndent(),
+            binary = byteArrayOf(1, 2, 3, 4),
+        )
+        val invalidBufferViewThumbnail = createGlb(
+            json = """
+                {
+                  "asset": {"version": "2.0"},
+                  "extensions": {
+                    "VRMC_vrm": {
+                      "specVersion": "1.0",
+                      "meta": {
+                        "name": "Invalid Buffer View",
+                        "authors": ["OpenAI"],
+                        "thumbnailImage": 0
+                      }
+                    }
+                  },
+                  "images": [{"bufferView": 3, "mimeType": "image/png"}],
+                  "bufferViews": [{"buffer": 0, "byteOffset": 0, "byteLength": 4}]
+                }
+            """.trimIndent(),
+            binary = byteArrayOf(1, 2, 3, 4),
+        )
+
+        val outOfRangeResult = VrmAvatarParser.parse("out_of_range.glb", outOfRangeThumbnail).getOrThrow()
+        val nonImageResult = VrmAvatarParser.parse("non_image.glb", nonImageMimeTypeThumbnail).getOrThrow()
+        val invalidBufferViewResult =
+            VrmAvatarParser.parse("invalid_buffer_view.glb", invalidBufferViewThumbnail).getOrThrow()
+
+        try {
+            assertNull(outOfRangeResult.preview.thumbnailBytes)
+            assertNull(nonImageResult.preview.thumbnailBytes)
+            assertNull(invalidBufferViewResult.preview.thumbnailBytes)
+        } finally {
+            AvatarAssetStore.remove(outOfRangeResult.assetHandle)
+            AvatarAssetStore.remove(nonImageResult.assetHandle)
+            AvatarAssetStore.remove(invalidBufferViewResult.assetHandle)
+        }
+    }
+
+    @Test
+    fun parseAvatarAppliesMetadataFallbacks() {
+        val fallbackMetadataGlb = createGlb(
+            json = """
+                {
+                  "asset": {"version": "2.9"},
+                  "extensions": {
+                    "VRMC_vrm": {
+                      "specVersion": "1.7",
+                      "meta": {
+                        "authors": [],
+                        "thumbnailImage": 0
+                      }
+                    }
+                  },
+                  "images": [{"bufferView": 0, "mimeType": "image/png"}],
+                  "bufferViews": [{"buffer": 0, "byteOffset": 0, "byteLength": 4}]
+                }
+            """.trimIndent(),
+            binary = byteArrayOf(1, 2, 3, 4),
+        )
+        val fallbackAssetVersionGlb = createGlb(
+            json = """
+                {
+                  "asset": {"version": "2.5"},
+                  "extensions": {
+                    "VRM": {
+                      "meta": {
+                        "title": "VRM 0 Fallback",
+                        "author": ""
+                      }
+                    }
+                  }
+                }
+            """.trimIndent(),
+            binary = byteArrayOf(),
+        )
+
+        val rawSpecFallbackResult = VrmAvatarParser.parse("fallback_name.glb", fallbackMetadataGlb).getOrThrow()
+        val assetVersionFallbackResult = VrmAvatarParser.parse("fallback_asset.vrm", fallbackAssetVersionGlb).getOrThrow()
+
+        try {
+            assertEquals("fallback_name", rawSpecFallbackResult.preview.avatarName)
+            assertNull(rawSpecFallbackResult.preview.authorName)
+            assertEquals("1.7", rawSpecFallbackResult.preview.vrmVersion)
+
+            assertEquals("VRM 0 Fallback", assetVersionFallbackResult.preview.avatarName)
+            assertNull(assetVersionFallbackResult.preview.authorName)
+            assertEquals("2.5", assetVersionFallbackResult.preview.vrmVersion)
+        } finally {
+            AvatarAssetStore.remove(rawSpecFallbackResult.assetHandle)
+            AvatarAssetStore.remove(assetVersionFallbackResult.assetHandle)
+        }
+    }
+
+    private fun assertFilePickerErrorRes(
+        fileName: String,
+        bytes: ByteArray,
+        expectedMessageRes: org.jetbrains.compose.resources.StringResource,
+    ) {
+        val exception = VrmAvatarParser.parse(fileName, bytes).exceptionOrNull()
+        assertNotNull(exception)
+        val filePickerException = assertIs<FilePickerException>(exception)
+        assertEquals(expectedMessageRes, filePickerException.messageRes)
+    }
+
+    private fun createGlb(
+        json: String,
+        binary: ByteArray,
+        magic: Int = 0x46546C67,
+        declaredLengthOverride: Int? = null,
+    ): ByteArray {
         val jsonBytes = json.encodeToByteArray().padTo4Bytes(0x20)
         val binaryBytes = binary.padTo4Bytes(0x00)
-        val totalLength = 12 + 8 + jsonBytes.size + 8 + binaryBytes.size
+        val totalLength = declaredLengthOverride ?: (12 + 8 + jsonBytes.size + 8 + binaryBytes.size)
         return buildList<Byte>() {
-            addIntLE(0x46546C67)
+            addIntLE(magic)
             addIntLE(2)
             addIntLE(totalLength)
             addIntLE(jsonBytes.size)
             addIntLE(0x4E4F534A)
             addAll(jsonBytes.toList())
+            addIntLE(binaryBytes.size)
+            addIntLE(0x004E4942)
+            addAll(binaryBytes.toList())
+        }.toByteArray()
+    }
+
+    private fun createGlbWithoutJsonChunk(binary: ByteArray): ByteArray {
+        val binaryBytes = binary.padTo4Bytes(0x00)
+        val totalLength = 12 + 8 + binaryBytes.size
+        return buildList<Byte> {
+            addIntLE(0x46546C67)
+            addIntLE(2)
+            addIntLE(totalLength)
             addIntLE(binaryBytes.size)
             addIntLE(0x004E4942)
             addAll(binaryBytes.toList())

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt
@@ -11,6 +11,10 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import vtubercamera_kmp_ver.composeapp.generated.resources.Res
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_invalid_format
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_metadata_parse_failed
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_read_failed
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_select_file
 
 class ComposeAppCommonTest {
 


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for VRM/GLB parsing to cover error mapping and metadata fallback behaviors requested in issue #77.  
- Ensure the parser reports user-facing picker errors for malformed GLB inputs and treats missing/blank metadata consistently.  
- Prevent blank author strings from surfacing as an author name in preview metadata.

### Description
- Added many test cases to `composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/ComposeAppCommonTest.kt` covering uppercase extension acceptance, extensionless rejection, broken GLB cases (short header, invalid magic, declared-length mismatch, missing JSON chunk), missing VRM extension, invalid thumbnail sources, and metadata fallback behaviors.  
- Updated `VrmAvatarParser` (`composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt`) to pick the first non-blank author via `firstOrNull { it.isNotBlank() }`.  
- Added test helpers used by the new tests: extended `createGlb` with `magic` and `declaredLengthOverride` parameters, `createGlbWithoutJsonChunk`, and `assertFilePickerErrorRes` to centralize error assertions.  
- Adjusted expectations in tests to assert `null` author when only blank author strings are present and updated imports in `ComposeAppCommonTest` accordingly.

### Testing
- Attempted to run the new test suite with `./gradlew :composeApp:commonTest --tests com.example.vtubercamera_kmp_ver.ComposeAppCommonTest`.  
- Test execution failed in this environment during Gradle settings/plugin resolution due to inability to resolve `org.gradle.toolchains.foojay-resolver-convention:1.0.0`, so tests could not complete here.  
- No automated test run succeeded in this container; the changes are limited to shared code and unit tests and should run in a correctly configured local CI/Dev environment where Gradle plugin resolution succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6e01e12c8330aaed62ae9ea6c777)