### PR TITLE
test: add shared tests for expression mapping and face-tracking display (fixes #78)

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/VrmExpressionMapTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/VrmExpressionMapTest.kt
@@ -2,6 +2,7 @@ package com.example.vtubercamera_kmp_ver.avatar.mapping
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class VrmExpressionMapTest {
 
@@ -20,5 +21,67 @@ class VrmExpressionMapTest {
 
         assertEquals("joy", vrm0)
         assertEquals("happy", vrm1)
+    }
+
+    @Test
+    fun resolve_supportsBlinkLeftAliasPriorityForVrm0AndVrm1() {
+        val vrm0 = VrmExpressionMap.resolve(
+            expression = AvatarExpressionId.BlinkLeft,
+            specVersion = VrmSpecVersion.Vrm0,
+            availableNames = setOf("Blink_L", "blinkLeft"),
+        )
+        val vrm1 = VrmExpressionMap.resolve(
+            expression = AvatarExpressionId.BlinkLeft,
+            specVersion = VrmSpecVersion.Vrm1,
+            availableNames = setOf("BlinkLeft", "blink_l"),
+        )
+
+        assertEquals("blinkLeft", vrm0)
+        assertEquals("blink_l", vrm1)
+    }
+
+    @Test
+    fun resolve_supportsBlinkRightAliasPriorityForVrm0AndVrm1() {
+        val vrm0 = VrmExpressionMap.resolve(
+            expression = AvatarExpressionId.BlinkRight,
+            specVersion = VrmSpecVersion.Vrm0,
+            availableNames = setOf("Blink_R", "blinkRight"),
+        )
+        val vrm1 = VrmExpressionMap.resolve(
+            expression = AvatarExpressionId.BlinkRight,
+            specVersion = VrmSpecVersion.Vrm1,
+            availableNames = setOf("BlinkRight", "blink_r"),
+        )
+
+        assertEquals("blinkRight", vrm0)
+        assertEquals("blink_r", vrm1)
+    }
+
+    @Test
+    fun resolve_supportsJawOpenAliasPriorityForVrm0AndVrm1() {
+        val vrm0 = VrmExpressionMap.resolve(
+            expression = AvatarExpressionId.JawOpen,
+            specVersion = VrmSpecVersion.Vrm0,
+            availableNames = setOf("aa", "jawOpen"),
+        )
+        val vrm1 = VrmExpressionMap.resolve(
+            expression = AvatarExpressionId.JawOpen,
+            specVersion = VrmSpecVersion.Vrm1,
+            availableNames = setOf("a", "jawOpen"),
+        )
+
+        assertEquals("aa", vrm0)
+        assertEquals("a", vrm1)
+    }
+
+    @Test
+    fun resolve_returnsNullWhenNoAliasesAreAvailable() {
+        val resolved = VrmExpressionMap.resolve(
+            expression = AvatarExpressionId.JawOpen,
+            specVersion = VrmSpecVersion.Vrm1,
+            availableNames = setOf("neutral", "angry"),
+        )
+
+        assertNull(resolved)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarTrackingStatus
 import com.example.vtubercamera_kmp_ver.avatar.mapping.VrmSpecVersion
 import com.example.vtubercamera_kmp_ver.avatar.vrm.VrmRuntimeAssetDescriptor
 import com.example.vtubercamera_kmp_ver.avatar.vrm.VrmRuntimeMeta
@@ -536,6 +537,123 @@ class CameraViewModelTest {
         assertEquals(1, cameraRepository.switchLensCallCount)
     }
 
+    @Test
+    fun onFaceTrackingFrameChanged_formatsAngleAndClampsPercentLabels() = runTest {
+        val viewModel = CameraViewModel(
+            cameraRepository = FakeCameraRepository(),
+            permissionRepository = FakePermissionRepository(PermissionState.Unknown),
+        )
+        val frame = createFaceFrame(
+            timestampMillis = 100L,
+            trackingConfidence = 0.9f,
+            headYawDegrees = 12.4f,
+            headPitchDegrees = -8.6f,
+            headRollDegrees = 30.2f,
+            leftEyeBlink = -0.1f,
+            rightEyeBlink = 0.453f,
+            jawOpen = 1.3f,
+            mouthSmile = 0.995f,
+        )
+
+        viewModel.onFaceTrackingFrameChanged(frame)
+        advanceUntilIdle()
+
+        val display = assertNotNull(viewModel.uiState.value.faceTracking.display)
+        assertEquals("12 deg", display.headYawLabel)
+        assertEquals("-9 deg", display.headPitchLabel)
+        assertEquals("30 deg", display.headRollLabel)
+        assertEquals("0%", display.leftEyeBlinkLabel)
+        assertEquals("45%", display.rightEyeBlinkLabel)
+        assertEquals("100%", display.jawOpenLabel)
+        assertEquals("100%", display.mouthSmileLabel)
+    }
+
+    @Test
+    fun onFaceTrackingFrameChanged_whenFrameIsNull_setsNotTrackingAndClearsDisplay() = runTest {
+        val viewModel = CameraViewModel(
+            cameraRepository = FakeCameraRepository(),
+            permissionRepository = FakePermissionRepository(PermissionState.Unknown),
+        )
+        viewModel.onFaceTrackingFrameChanged(createFaceFrame())
+        advanceUntilIdle()
+
+        viewModel.onFaceTrackingFrameChanged(null)
+        advanceUntilIdle()
+
+        val faceTracking = viewModel.uiState.value.faceTracking
+        assertEquals(false, faceTracking.isTracking)
+        assertNull(faceTracking.frame)
+        assertNull(faceTracking.display)
+    }
+
+    @Test
+    fun onFaceTrackingFrameChanged_whenConfidenceLow_transitionsAvatarStateToLost() = runTest {
+        val viewModel = CameraViewModel(
+            cameraRepository = FakeCameraRepository(),
+            permissionRepository = FakePermissionRepository(PermissionState.Unknown),
+        )
+        val highConfidenceFrame = createFaceFrame(
+            timestampMillis = 200L,
+            trackingConfidence = 0.92f,
+            headYawDegrees = 9f,
+            headPitchDegrees = 1f,
+            headRollDegrees = -4f,
+        )
+        val lowConfidenceFrame = createFaceFrame(
+            timestampMillis = 201L,
+            trackingConfidence = 0.2f,
+            headYawDegrees = 3f,
+            headPitchDegrees = 2f,
+            headRollDegrees = 1f,
+        )
+
+        viewModel.onFaceTrackingFrameChanged(highConfidenceFrame)
+        advanceUntilIdle()
+        viewModel.onFaceTrackingFrameChanged(lowConfidenceFrame)
+        advanceUntilIdle()
+
+        val avatarState = viewModel.uiState.value.avatarRenderState
+        assertEquals(AvatarTrackingStatus.Lost, avatarState.trackingStatus)
+        assertEquals(0.2f, avatarState.trackingConfidence)
+        assertEquals(201L, avatarState.sourceTimestampMillis)
+    }
+
+    @Test
+    fun onFaceTrackingFrameChanged_usesPreviousAvatarStateAcrossSequentialFrames() = runTest {
+        val viewModel = CameraViewModel(
+            cameraRepository = FakeCameraRepository(),
+            permissionRepository = FakePermissionRepository(PermissionState.Unknown),
+        )
+        val firstFrame = createFaceFrame(
+            timestampMillis = 300L,
+            trackingConfidence = 0.95f,
+            headYawDegrees = 10f,
+        )
+        val secondFrame = createFaceFrame(
+            timestampMillis = 301L,
+            trackingConfidence = 0.1f,
+            headYawDegrees = 8f,
+        )
+
+        viewModel.onFaceTrackingFrameChanged(firstFrame)
+        advanceUntilIdle()
+        val trackedState = viewModel.uiState.value.avatarRenderState
+        assertEquals(AvatarTrackingStatus.Tracking, trackedState.trackingStatus)
+        assertEquals(300L, trackedState.sourceTimestampMillis)
+
+        viewModel.onFaceTrackingFrameChanged(secondFrame)
+        advanceUntilIdle()
+        val lostState = viewModel.uiState.value.avatarRenderState
+        assertEquals(AvatarTrackingStatus.Lost, lostState.trackingStatus)
+        assertEquals(301L, lostState.sourceTimestampMillis)
+
+        viewModel.onFaceTrackingFrameChanged(null)
+        advanceUntilIdle()
+        val notTrackedState = viewModel.uiState.value.avatarRenderState
+        assertEquals(AvatarTrackingStatus.NotTracked, notTrackedState.trackingStatus)
+        assertEquals(301L, notTrackedState.sourceTimestampMillis)
+    }
+
     // ---------------------------------------------------------------------------
     // onFilePicked()
     // ---------------------------------------------------------------------------
@@ -727,6 +845,28 @@ class CameraViewModelTest {
             ),
         )
     }
+
+    private fun createFaceFrame(
+        timestampMillis: Long = 42L,
+        trackingConfidence: Float = 0.8f,
+        headYawDegrees: Float = 0f,
+        headPitchDegrees: Float = 0f,
+        headRollDegrees: Float = 0f,
+        leftEyeBlink: Float = 0f,
+        rightEyeBlink: Float = 0f,
+        jawOpen: Float = 0f,
+        mouthSmile: Float = 0f,
+    ): NormalizedFaceFrame = NormalizedFaceFrame(
+        timestampMillis = timestampMillis,
+        trackingConfidence = trackingConfidence,
+        headYawDegrees = headYawDegrees,
+        headPitchDegrees = headPitchDegrees,
+        headRollDegrees = headRollDegrees,
+        leftEyeBlink = leftEyeBlink,
+        rightEyeBlink = rightEyeBlink,
+        jawOpen = jawOpen,
+        mouthSmile = mouthSmile,
+    )
 
     private class FakeCameraRepository(
         private val resolveInitialLensResult: Result<CameraLensFacing> = Result.success(CameraLensFacing.Back),


### PR DESCRIPTION
### Motivation

- Add unit coverage for VRM expression name resolution and the face-tracking to UI mapping to prevent regressions described in issue #78. 

### Description

- Add new assertions and cases to `VrmExpressionMapTest` to verify VRM0/VRM1 alias priority for `BlinkLeft`, `BlinkRight`, and `JawOpen`, and a no-match case that expects `null` (file: `composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/mapping/VrmExpressionMapTest.kt`).
- Add multiple `CameraViewModel` tests validating `onFaceTrackingFrameChanged()` formatting and state transitions (angle rounding to `deg`, percent clamping to `0..100%`, `null` frame behavior, low-confidence `Lost` transition, and sequential-frame behavior) and a `createFaceFrame` test helper (file: `composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt`).
- Import and use `AvatarTrackingStatus` and `assertNull` where needed and keep tests isolated with the existing fake repositories and `AvatarAssetStore` cleanup.

### Testing

- Attempted to run the added tests with `./gradlew :composeApp:commonTest --tests "com.example.vtubercamera_kmp_ver.avatar.mapping.VrmExpressionMapTest" --tests "com.example.vtubercamera_kmp_ver.camera.CameraViewModelTest"`, but the run failed because Gradle could not download the required JDK 21 toolchain from Foojay (HTTP 403), so tests could not be executed in this environment.
- All test code changes are committed so CI or an environment with JDK/toolchain access can execute the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee21b7acf08330bc7264fc51af85f3)