### PR TITLE
feat: stabilize iOS renderer overlay integration

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -5,6 +5,8 @@ import ComposeApp
 private let avatarOverlayWidthRatio: CGFloat = 0.56
 private let avatarOverlayHeightRatio: CGFloat = 0.48
 private let avatarOverlayBottomPadding: CGFloat = 24
+private let cameraLayerZIndex: Double = 0
+private let rendererLayerZIndex: Double = 1
 
 struct ContentView: View {
     var body: some View {
@@ -12,6 +14,7 @@ struct ContentView: View {
             ZStack(alignment: .bottom) {
                 ComposeCameraRootView()
                     .ignoresSafeArea()
+                    .zIndex(cameraLayerZIndex)
 
                 FilamentAvatarView()
                     .frame(
@@ -20,6 +23,7 @@ struct ContentView: View {
                     )
                     .padding(.bottom, avatarOverlayBottomPadding)
                     .allowsHitTesting(false)
+                    .zIndex(rendererLayerZIndex)
             }
         }
     }

--- a/iosApp/iosApp/IOSCameraViewModel.swift
+++ b/iosApp/iosApp/IOSCameraViewModel.swift
@@ -249,7 +249,7 @@ final class IOSCameraViewModel: ObservableObject {
     }
 
     private func publishAvatarRenderState(_ frame: IOSNormalizedFaceFrame?) {
-        let frame = frame ?? IOSNormalizedFaceFrame(
+        let normalizedFaceFrame = frame ?? IOSNormalizedFaceFrame(
             timestampMillis: 0,
             trackingConfidence: 0,
             headYawDegrees: 0,
@@ -265,13 +265,13 @@ final class IOSCameraViewModel: ObservableObject {
             name: IOSAvatarRenderBridge.avatarRenderStateDidChangeNotification,
             object: nil,
             userInfo: [
-                IOSAvatarRenderBridge.headYawDegreesKey: frame.headYawDegrees,
-                IOSAvatarRenderBridge.headPitchDegreesKey: frame.headPitchDegrees,
-                IOSAvatarRenderBridge.headRollDegreesKey: frame.headRollDegrees,
-                IOSAvatarRenderBridge.leftEyeBlinkKey: frame.leftEyeBlink,
-                IOSAvatarRenderBridge.rightEyeBlinkKey: frame.rightEyeBlink,
-                IOSAvatarRenderBridge.jawOpenKey: frame.jawOpen,
-                IOSAvatarRenderBridge.mouthSmileKey: frame.mouthSmile,
+                IOSAvatarRenderBridge.headYawDegreesKey: normalizedFaceFrame.headYawDegrees,
+                IOSAvatarRenderBridge.headPitchDegreesKey: normalizedFaceFrame.headPitchDegrees,
+                IOSAvatarRenderBridge.headRollDegreesKey: normalizedFaceFrame.headRollDegrees,
+                IOSAvatarRenderBridge.leftEyeBlinkKey: normalizedFaceFrame.leftEyeBlink,
+                IOSAvatarRenderBridge.rightEyeBlinkKey: normalizedFaceFrame.rightEyeBlink,
+                IOSAvatarRenderBridge.jawOpenKey: normalizedFaceFrame.jawOpen,
+                IOSAvatarRenderBridge.mouthSmileKey: normalizedFaceFrame.mouthSmile,
             ]
         )
     }

--- a/iosApp/iosApp/IOSCameraViewModel.swift
+++ b/iosApp/iosApp/IOSCameraViewModel.swift
@@ -2,6 +2,7 @@ import SwiftUI
 @preconcurrency import AVFoundation
 import ARKit
 import ComposeApp
+import Foundation
 
 @MainActor
 final class IOSCameraViewModel: ObservableObject {
@@ -117,6 +118,7 @@ final class IOSCameraViewModel: ObservableObject {
 
     func handleFaceTrackingFrameChanged(_ frame: IOSNormalizedFaceFrame?) {
         faceTrackingFrame = frame
+        publishAvatarRenderState(frame)
     }
 
     func stopSession() {
@@ -240,6 +242,34 @@ final class IOSCameraViewModel: ObservableObject {
         lensFacing = resolvedLensFacing
         isConfigured = true
         return true
+    }
+
+    private func publishAvatarRenderState(_ frame: IOSNormalizedFaceFrame?) {
+        let frame = frame ?? IOSNormalizedFaceFrame(
+            timestampMillis: 0,
+            trackingConfidence: 0,
+            headYawDegrees: 0,
+            headPitchDegrees: 0,
+            headRollDegrees: 0,
+            leftEyeBlink: 0,
+            rightEyeBlink: 0,
+            jawOpen: 0,
+            mouthSmile: 0
+        )
+
+        NotificationCenter.default.post(
+            name: IOSAvatarRenderBridge.avatarRenderStateDidChangeNotification,
+            object: nil,
+            userInfo: [
+                IOSAvatarRenderBridge.headYawDegreesKey: frame.headYawDegrees,
+                IOSAvatarRenderBridge.headPitchDegreesKey: frame.headPitchDegrees,
+                IOSAvatarRenderBridge.headRollDegreesKey: frame.headRollDegrees,
+                IOSAvatarRenderBridge.leftEyeBlinkKey: frame.leftEyeBlink,
+                IOSAvatarRenderBridge.rightEyeBlinkKey: frame.rightEyeBlink,
+                IOSAvatarRenderBridge.jawOpenKey: frame.jawOpen,
+                IOSAvatarRenderBridge.mouthSmileKey: frame.mouthSmile,
+            ]
+        )
     }
 
     private func openAppSettings() {

--- a/iosApp/iosApp/IOSCameraViewModel.swift
+++ b/iosApp/iosApp/IOSCameraViewModel.swift
@@ -117,17 +117,21 @@ final class IOSCameraViewModel: ObservableObject {
     }
 
     func handleFaceTrackingFrameChanged(_ frame: IOSNormalizedFaceFrame?) {
-        faceTrackingFrame = frame
-        publishAvatarRenderState(frame)
+        updateFaceTrackingFrame(frame)
     }
 
     func stopSession() {
         let captureSession = avCaptureSession
-        faceTrackingFrame = nil
+        updateFaceTrackingFrame(nil)
         guard captureSession.isRunning else { return }
         sessionQueue.async {
             captureSession.stopRunning()
         }
+    }
+
+    private func updateFaceTrackingFrame(_ frame: IOSNormalizedFaceFrame?) {
+        faceTrackingFrame = frame
+        publishAvatarRenderState(frame)
     }
 
     private func loadPermissionTexts() {


### PR DESCRIPTION
### Motivation
- Ensure the iOS avatar renderer overlay consistently appears above the camera preview in SwiftUI so the overlay doesn’t disappear behind the camera view.
- Provide a reliable path for AR face-tracking updates to reach the native Filament renderer so avatar pose channels are updated in real time.
- When face tracking is lost, send a neutral render-state so the native renderer can reset pose channels to default.

### Description
- Added explicit z-index constants and applied `.zIndex(...)` to the camera root and `FilamentAvatarView` in `iosApp/iosApp/ContentView.swift` to stabilize stacking order.
- Extended `IOSCameraViewModel` (`iosApp/iosApp/IOSCameraViewModel.swift`) to call a new `publishAvatarRenderState(_:)` when `handleFaceTrackingFrameChanged(_:)` is invoked.
- Implemented `publishAvatarRenderState(_:)` which posts `NotificationCenter` notifications using `IOSAvatarRenderBridge.*` keys and sends a neutral `IOSNormalizedFaceFrame` when the input frame is `nil`.
- Added `import Foundation` to the view model to support `NotificationCenter` usage.

### Testing
- Ran `./gradlew :composeApp:compileKotlinMetadata` which failed in this environment due to inability to resolve plugin `org.gradle.toolchains.foojay-resolver-convention:1.0.0` from the configured repositories, so a full project build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1db6b6c4833094916d57b418b377)