### PR TITLE
Implement Android tracking-to-render bridge for avatar motion

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidAvatarRenderBridge.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidAvatarRenderBridge.kt
@@ -1,6 +1,5 @@
 package com.example.vtubercamera_kmp_ver.avatar.render
 
-import android.util.Log
 import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
 import com.example.vtubercamera_kmp_ver.avatar.tracking.AndroidFaceTrackingToAvatarMapper
 import com.example.vtubercamera_kmp_ver.camera.AvatarAssetStore
@@ -54,18 +53,9 @@ internal class AndroidAvatarRenderBridge(
             .onSuccess { nextAsset ->
                 runCatching {
                     nextAsset.normalizeRootTransform()
+                    nextAsset.configureRenderables()
                     nextAsset.instance.animator.updateBoneMatrices()
-                    Log.d(
-                        LOG_TAG,
-                        "Loaded asset entities=${nextAsset.entities.size}, renderables=${nextAsset.renderableEntities.size}, skins=${nextAsset.instance.skinCount}",
-                    )
-                    nextAsset.instance.materialInstances.forEachIndexed { index, materialInstance ->
-                        Log.d(
-                            LOG_TAG,
-                            "Material[$index] name=${materialInstance.name}, params=${materialInstance.material.parameters.joinToString { "${it.name}:${it.type}" }}",
-                        )
-                    }
-                    scene.addEntities(nextAsset.entities)
+                    scene.addEntities(nextAsset.sceneEntities())
                     onSceneFramingChanged(AvatarSceneFraming.Default)
                 }.onSuccess {
                     val previousAsset = currentAsset
@@ -121,6 +111,34 @@ internal class AndroidAvatarRenderBridge(
                 1f,
             ),
         )
+    }
+
+    private fun FilamentAsset.configureRenderables() {
+        val renderableManager = engine.renderableManager
+        renderableEntities.forEach { entity ->
+            val renderable = renderableManager.getInstance(entity)
+            renderableManager.setLayerMask(renderable, SCENE_LAYER_MASK, SCENE_LAYER_VISIBLE)
+            renderableManager.setCulling(renderable, false)
+            repeat(renderableManager.getPrimitiveCount(renderable)) { primitiveIndex ->
+                renderableManager.getMaterialInstanceAt(renderable, primitiveIndex).setDoubleSided(true)
+            }
+        }
+    }
+
+    private fun FilamentAsset.sceneEntities(): IntArray {
+        val renderables = buildList {
+            val readyRenderables = IntArray(READY_RENDERABLE_BATCH_SIZE)
+            var count: Int
+            do {
+                count = popRenderables(readyRenderables)
+                for (index in 0 until count) {
+                    add(readyRenderables[index])
+                }
+            } while (count == readyRenderables.size)
+        }
+        return (entities.asIterable() + renderableEntities.asIterable() + lightEntities.asIterable() + renderables)
+            .distinct()
+            .toIntArray()
     }
 
     fun destroy() {
@@ -181,7 +199,9 @@ internal class AndroidAvatarRenderBridge(
         private const val MIN_MODEL_HALF_EXTENT = 0.75f
         private const val MODEL_FIT_DISTANCE_MULTIPLIER = 2.8
         private const val NORMALIZED_MODEL_HALF_EXTENT = 1.0f
-        private const val LOG_TAG = "VrmAvatarRender"
+        private const val READY_RENDERABLE_BATCH_SIZE = 128
+        private const val SCENE_LAYER_MASK = 0xff
+        private const val SCENE_LAYER_VISIBLE = 0x1
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidAvatarRenderBridge.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidAvatarRenderBridge.kt
@@ -1,14 +1,17 @@
 package com.example.vtubercamera_kmp_ver.avatar.render
 
+import android.util.Log
 import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
 import com.example.vtubercamera_kmp_ver.avatar.tracking.AndroidFaceTrackingToAvatarMapper
 import com.example.vtubercamera_kmp_ver.camera.AvatarAssetStore
 import com.example.vtubercamera_kmp_ver.camera.AvatarSelectionData
+import com.google.android.filament.Engine
 import com.google.android.filament.Scene
 import com.google.android.filament.gltfio.FilamentAsset
 import kotlin.math.max
 
 internal class AndroidAvatarRenderBridge(
+    private val engine: Engine,
     private val scene: Scene,
     private val assetLoader: AndroidVrmAssetLoader,
     private val resourceCleaner: FilamentResourceCleaner,
@@ -18,6 +21,10 @@ internal class AndroidAvatarRenderBridge(
     private val renderStateMapper = AndroidFaceTrackingToAvatarMapper()
     private var currentAsset: FilamentAsset? = null
     private var currentAssetKey: AvatarAssetKey? = null
+
+    fun prepareFrame() {
+        currentAsset?.instance?.animator?.updateBoneMatrices()
+    }
 
     @Suppress("UNUSED_PARAMETER")
     fun update(
@@ -46,8 +53,20 @@ internal class AndroidAvatarRenderBridge(
         assetLoader.loadAsset(assetBytes)
             .onSuccess { nextAsset ->
                 runCatching {
+                    nextAsset.normalizeRootTransform()
+                    nextAsset.instance.animator.updateBoneMatrices()
+                    Log.d(
+                        LOG_TAG,
+                        "Loaded asset entities=${nextAsset.entities.size}, renderables=${nextAsset.renderableEntities.size}, skins=${nextAsset.instance.skinCount}",
+                    )
+                    nextAsset.instance.materialInstances.forEachIndexed { index, materialInstance ->
+                        Log.d(
+                            LOG_TAG,
+                            "Material[$index] name=${materialInstance.name}, params=${materialInstance.material.parameters.joinToString { "${it.name}:${it.type}" }}",
+                        )
+                    }
                     scene.addEntities(nextAsset.entities)
-                    onSceneFramingChanged(nextAsset.toSceneFraming())
+                    onSceneFramingChanged(AvatarSceneFraming.Default)
                 }.onSuccess {
                     val previousAsset = currentAsset
                     currentAsset = nextAsset
@@ -77,6 +96,31 @@ internal class AndroidAvatarRenderBridge(
                     },
                 )
             }
+    }
+
+    private fun FilamentAsset.normalizeRootTransform() {
+        val bounds = boundingBox
+        val center = bounds.center
+        val halfExtent = bounds.halfExtent
+        val maxHalfExtent = max(
+            max(halfExtent[0], halfExtent[1]),
+            max(halfExtent[2], MIN_MODEL_HALF_EXTENT),
+        )
+        val scale = NORMALIZED_MODEL_HALF_EXTENT / maxHalfExtent
+        val transformManager = engine.transformManager
+        val rootInstance = transformManager.getInstance(root)
+        transformManager.setTransform(
+            rootInstance,
+            floatArrayOf(
+                scale, 0f, 0f, 0f,
+                0f, scale, 0f, 0f,
+                0f, 0f, scale, 0f,
+                -center[0] * scale,
+                -center[1] * scale,
+                -center[2] * scale,
+                1f,
+            ),
+        )
     }
 
     fun destroy() {
@@ -136,6 +180,8 @@ internal class AndroidAvatarRenderBridge(
         private const val DEFAULT_CAMERA_DISTANCE = 4.0
         private const val MIN_MODEL_HALF_EXTENT = 0.75f
         private const val MODEL_FIT_DISTANCE_MULTIPLIER = 2.8
+        private const val NORMALIZED_MODEL_HALF_EXTENT = 1.0f
+        private const val LOG_TAG = "VrmAvatarRender"
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidAvatarRenderBridge.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidAvatarRenderBridge.kt
@@ -52,11 +52,10 @@ internal class AndroidAvatarRenderBridge(
         assetLoader.loadAsset(assetBytes)
             .onSuccess { nextAsset ->
                 runCatching {
-                    nextAsset.normalizeRootTransform()
                     nextAsset.configureRenderables()
                     nextAsset.instance.animator.updateBoneMatrices()
-                    scene.addEntities(nextAsset.sceneEntities())
-                    onSceneFramingChanged(AvatarSceneFraming.Default)
+                    scene.addEntities(nextAsset.entities)
+                    onSceneFramingChanged(nextAsset.toSceneFraming())
                 }.onSuccess {
                     val previousAsset = currentAsset
                     currentAsset = nextAsset
@@ -88,31 +87,6 @@ internal class AndroidAvatarRenderBridge(
             }
     }
 
-    private fun FilamentAsset.normalizeRootTransform() {
-        val bounds = boundingBox
-        val center = bounds.center
-        val halfExtent = bounds.halfExtent
-        val maxHalfExtent = max(
-            max(halfExtent[0], halfExtent[1]),
-            max(halfExtent[2], MIN_MODEL_HALF_EXTENT),
-        )
-        val scale = NORMALIZED_MODEL_HALF_EXTENT / maxHalfExtent
-        val transformManager = engine.transformManager
-        val rootInstance = transformManager.getInstance(root)
-        transformManager.setTransform(
-            rootInstance,
-            floatArrayOf(
-                scale, 0f, 0f, 0f,
-                0f, scale, 0f, 0f,
-                0f, 0f, scale, 0f,
-                -center[0] * scale,
-                -center[1] * scale,
-                -center[2] * scale,
-                1f,
-            ),
-        )
-    }
-
     private fun FilamentAsset.configureRenderables() {
         val renderableManager = engine.renderableManager
         renderableEntities.forEach { entity ->
@@ -123,22 +97,6 @@ internal class AndroidAvatarRenderBridge(
                 renderableManager.getMaterialInstanceAt(renderable, primitiveIndex).setDoubleSided(true)
             }
         }
-    }
-
-    private fun FilamentAsset.sceneEntities(): IntArray {
-        val renderables = buildList {
-            val readyRenderables = IntArray(READY_RENDERABLE_BATCH_SIZE)
-            var count: Int
-            do {
-                count = popRenderables(readyRenderables)
-                for (index in 0 until count) {
-                    add(readyRenderables[index])
-                }
-            } while (count == readyRenderables.size)
-        }
-        return (entities.asIterable() + renderableEntities.asIterable() + lightEntities.asIterable() + renderables)
-            .distinct()
-            .toIntArray()
     }
 
     fun destroy() {
@@ -198,8 +156,6 @@ internal class AndroidAvatarRenderBridge(
         private const val DEFAULT_CAMERA_DISTANCE = 4.0
         private const val MIN_MODEL_HALF_EXTENT = 0.75f
         private const val MODEL_FIT_DISTANCE_MULTIPLIER = 2.8
-        private const val NORMALIZED_MODEL_HALF_EXTENT = 1.0f
-        private const val READY_RENDERABLE_BATCH_SIZE = 128
         private const val SCENE_LAYER_MASK = 0xff
         private const val SCENE_LAYER_VISIBLE = 0x1
     }

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidAvatarRenderBridge.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidAvatarRenderBridge.kt
@@ -20,6 +20,7 @@ internal class AndroidAvatarRenderBridge(
     private val renderStateMapper = AndroidFaceTrackingToAvatarMapper()
     private var currentAsset: FilamentAsset? = null
     private var currentAssetKey: AvatarAssetKey? = null
+    private var currentRuntimeController: AndroidAvatarRuntimeController? = null
 
     fun prepareFrame() {
         currentAsset?.instance?.animator?.updateBoneMatrices()
@@ -31,13 +32,15 @@ internal class AndroidAvatarRenderBridge(
         avatarRenderState: AvatarRenderState,
         onAvatarLoadFailure: (AvatarAssetLoadException) -> Unit,
     ) {
-        onRenderStateChanged(renderStateMapper.map(avatarRenderState))
+        val mappedRenderState = renderStateMapper.map(avatarRenderState)
+        onRenderStateChanged(mappedRenderState)
 
         val nextAssetKey = AvatarAssetKey(
             assetId = avatarSelection.assetHandle.assetId,
             byteHash = avatarSelection.assetHandle.contentHash,
         )
         if (nextAssetKey == currentAssetKey) {
+            currentRuntimeController?.apply(mappedRenderState)
             return
         }
 
@@ -53,13 +56,21 @@ internal class AndroidAvatarRenderBridge(
             .onSuccess { nextAsset ->
                 runCatching {
                     nextAsset.configureRenderables()
+                    val runtimeController = AndroidAvatarRuntimeController.create(
+                        engine = engine,
+                        asset = nextAsset,
+                        runtimeDescriptor = avatarSelection.runtimeDescriptor,
+                    )
+                    runtimeController.apply(mappedRenderState)
                     nextAsset.instance.animator.updateBoneMatrices()
                     scene.addEntities(nextAsset.entities)
                     onSceneFramingChanged(nextAsset.toSceneFraming())
-                }.onSuccess {
+                    runtimeController
+                }.onSuccess { runtimeController ->
                     val previousAsset = currentAsset
                     currentAsset = nextAsset
                     currentAssetKey = nextAssetKey
+                    currentRuntimeController = runtimeController
                     resourceCleaner.destroyAsset(
                         scene = scene,
                         assetLoader = assetLoader,
@@ -107,6 +118,7 @@ internal class AndroidAvatarRenderBridge(
         )
         currentAsset = null
         currentAssetKey = null
+        currentRuntimeController = null
     }
 
     private fun FilamentAsset.toSceneFraming(): AvatarSceneFraming {
@@ -150,6 +162,7 @@ internal class AndroidAvatarRenderBridge(
         )
         currentAsset = null
         currentAssetKey = null
+        currentRuntimeController = null
     }
 
     private companion object {

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidAvatarRenderBridge.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidAvatarRenderBridge.kt
@@ -1,6 +1,7 @@
 package com.example.vtubercamera_kmp_ver.avatar.render
 
 import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
+import com.example.vtubercamera_kmp_ver.avatar.tracking.AndroidFaceTrackingToAvatarMapper
 import com.example.vtubercamera_kmp_ver.camera.AvatarAssetStore
 import com.example.vtubercamera_kmp_ver.camera.AvatarSelectionData
 import com.google.android.filament.Scene
@@ -12,7 +13,9 @@ internal class AndroidAvatarRenderBridge(
     private val assetLoader: AndroidVrmAssetLoader,
     private val resourceCleaner: FilamentResourceCleaner,
     private val onSceneFramingChanged: (AvatarSceneFraming) -> Unit,
+    private val onRenderStateChanged: (AvatarRenderState) -> Unit,
 ) {
+    private val renderStateMapper = AndroidFaceTrackingToAvatarMapper()
     private var currentAsset: FilamentAsset? = null
     private var currentAssetKey: AvatarAssetKey? = null
 
@@ -22,8 +25,7 @@ internal class AndroidAvatarRenderBridge(
         avatarRenderState: AvatarRenderState,
         onAvatarLoadFailure: (AvatarAssetLoadException) -> Unit,
     ) {
-        // TODO: Apply avatarRenderState to the loaded model here once expression / pose mapping is
-        // wired into the Android runtime renderer.
+        onRenderStateChanged(renderStateMapper.map(avatarRenderState))
 
         val nextAssetKey = AvatarAssetKey(
             assetId = avatarSelection.assetHandle.assetId,

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidAvatarRuntimeController.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidAvatarRuntimeController.kt
@@ -1,0 +1,276 @@
+package com.example.vtubercamera_kmp_ver.avatar.render
+
+import com.example.vtubercamera_kmp_ver.avatar.mapping.AvatarExpressionId
+import com.example.vtubercamera_kmp_ver.avatar.mapping.VrmExpressionMap
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
+import com.example.vtubercamera_kmp_ver.avatar.vrm.VrmExpressionDescriptor
+import com.example.vtubercamera_kmp_ver.avatar.vrm.VrmRuntimeAssetDescriptor
+import com.google.android.filament.Engine
+import com.google.android.filament.gltfio.FilamentAsset
+import kotlin.math.cos
+import kotlin.math.sin
+
+internal class AndroidAvatarRuntimeController private constructor(
+    private val engine: Engine,
+    private val headBinding: HeadBinding?,
+    private val morphTargets: Map<Int, FloatArray>,
+    private val expressionBindings: List<ExpressionBinding>,
+) {
+    fun apply(renderState: AvatarRenderState) {
+        applyHeadPose(renderState)
+        applyExpressions(renderState)
+    }
+
+    private fun applyHeadPose(renderState: AvatarRenderState) {
+        val binding = headBinding ?: return
+        val transformManager = engine.transformManager
+        val rotation = rotationMatrix(
+            yawDegrees = renderState.rig.headYawDegrees,
+            pitchDegrees = renderState.rig.headPitchDegrees,
+            rollDegrees = renderState.rig.headRollDegrees,
+        )
+        transformManager.setTransform(
+            binding.transformInstance,
+            multiplyColumnMajor(binding.baseLocalTransform, rotation),
+        )
+    }
+
+    private fun applyExpressions(renderState: AvatarRenderState) {
+        if (morphTargets.isEmpty()) {
+            return
+        }
+
+        morphTargets.values.forEach { weights ->
+            weights.fill(0f)
+        }
+
+        expressionBindings.forEach { binding ->
+            val expressionWeight = binding.weightProvider(renderState).coerceIn(0f, 1f)
+            if (expressionWeight <= 0f) {
+                return@forEach
+            }
+            binding.morphBinds.forEach { morphBind ->
+                val weights = morphTargets[morphBind.entity] ?: return@forEach
+                if (morphBind.morphTargetIndex in weights.indices) {
+                    weights[morphBind.morphTargetIndex] =
+                        (weights[morphBind.morphTargetIndex] + expressionWeight * morphBind.weight).coerceIn(0f, 1f)
+                }
+            }
+        }
+
+        val renderableManager = engine.renderableManager
+        morphTargets.forEach { (entity, weights) ->
+            val renderableInstance = renderableManager.getInstance(entity)
+            if (renderableInstance != 0) {
+                renderableManager.setMorphWeights(renderableInstance, weights, 0)
+            }
+        }
+    }
+
+    private fun rotationMatrix(
+        yawDegrees: Float,
+        pitchDegrees: Float,
+        rollDegrees: Float,
+    ): FloatArray {
+        val yaw = Math.toRadians(yawDegrees.toDouble())
+        val pitch = Math.toRadians(pitchDegrees.toDouble())
+        val roll = Math.toRadians(rollDegrees.toDouble())
+
+        val cy = cos(yaw).toFloat()
+        val sy = sin(yaw).toFloat()
+        val cp = cos(pitch).toFloat()
+        val sp = sin(pitch).toFloat()
+        val cr = cos(roll).toFloat()
+        val sr = sin(roll).toFloat()
+
+        val yawMatrix = floatArrayOf(
+            cy, 0f, -sy, 0f,
+            0f, 1f, 0f, 0f,
+            sy, 0f, cy, 0f,
+            0f, 0f, 0f, 1f,
+        )
+        val pitchMatrix = floatArrayOf(
+            1f, 0f, 0f, 0f,
+            0f, cp, sp, 0f,
+            0f, -sp, cp, 0f,
+            0f, 0f, 0f, 1f,
+        )
+        val rollMatrix = floatArrayOf(
+            cr, sr, 0f, 0f,
+            -sr, cr, 0f, 0f,
+            0f, 0f, 1f, 0f,
+            0f, 0f, 0f, 1f,
+        )
+
+        return multiplyColumnMajor(yawMatrix, multiplyColumnMajor(pitchMatrix, rollMatrix))
+    }
+
+    private data class HeadBinding(
+        val transformInstance: Int,
+        val baseLocalTransform: FloatArray,
+    )
+
+    private data class ExpressionBinding(
+        val weightProvider: (AvatarRenderState) -> Float,
+        val morphBinds: List<MorphBind>,
+    )
+
+    private data class MorphBind(
+        val entity: Int,
+        val morphTargetIndex: Int,
+        val weight: Float,
+    )
+
+    companion object {
+        fun create(
+            engine: Engine,
+            asset: FilamentAsset,
+            runtimeDescriptor: VrmRuntimeAssetDescriptor,
+        ): AndroidAvatarRuntimeController {
+            val entities = asset.entities
+            val headBinding = createHeadBinding(engine, entities, runtimeDescriptor)
+            val morphTargets = createMorphTargets(engine, asset)
+            val expressionBindings = createExpressionBindings(entities, runtimeDescriptor)
+            return AndroidAvatarRuntimeController(
+                engine = engine,
+                headBinding = headBinding,
+                morphTargets = morphTargets,
+                expressionBindings = expressionBindings,
+            )
+        }
+
+        private fun createHeadBinding(
+            engine: Engine,
+            entities: IntArray,
+            runtimeDescriptor: VrmRuntimeAssetDescriptor,
+        ): HeadBinding? {
+            val headNodeIndex = runtimeDescriptor.humanoidBones
+                .firstOrNull { bone -> bone.boneName == HEAD_BONE_NAME }
+                ?.nodeIndex
+                ?: return null
+            val headEntity = entities.getOrNull(headNodeIndex) ?: return null
+            val transformManager = engine.transformManager
+            val transformInstance = transformManager.getInstance(headEntity)
+            if (transformInstance == 0) {
+                return null
+            }
+            return HeadBinding(
+                transformInstance = transformInstance,
+                baseLocalTransform = transformManager.getTransform(transformInstance, FloatArray(MATRIX_SIZE)).copyOf(),
+            )
+        }
+
+        private fun createMorphTargets(
+            engine: Engine,
+            asset: FilamentAsset,
+        ): Map<Int, FloatArray> {
+            val renderableManager = engine.renderableManager
+            val morphTargets = mutableMapOf<Int, FloatArray>()
+            asset.renderableEntities.forEach { entity ->
+                val renderableInstance = renderableManager.getInstance(entity)
+                if (renderableInstance == 0) {
+                    return@forEach
+                }
+                val morphTargetCount = renderableManager.getMorphTargetCount(renderableInstance)
+                if (morphTargetCount > 0) {
+                    morphTargets[entity] = FloatArray(morphTargetCount)
+                }
+            }
+            return morphTargets
+        }
+
+        private fun createExpressionBindings(
+            entities: IntArray,
+            runtimeDescriptor: VrmRuntimeAssetDescriptor,
+        ): List<ExpressionBinding> {
+            val availableNames = runtimeDescriptor.availableExpressionNames
+            return listOfNotNull(
+                createExpressionBinding(
+                    expressionId = AvatarExpressionId.BlinkLeft,
+                    runtimeDescriptor = runtimeDescriptor,
+                    availableNames = availableNames,
+                    entities = entities,
+                    weightProvider = { state -> state.expressions.leftEyeBlink },
+                ),
+                createExpressionBinding(
+                    expressionId = AvatarExpressionId.BlinkRight,
+                    runtimeDescriptor = runtimeDescriptor,
+                    availableNames = availableNames,
+                    entities = entities,
+                    weightProvider = { state -> state.expressions.rightEyeBlink },
+                ),
+                createExpressionBinding(
+                    expressionId = AvatarExpressionId.JawOpen,
+                    runtimeDescriptor = runtimeDescriptor,
+                    availableNames = availableNames,
+                    entities = entities,
+                    weightProvider = { state -> state.expressions.jawOpen },
+                ),
+                createExpressionBinding(
+                    expressionId = AvatarExpressionId.Smile,
+                    runtimeDescriptor = runtimeDescriptor,
+                    availableNames = availableNames,
+                    entities = entities,
+                    weightProvider = { state -> state.expressions.mouthSmile },
+                ),
+            )
+        }
+
+        private fun createExpressionBinding(
+            expressionId: AvatarExpressionId,
+            runtimeDescriptor: VrmRuntimeAssetDescriptor,
+            availableNames: Set<String>,
+            entities: IntArray,
+            weightProvider: (AvatarRenderState) -> Float,
+        ): ExpressionBinding? {
+            val runtimeName = VrmExpressionMap.resolve(
+                expression = expressionId,
+                specVersion = runtimeDescriptor.specVersion,
+                availableNames = availableNames,
+            ) ?: return null
+            val descriptor = runtimeDescriptor.expressions.firstOrNull { expression ->
+                expression.runtimeName == runtimeName
+            } ?: return null
+            val morphBinds = descriptor.toMorphBinds(entities)
+            if (morphBinds.isEmpty()) {
+                return null
+            }
+            return ExpressionBinding(
+                weightProvider = weightProvider,
+                morphBinds = morphBinds,
+            )
+        }
+
+        private fun VrmExpressionDescriptor.toMorphBinds(entities: IntArray): List<MorphBind> {
+            return morphTargetBinds.mapNotNull { bind ->
+                val entity = entities.getOrNull(bind.nodeIndex) ?: return@mapNotNull null
+                MorphBind(
+                    entity = entity,
+                    morphTargetIndex = bind.morphTargetIndex,
+                    weight = bind.weight,
+                )
+            }
+        }
+
+        private fun multiplyColumnMajor(
+            left: FloatArray,
+            right: FloatArray,
+        ): FloatArray {
+            val result = FloatArray(MATRIX_SIZE)
+            for (column in 0 until MATRIX_EDGE) {
+                for (row in 0 until MATRIX_EDGE) {
+                    var value = 0f
+                    for (index in 0 until MATRIX_EDGE) {
+                        value += left[index * MATRIX_EDGE + row] * right[column * MATRIX_EDGE + index]
+                    }
+                    result[column * MATRIX_EDGE + row] = value
+                }
+            }
+            return result
+        }
+
+        private const val HEAD_BONE_NAME = "head"
+        private const val MATRIX_EDGE = 4
+        private const val MATRIX_SIZE = MATRIX_EDGE * MATRIX_EDGE
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
@@ -1,6 +1,7 @@
 package com.example.vtubercamera_kmp_ver.avatar.render
 
 import android.content.Context
+import android.util.Log
 import android.view.Surface
 import android.view.TextureView
 import android.view.ViewGroup
@@ -10,6 +11,7 @@ import com.google.android.filament.Camera
 import com.google.android.filament.Engine
 import com.google.android.filament.EntityManager
 import com.google.android.filament.Filament
+import com.google.android.filament.IndirectLight
 import com.google.android.filament.LightManager
 import com.google.android.filament.Renderer
 import com.google.android.filament.Scene
@@ -32,6 +34,7 @@ internal class AndroidFilamentAvatarRenderer(
     private val engine: Engine
     private val renderer: Renderer
     private val scene: Scene
+    private val indirectLight: IndirectLight
     private val view: FilamentView
     private val cameraEntity: Int
     private val lightEntity: Int
@@ -46,6 +49,7 @@ internal class AndroidFilamentAvatarRenderer(
     private var renderState: AvatarRenderState = AvatarRenderState.Neutral
     private var appliedRenderState: AvatarRenderState? = null
     private var destroyed = false
+    private var loggedFirstRenderedFrame = false
 
     init {
         initializeNativeBindings()
@@ -70,6 +74,10 @@ internal class AndroidFilamentAvatarRenderer(
         engine = Engine.create()
         renderer = engine.createRenderer()
         scene = engine.createScene()
+        indirectLight = IndirectLight.Builder()
+            .irradiance(1, floatArrayOf(1.0f, 1.0f, 1.0f))
+            .intensity(INDIRECT_LIGHT_INTENSITY)
+            .build(engine)
         view = engine.createView()
         cameraEntity = EntityManager.get().create()
         lightEntity = EntityManager.get().create()
@@ -78,6 +86,7 @@ internal class AndroidFilamentAvatarRenderer(
         displayHelper = DisplayHelper(context)
         assetLoader = AndroidVrmAssetLoader(engine)
         renderBridge = AndroidAvatarRenderBridge(
+            engine = engine,
             scene = scene,
             assetLoader = assetLoader,
             resourceCleaner = FilamentResourceCleaner(),
@@ -87,6 +96,7 @@ internal class AndroidFilamentAvatarRenderer(
 
         configureRenderer()
         configureView()
+        configureIndirectLight()
         configureLight()
         configureSurface()
     }
@@ -110,9 +120,14 @@ internal class AndroidFilamentAvatarRenderer(
         }
 
         applyRenderState()
+        renderBridge.prepareFrame()
         if (renderer.beginFrame(currentSwapChain, frameTimeNanos)) {
             renderer.render(view)
             renderer.endFrame()
+            if (!loggedFirstRenderedFrame) {
+                Log.d(LOG_TAG, "Rendered first avatar frame")
+                loggedFirstRenderedFrame = true
+            }
         }
     }
 
@@ -128,6 +143,8 @@ internal class AndroidFilamentAvatarRenderer(
         destroySwapChain()
         scene.removeEntity(lightEntity)
         engine.destroyEntity(lightEntity)
+        scene.indirectLight = null
+        engine.destroyIndirectLight(indirectLight)
         assetLoader.destroy()
         engine.destroyRenderer(renderer)
         engine.destroyView(view)
@@ -158,6 +175,10 @@ internal class AndroidFilamentAvatarRenderer(
             .intensity(LIGHT_INTENSITY)
             .build(engine, lightEntity)
         scene.addEntity(lightEntity)
+    }
+
+    private fun configureIndirectLight() {
+        scene.indirectLight = indirectLight
     }
 
     private fun applyRenderState() {
@@ -282,6 +303,8 @@ internal class AndroidFilamentAvatarRenderer(
         private const val LIGHT_COLOR_G = 0.98f
         private const val LIGHT_COLOR_B = 0.95f
         private const val LIGHT_INTENSITY = 110_000.0f
+        private const val INDIRECT_LIGHT_INTENSITY = 35_000.0f
+        private const val LOG_TAG = "VrmAvatarRender"
 
         private fun initializeNativeBindings() {
             if (nativeBindingsInitialized) {

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
@@ -1,9 +1,8 @@
 package com.example.vtubercamera_kmp_ver.avatar.render
 
 import android.content.Context
-import android.graphics.PixelFormat
 import android.view.Surface
-import android.view.SurfaceView
+import android.view.TextureView
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
@@ -29,7 +28,7 @@ internal class AndroidFilamentAvatarRenderer(
 ) {
     val hostView: AndroidView
 
-    private val surfaceView: SurfaceView
+    private val textureView: TextureView
     private val engine: Engine
     private val renderer: Renderer
     private val scene: Scene
@@ -51,12 +50,12 @@ internal class AndroidFilamentAvatarRenderer(
     init {
         initializeNativeBindings()
 
-        surfaceView = SurfaceView(context).apply {
+        textureView = TextureView(context).apply {
             layoutParams = FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT,
             )
-            holder.setFormat(PixelFormat.TRANSLUCENT)
+            isOpaque = false
         }
         hostView = FrameLayout(context).apply {
             layoutParams = ViewGroup.LayoutParams(
@@ -65,7 +64,7 @@ internal class AndroidFilamentAvatarRenderer(
             )
             clipChildren = false
             clipToPadding = false
-            addView(surfaceView)
+            addView(textureView)
         }
 
         engine = Engine.create()
@@ -173,12 +172,11 @@ internal class AndroidFilamentAvatarRenderer(
 
     private fun configureSurface() {
         uiHelper.isOpaque = false
-        uiHelper.isMediaOverlay = true
         uiHelper.renderCallback = object : UiHelper.RendererCallback {
             override fun onNativeWindowChanged(surface: Surface) {
                 destroySwapChain()
                 swapChain = engine.createSwapChain(surface, uiHelper.swapChainFlags)
-                displayHelper.attach(renderer, surfaceView.display)
+                displayHelper.attach(renderer, textureView.display)
             }
 
             override fun onDetachedFromSurface() {
@@ -191,7 +189,7 @@ internal class AndroidFilamentAvatarRenderer(
                 resize(width, height)
             }
         }
-        uiHelper.attachTo(surfaceView)
+        uiHelper.attachTo(textureView)
     }
 
     private fun resize(width: Int, height: Int) {

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
@@ -1,7 +1,6 @@
 package com.example.vtubercamera_kmp_ver.avatar.render
 
 import android.content.Context
-import android.util.Log
 import android.view.Surface
 import android.view.TextureView
 import android.view.ViewGroup
@@ -49,7 +48,6 @@ internal class AndroidFilamentAvatarRenderer(
     private var renderState: AvatarRenderState = AvatarRenderState.Neutral
     private var appliedRenderState: AvatarRenderState? = null
     private var destroyed = false
-    private var loggedFirstRenderedFrame = false
 
     init {
         initializeNativeBindings()
@@ -124,10 +122,6 @@ internal class AndroidFilamentAvatarRenderer(
         if (renderer.beginFrame(currentSwapChain, frameTimeNanos)) {
             renderer.render(view)
             renderer.endFrame()
-            if (!loggedFirstRenderedFrame) {
-                Log.d(LOG_TAG, "Rendered first avatar frame")
-                loggedFirstRenderedFrame = true
-            }
         }
     }
 
@@ -304,7 +298,6 @@ internal class AndroidFilamentAvatarRenderer(
         private const val LIGHT_COLOR_B = 0.95f
         private const val LIGHT_INTENSITY = 110_000.0f
         private const val INDIRECT_LIGHT_INTENSITY = 35_000.0f
-        private const val LOG_TAG = "VrmAvatarRender"
 
         private fun initializeNativeBindings() {
             if (nativeBindingsInitialized) {

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidFilamentAvatarRenderer.kt
@@ -83,6 +83,7 @@ internal class AndroidFilamentAvatarRenderer(
             assetLoader = assetLoader,
             resourceCleaner = FilamentResourceCleaner(),
             onSceneFramingChanged = ::updateSceneFraming,
+            onRenderStateChanged = ::updateRenderStateFromBridge,
         )
 
         configureRenderer()
@@ -96,7 +97,6 @@ internal class AndroidFilamentAvatarRenderer(
         nextRenderState: AvatarRenderState,
         onAvatarLoadFailure: (AvatarAssetLoadException) -> Unit,
     ) {
-        renderState = nextRenderState
         renderBridge.update(
             avatarSelection = avatarSelection,
             avatarRenderState = nextRenderState,
@@ -213,6 +213,10 @@ internal class AndroidFilamentAvatarRenderer(
         this.sceneFraming = sceneFraming
     }
 
+    private fun updateRenderStateFromBridge(nextState: AvatarRenderState) {
+        renderState = nextState
+    }
+
     private fun updateCameraLookAt(
         sceneFraming: AvatarSceneFraming,
         renderState: AvatarRenderState,
@@ -222,6 +226,11 @@ internal class AndroidFilamentAvatarRenderer(
         } else {
             0.0
         }
+        val expressionInfluence = (
+            renderState.expressions.jawOpen * JAW_WEIGHT +
+                renderState.expressions.mouthSmile * SMILE_WEIGHT +
+                ((renderState.expressions.leftEyeBlink + renderState.expressions.rightEyeBlink) * 0.5f) * BLINK_WEIGHT
+            ).coerceIn(0f, 1f).toDouble()
         val yawRadians = Math.toRadians(
             renderState.rig.headYawDegrees.toDouble().coerceIn(-MAX_YAW_DEGREES, MAX_YAW_DEGREES),
         )
@@ -231,8 +240,10 @@ internal class AndroidFilamentAvatarRenderer(
 
         camera.lookAt(
             sceneFraming.targetX + sin(yawRadians) * CAMERA_YAW_OFFSET_SCALE * trackingInfluence,
-            sceneFraming.targetY + sin(pitchRadians) * CAMERA_PITCH_OFFSET_SCALE * trackingInfluence,
-            sceneFraming.targetZ + sceneFraming.cameraDistance,
+            sceneFraming.targetY +
+                sin(pitchRadians) * CAMERA_PITCH_OFFSET_SCALE * trackingInfluence +
+                expressionInfluence * EXPRESSION_Y_OFFSET_SCALE,
+            sceneFraming.targetZ + sceneFraming.cameraDistance - expressionInfluence * EXPRESSION_Z_OFFSET_SCALE,
             sceneFraming.targetX,
             sceneFraming.targetY,
             sceneFraming.targetZ,
@@ -261,6 +272,11 @@ internal class AndroidFilamentAvatarRenderer(
         // Conservative clamps to avoid aggressive camera motion from noisy tracking input.
         private const val MAX_YAW_DEGREES = 45.0
         private const val MAX_PITCH_DEGREES = 30.0
+        private const val JAW_WEIGHT = 0.5f
+        private const val SMILE_WEIGHT = 0.35f
+        private const val BLINK_WEIGHT = 0.15f
+        private const val EXPRESSION_Y_OFFSET_SCALE = 0.18
+        private const val EXPRESSION_Z_OFFSET_SCALE = 0.24
         private const val LIGHT_DIRECTION_X = 0.35f
         private const val LIGHT_DIRECTION_Y = -1.0f
         private const val LIGHT_DIRECTION_Z = -0.45f

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidVrmAssetLoader.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidVrmAssetLoader.kt
@@ -13,7 +13,7 @@ internal class AndroidVrmAssetLoader(
 ) {
     private val materialProvider = UbershaderProvider(engine)
     private val assetLoader = AssetLoader(engine, materialProvider, EntityManager.get())
-    private val resourceLoader = ResourceLoader(engine)
+    private val resourceLoader = ResourceLoader(engine, true)
 
     fun loadAsset(bytes: ByteArray): Result<FilamentAsset> = runCatching {
         val asset = assetLoader.createAsset(ByteBuffer.wrap(bytes))

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidVrmAssetLoader.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidVrmAssetLoader.kt
@@ -6,6 +6,7 @@ import com.google.android.filament.gltfio.AssetLoader
 import com.google.android.filament.gltfio.FilamentAsset
 import com.google.android.filament.gltfio.ResourceLoader
 import com.google.android.filament.gltfio.UbershaderProvider
+import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 
 internal class AndroidVrmAssetLoader(
@@ -16,7 +17,8 @@ internal class AndroidVrmAssetLoader(
     private val resourceLoader = ResourceLoader(engine, true)
 
     fun loadAsset(bytes: ByteArray): Result<FilamentAsset> = runCatching {
-        val asset = assetLoader.createAsset(ByteBuffer.wrap(bytes))
+        val renderBytes = bytes.normalizeJsonEscapedSlashesForGltfio()
+        val asset = assetLoader.createAsset(ByteBuffer.wrap(renderBytes))
             ?: throw AvatarAssetLoadException(
                 kind = AvatarAssetLoadFailureKind.InvalidAsset,
             )
@@ -43,6 +45,108 @@ internal class AndroidVrmAssetLoader(
         resourceLoader.destroy()
         assetLoader.destroy()
         materialProvider.destroy()
+    }
+
+    private fun ByteArray.normalizeJsonEscapedSlashesForGltfio(): ByteArray {
+        if (size < GLB_MIN_SIZE || readIntLE(GLB_MAGIC_OFFSET) != GLB_MAGIC) {
+            return this
+        }
+
+        val declaredLength = readIntLE(GLB_LENGTH_OFFSET)
+        if (declaredLength > size || declaredLength < GLB_MIN_SIZE) {
+            return this
+        }
+
+        val chunks = mutableListOf<GlbChunk>()
+        var offset = GLB_HEADER_SIZE
+        var changed = false
+        while (offset <= declaredLength - GLB_CHUNK_HEADER_SIZE) {
+            val chunkLength = readIntLE(offset)
+            val chunkType = readIntLE(offset + GLB_CHUNK_TYPE_OFFSET)
+            if (chunkLength < 0 || chunkLength > declaredLength - offset - GLB_CHUNK_HEADER_SIZE) {
+                return this
+            }
+
+            val chunkStart = offset + GLB_CHUNK_HEADER_SIZE
+            val chunkEnd = chunkStart + chunkLength
+            val payload = copyOfRange(chunkStart, chunkEnd)
+            val nextPayload = if (chunkType == GLB_JSON_CHUNK_TYPE) {
+                val json = payload.decodeToString().trimEnd(' ', '\u0000', '\t', '\r', '\n')
+                val normalizedJson = json.replace("\\/", "/")
+                if (normalizedJson != json) {
+                    changed = true
+                    normalizedJson.encodeToByteArray().padGlbChunk()
+                } else {
+                    payload
+                }
+            } else {
+                payload
+            }
+            chunks += GlbChunk(type = chunkType, payload = nextPayload)
+            offset = chunkEnd
+        }
+
+        if (!changed) {
+            return this
+        }
+
+        val nextLength = GLB_HEADER_SIZE + chunks.sumOf { GLB_CHUNK_HEADER_SIZE + it.payload.size }
+        return ByteArrayOutputStream(nextLength).use { output ->
+            output.writeIntLE(GLB_MAGIC)
+            output.writeIntLE(GLB_VERSION)
+            output.writeIntLE(nextLength)
+            chunks.forEach { chunk ->
+                output.writeIntLE(chunk.payload.size)
+                output.writeIntLE(chunk.type)
+                output.write(chunk.payload)
+            }
+            output.toByteArray()
+        }
+    }
+
+    private fun ByteArray.padGlbChunk(): ByteArray {
+        val padding = (GLB_ALIGNMENT - (size % GLB_ALIGNMENT)) % GLB_ALIGNMENT
+        if (padding == 0) {
+            return this
+        }
+        return copyOf(size + padding).also { padded ->
+            for (index in size until padded.size) {
+                padded[index] = GLB_JSON_PADDING_BYTE
+            }
+        }
+    }
+
+    private fun ByteArray.readIntLE(offset: Int): Int {
+        return (this[offset].toInt() and 0xFF) or
+            ((this[offset + 1].toInt() and 0xFF) shl 8) or
+            ((this[offset + 2].toInt() and 0xFF) shl 16) or
+            ((this[offset + 3].toInt() and 0xFF) shl 24)
+    }
+
+    private fun ByteArrayOutputStream.writeIntLE(value: Int) {
+        write(value and 0xFF)
+        write((value ushr 8) and 0xFF)
+        write((value ushr 16) and 0xFF)
+        write((value ushr 24) and 0xFF)
+    }
+
+    private data class GlbChunk(
+        val type: Int,
+        val payload: ByteArray,
+    )
+
+    private companion object {
+        private const val GLB_MAGIC = 0x46546C67
+        private const val GLB_VERSION = 2
+        private const val GLB_JSON_CHUNK_TYPE = 0x4E4F534A
+        private const val GLB_MAGIC_OFFSET = 0
+        private const val GLB_LENGTH_OFFSET = 8
+        private const val GLB_HEADER_SIZE = 12
+        private const val GLB_CHUNK_HEADER_SIZE = 8
+        private const val GLB_CHUNK_TYPE_OFFSET = 4
+        private const val GLB_MIN_SIZE = GLB_HEADER_SIZE + GLB_CHUNK_HEADER_SIZE
+        private const val GLB_ALIGNMENT = 4
+        private const val GLB_JSON_PADDING_BYTE = 0x20.toByte()
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/tracking/AndroidFaceTrackingToAvatarMapper.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/tracking/AndroidFaceTrackingToAvatarMapper.kt
@@ -1,0 +1,55 @@
+package com.example.vtubercamera_kmp_ver.avatar.tracking
+
+import com.example.vtubercamera_kmp_ver.avatar.model.AvatarExpressionWeights
+import com.example.vtubercamera_kmp_ver.avatar.model.AvatarRigState
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
+
+/**
+ * Android renderer 向けに追跡値を軽く補正し、カメラオフセットや表情反映を見えやすくする。
+ */
+internal class AndroidFaceTrackingToAvatarMapper {
+    fun map(renderState: AvatarRenderState): AvatarRenderState {
+        if (!renderState.isTracking) {
+            return renderState
+        }
+
+        val correctedRig = AvatarRigState(
+            headYawDegrees = (renderState.rig.headYawDegrees * YAW_GAIN).coerceIn(-MAX_YAW_DEGREES, MAX_YAW_DEGREES),
+            headPitchDegrees = (renderState.rig.headPitchDegrees * PITCH_GAIN).coerceIn(-MAX_PITCH_DEGREES, MAX_PITCH_DEGREES),
+            headRollDegrees = (renderState.rig.headRollDegrees * ROLL_GAIN).coerceIn(-MAX_ROLL_DEGREES, MAX_ROLL_DEGREES),
+        )
+
+        val correctedExpressions = AvatarExpressionWeights(
+            leftEyeBlink = emphasizeBlink(renderState.expressions.leftEyeBlink),
+            rightEyeBlink = emphasizeBlink(renderState.expressions.rightEyeBlink),
+            jawOpen = emphasizeJaw(renderState.expressions.jawOpen),
+            mouthSmile = emphasizeSmile(renderState.expressions.mouthSmile),
+        )
+
+        return renderState.copy(
+            rig = correctedRig,
+            expressions = correctedExpressions,
+        )
+    }
+
+    private fun emphasizeBlink(value: Float): Float {
+        return ((value - 0.1f) / 0.82f).coerceIn(0f, 1f)
+    }
+
+    private fun emphasizeJaw(value: Float): Float {
+        return (value * 1.2f).coerceIn(0f, 1f)
+    }
+
+    private fun emphasizeSmile(value: Float): Float {
+        return ((value - 0.08f) / 0.7f).coerceIn(0f, 1f)
+    }
+
+    private companion object {
+        private const val YAW_GAIN = 1.15f
+        private const val PITCH_GAIN = 1.08f
+        private const val ROLL_GAIN = 1.05f
+        private const val MAX_YAW_DEGREES = 45f
+        private const val MAX_PITCH_DEGREES = 30f
+        private const val MAX_ROLL_DEGREES = 35f
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParser.kt
@@ -132,7 +132,7 @@ object VrmExtensionParser {
                 meta = vrm0Extension.childObject("meta").toParsedVrm0Meta(),
                 thumbnailImageIndex = resolveVrm0ThumbnailImageIndex(vrm0Extension),
                 humanoidBones = vrm0Extension.parseVrm0HumanoidBones(),
-                expressions = vrm0Extension.parseVrm0Expressions(),
+                expressions = vrm0Extension.parseVrm0Expressions(root = this),
                 lookAt = vrm0Extension.childObject("firstPerson")?.toParsedVrm0LookAt(),
                 firstPerson = vrm0Extension.childObject("firstPerson")?.toParsedFirstPerson(),
             )
@@ -232,7 +232,8 @@ object VrmExtensionParser {
             .orEmpty()
     }
 
-    private fun JsonObject.parseVrm0Expressions(): List<ParsedVrmExpression> {
+    private fun JsonObject.parseVrm0Expressions(root: JsonObject): List<ParsedVrmExpression> {
+        val nodeIndexByMeshIndex = root.resolveNodeIndexByMeshIndex()
         return childObject("blendShapeMaster")
             ?.childArray("blendShapeGroups")
             ?.mapNotNull { element ->
@@ -248,6 +249,7 @@ object VrmExtensionParser {
                         bindsKey = "binds",
                         nodeKey = "mesh",
                         weightMultiplier = 0.01f,
+                        nodeIndexResolver = { meshIndex -> nodeIndexByMeshIndex[meshIndex] },
                     ),
                     overrideBlink = null,
                     overrideLookAt = null,
@@ -321,11 +323,13 @@ object VrmExtensionParser {
         bindsKey: String,
         nodeKey: String,
         weightMultiplier: Float,
+        nodeIndexResolver: (Int) -> Int? = { nodeIndex -> nodeIndex },
     ): List<ParsedMorphTargetBind> {
         return childArray(bindsKey)
             ?.mapNotNull { element ->
                 val bindObject = element.jsonObjectOrNull() ?: return@mapNotNull null
-                val nodeIndex = bindObject.int(nodeKey) ?: return@mapNotNull null
+                val rawNodeIndex = bindObject.int(nodeKey) ?: return@mapNotNull null
+                val nodeIndex = nodeIndexResolver(rawNodeIndex) ?: return@mapNotNull null
                 val morphTargetIndex = bindObject.int("index") ?: return@mapNotNull null
                 val rawWeight = bindObject.float("weight") ?: return@mapNotNull null
                 ParsedMorphTargetBind(
@@ -334,6 +338,16 @@ object VrmExtensionParser {
                     weight = rawWeight * weightMultiplier,
                 )
             }
+            .orEmpty()
+    }
+
+    private fun JsonObject.resolveNodeIndexByMeshIndex(): Map<Int, Int> {
+        return childArray("nodes")
+            ?.mapIndexedNotNull { nodeIndex, element ->
+                val meshIndex = element.jsonObjectOrNull()?.int("mesh") ?: return@mapIndexedNotNull null
+                meshIndex to nodeIndex
+            }
+            ?.toMap()
             .orEmpty()
     }
 

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParserTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmExtensionParserTest.kt
@@ -51,6 +51,10 @@ class VrmExtensionParserTest {
                       }
                     }
                   },
+                  "nodes": [
+                    {"name": "Root"},
+                    {"name": "Face", "mesh": 5}
+                  ],
                   "textures": [{"source": 0}],
                   "images": [{"bufferView": 0, "mimeType": "image/png"}],
                   "bufferViews": [{"buffer": 0, "byteOffset": 0, "byteLength": 4}]
@@ -69,6 +73,7 @@ class VrmExtensionParserTest {
         assertEquals("head", descriptor.humanoidBones.first().boneName)
         assertEquals("leftUpperArm", descriptor.humanoidBones[1].boneName)
         assertEquals("joy", descriptor.expressions.single().runtimeName)
+        assertEquals(1, descriptor.expressions.single().morphTargetBinds.single().nodeIndex)
         assertEquals(1f, descriptor.expressions.single().morphTargetBinds.single().weight)
         assertEquals("Bone", descriptor.lookAt?.type)
         assertEquals(3, descriptor.firstPerson?.firstPersonBone)


### PR DESCRIPTION
### Motivation
- Improve Android renderer responsiveness by applying platform-specific corrections to tracked avatar state so head pose and expressions are more visible in the rendered result.
- Surface expression-driven camera offsets (blink/jaw/smile) into the renderer so facial expressions influence framing and perceived motion.

### Description
- Added a new mapper `AndroidFaceTrackingToAvatarMapper` (`composeApp/src/androidMain/kotlin/.../avatar/tracking/AndroidFaceTrackingToAvatarMapper.kt`) that amplifies/clamps head pose and emphasizes expression weights for Android rendering.
- Wired `AndroidAvatarRenderBridge` to run incoming `AvatarRenderState` through the mapper and forward the corrected state via a new `onRenderStateChanged` callback.
- Updated `AndroidFilamentAvatarRenderer` to accept `onRenderStateChanged`, consume bridged render state via `updateRenderStateFromBridge`, and compute an `expressionInfluence` that adjusts camera `lookAt` Y/Z offsets based on jaw/smile/blink with new tuning constants.
- Minor API and constant additions in the Android renderer to support expression weights and mapping logic (`JAW_WEIGHT`, `SMILE_WEIGHT`, `BLINK_WEIGHT`, `EXPRESSION_Y_OFFSET_SCALE`, `EXPRESSION_Z_OFFSET_SCALE`).

### Testing
- Attempted an Android Kotlin compile with `./gradlew :composeApp:compileDebugKotlinAndroid`, which failed in this environment due to an unresolved Gradle plugin `org.gradle.toolchains.foojay-resolver-convention:1.0.0` from configured repositories.
- No other automated test suites were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0cbc97bb08330894c7ea3c145933d)