### PR TITLE
chore(ci): update Android workflow actions to Node 24-ready versions

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -11,19 +11,19 @@ jobs:
   android-verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with: 
           distribution: jetbrains
           java-version: '21'
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
 
       - name: Lint
         run: ./gradlew :composeApp:lintDebug
 
       - name: Unit tests
-        run: ./gradlew :composeApp:testDebugUnitTest
+        run: ./gradlew :composeApp:testDebugUnitTest --stacktrace
 
       - name: Build
         run: ./gradlew :composeApp:assembleDebug


### PR DESCRIPTION
### Motivation
- The referenced Actions run showed deprecation/compatibility concerns for workflow actions and the `Unit tests` step produced limited diagnostic output, so the Android CI workflow was updated to use newer action versions and to improve failure observability.

### Description
- Updated `.github/workflows/android-ci.yml` to use `actions/checkout@v5`, `actions/setup-java@v5`, and `gradle/actions/setup-gradle@v5` to address Node/runner compatibility warnings. 
- Added `--stacktrace` to the `./gradlew :composeApp:testDebugUnitTest` invocation so test failures produce fuller diagnostics in CI logs.

### Testing
- Verified the workflow file content locally with `nl -ba .github/workflows/android-ci.yml` and `git status` to confirm the updates landed as intended. 
- Attempted to run `./gradlew :composeApp:testDebugUnitTest` in this environment and it failed due to an unresolved Gradle plugin (`org.gradle.toolchains.foojay-resolver-convention:1.0.0`), so full Gradle verification could not be completed here; CI should run the updated workflow and provide stacktraces on test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed81e6b9488330abe7672b98bf3c04)