### PR TITLE
Implement iOS ARKit avatar state forwarding

### DIFF
--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3">
-   <BuildAction>
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForRunning = "YES">
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "9D7D5F02EAD009405095B4B4"
@@ -15,12 +21,26 @@
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
-   <LaunchAction
-      useCustomWorkingDirectory = "YES"
+   <TestAction
       buildConfiguration = "Debug"
-      allowLocationSimulation = "YES"
-      customWorkingDirectory = "/Users/j____takumi/Android_development/VtuberCamera_KMP_ver/iosApp">
-      <BuildableProductRunnable>
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "YES"
+      customWorkingDirectory = "/Users/j____takumi/Android_development/VtuberCamera_KMP_ver/iosApp"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "9D7D5F02EAD009405095B4B4"
@@ -34,4 +54,18 @@
          referenceType = "1">
       </LocationScenarioReference>
    </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
 </Scheme>

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -1,30 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.7">
-   <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+   version = "1.3">
+   <BuildAction>
       <BuildActionEntries>
          <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3C4D5E6F708192A3B4C5D6E7"
-               BuildableName = "iosAppTests.xctest"
-               BlueprintName = "iosAppTests"
-               ReferencedContainer = "container:iosApp.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForRunning = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "9D7D5F02EAD009405095B4B4"
@@ -35,39 +15,12 @@
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
-   <TestAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3C4D5E6F708192A3B4C5D6E7"
-               BuildableName = "iosAppTests.xctest"
-               BlueprintName = "iosAppTests"
-               ReferencedContainer = "container:iosApp.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
-   </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      launchStyle = "0"
       useCustomWorkingDirectory = "YES"
-      customWorkingDirectory = "/Users/j____takumi/Android_development/VtuberCamera_KMP_ver/iosApp"
-      ignoresPersistentStateOnLaunch = "NO"
-      debugDocumentVersioning = "YES"
-      debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      buildConfiguration = "Debug"
+      allowLocationSimulation = "YES"
+      customWorkingDirectory = "/Users/j____takumi/Android_development/VtuberCamera_KMP_ver/iosApp">
+      <BuildableProductRunnable>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "9D7D5F02EAD009405095B4B4"
@@ -81,18 +34,4 @@
          referenceType = "1">
       </LocationScenarioReference>
    </LaunchAction>
-   <ProfileAction
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      savedToolIdentifier = ""
-      useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
-   </ProfileAction>
-   <AnalyzeAction
-      buildConfiguration = "Debug">
-   </AnalyzeAction>
-   <ArchiveAction
-      buildConfiguration = "Release"
-      revealArchiveInOrganizer = "YES">
-   </ArchiveAction>
 </Scheme>

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -7,6 +7,20 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3C4D5E6F708192A3B4C5D6E7"
+               BuildableName = "iosAppTests.xctest"
+               BlueprintName = "iosAppTests"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
@@ -27,6 +41,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3C4D5E6F708192A3B4C5D6E7"
+               BuildableName = "iosAppTests.xctest"
+               BlueprintName = "iosAppTests"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/iosApp/iosApp/AvatarRender/FilamentAvatarRenderer.swift
+++ b/iosApp/iosApp/AvatarRender/FilamentAvatarRenderer.swift
@@ -154,3 +154,5 @@ final class FilamentAvatarRenderer {
         ])
     }
 }
+
+extension FilamentAvatarRenderer: IOSAvatarRenderStateApplying {}

--- a/iosApp/iosApp/AvatarRender/IOSAvatarRenderBridge.swift
+++ b/iosApp/iosApp/AvatarRender/IOSAvatarRenderBridge.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 @MainActor
+protocol IOSAvatarRenderStateApplying: AnyObject {
+    func applySelectedAvatar(_ payload: IOSVrmAssetPayload)
+    func clearAvatar()
+    func updateAvatarState(_ state: VTCAvatarRenderState)
+}
+
+@MainActor
 final class IOSAvatarRenderBridge {
     static let avatarSelectionDidChangeNotification =
         Notification.Name("com.example.vtubercamera_kmp_ver.avatar.selectionDidChange")
@@ -21,11 +28,11 @@ final class IOSAvatarRenderBridge {
     static let jawOpenKey = "jawOpen"
     static let mouthSmileKey = "mouthSmile"
 
-    private weak var renderer: FilamentAvatarRenderer?
+    private weak var renderer: IOSAvatarRenderStateApplying?
     private var observerTokens: [NSObjectProtocol] = []
     private let reusableRenderState = VTCAvatarRenderState()
 
-    init(renderer: FilamentAvatarRenderer) {
+    init(renderer: IOSAvatarRenderStateApplying) {
         self.renderer = renderer
     }
 
@@ -80,15 +87,25 @@ final class IOSAvatarRenderBridge {
     }
 
     /// Reuses a single render-state object while applying the latest tracking notification fields.
-    private func handleAvatarRenderStateChanged(_ notification: Notification) {
-        reusableRenderState.headYawDegrees = Self.floatValue(notification.userInfo, key: Self.headYawDegreesKey)
-        reusableRenderState.headPitchDegrees = Self.floatValue(notification.userInfo, key: Self.headPitchDegreesKey)
-        reusableRenderState.headRollDegrees = Self.floatValue(notification.userInfo, key: Self.headRollDegreesKey)
-        reusableRenderState.leftEyeBlink = Self.floatValue(notification.userInfo, key: Self.leftEyeBlinkKey)
-        reusableRenderState.rightEyeBlink = Self.floatValue(notification.userInfo, key: Self.rightEyeBlinkKey)
-        reusableRenderState.jawOpen = Self.floatValue(notification.userInfo, key: Self.jawOpenKey)
-        reusableRenderState.mouthSmile = Self.floatValue(notification.userInfo, key: Self.mouthSmileKey)
+    func handleAvatarRenderStateChanged(_ notification: Notification) {
+        Self.applyRenderState(from: notification.userInfo, to: reusableRenderState)
         renderer?.updateAvatarState(reusableRenderState)
+    }
+
+    static func makeRenderState(from userInfo: [AnyHashable: Any]?) -> VTCAvatarRenderState {
+        let state = VTCAvatarRenderState()
+        applyRenderState(from: userInfo, to: state)
+        return state
+    }
+
+    static func applyRenderState(from userInfo: [AnyHashable: Any]?, to state: VTCAvatarRenderState) {
+        state.headYawDegrees = floatValue(userInfo, key: headYawDegreesKey)
+        state.headPitchDegrees = floatValue(userInfo, key: headPitchDegreesKey)
+        state.headRollDegrees = floatValue(userInfo, key: headRollDegreesKey)
+        state.leftEyeBlink = floatValue(userInfo, key: leftEyeBlinkKey)
+        state.rightEyeBlink = floatValue(userInfo, key: rightEyeBlinkKey)
+        state.jawOpen = floatValue(userInfo, key: jawOpenKey)
+        state.mouthSmile = floatValue(userInfo, key: mouthSmileKey)
     }
 
     /// Returns the bridged float value or `0` when the key is absent, which the renderer treats as

--- a/iosApp/iosApp/VTCFilamentRendererBridge.h
+++ b/iosApp/iosApp/VTCFilamentRendererBridge.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface VTCFilamentRendererBridge : NSObject
 
 @property (nonatomic, readonly) UIView *renderView;
+@property (nonatomic, readonly) VTCAvatarRenderState *latestAvatarState;
 
 /// Returns whether Filament headers are discoverable at compile time for this target.
 /// This does not guarantee that the Filament SDK is fully configured, linkable, or runtime-ready.

--- a/iosApp/iosApp/VTCFilamentRendererBridge.mm
+++ b/iosApp/iosApp/VTCFilamentRendererBridge.mm
@@ -29,9 +29,22 @@ static NSString *const VTCFilamentRendererErrorDomain = @"io.github.jtakumi.Vtub
 @implementation VTCAvatarRenderState
 @end
 
+static VTCAvatarRenderState *VTCCopyAvatarRenderState(VTCAvatarRenderState *state) {
+    VTCAvatarRenderState *copy = [[VTCAvatarRenderState alloc] init];
+    copy.headYawDegrees = state.headYawDegrees;
+    copy.headPitchDegrees = state.headPitchDegrees;
+    copy.headRollDegrees = state.headRollDegrees;
+    copy.leftEyeBlink = state.leftEyeBlink;
+    copy.rightEyeBlink = state.rightEyeBlink;
+    copy.jawOpen = state.jawOpen;
+    copy.mouthSmile = state.mouthSmile;
+    return copy;
+}
+
 @interface VTCFilamentRendererBridge ()
 
 @property (nonatomic, strong) UIView *renderView;
+@property (nonatomic, strong) VTCAvatarRenderState *latestAvatarState;
 
 @end
 
@@ -45,6 +58,7 @@ static NSString *const VTCFilamentRendererErrorDomain = @"io.github.jtakumi.Vtub
     self = [super init];
     if (self != nil) {
         _renderView = [[VTCMetalContainerView alloc] initWithFrame:CGRectZero];
+        _latestAvatarState = [[VTCAvatarRenderState alloc] init];
     }
     return self;
 }
@@ -78,8 +92,9 @@ static NSString *const VTCFilamentRendererErrorDomain = @"io.github.jtakumi.Vtub
 }
 
 - (void)updateAvatarState:(VTCAvatarRenderState *)state {
-    // Placeholder until tracked avatar pose and expression state drives the renderer.
-    (void)state;
+    self.latestAvatarState = VTCCopyAvatarRenderState(state);
+    // The future Filament-backed implementation should consume latestAvatarState here to apply
+    // head pose and expression channels to the loaded avatar.
 }
 
 - (void)resizeToBounds:(CGRect)bounds contentScale:(CGFloat)contentScale {

--- a/iosApp/iosAppTests/IOSAvatarRenderBridgeTests.swift
+++ b/iosApp/iosAppTests/IOSAvatarRenderBridgeTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import VtuberCamera_KMP_ver
+
+@MainActor
+struct IOSAvatarRenderBridgeTests {
+    @Test
+    func makeRenderStateMapsNotificationPayloadToAvatarChannels() {
+        let state = IOSAvatarRenderBridge.makeRenderState(from: [
+            IOSAvatarRenderBridge.headYawDegreesKey: NSNumber(value: 12.5),
+            IOSAvatarRenderBridge.headPitchDegreesKey: NSNumber(value: -4.25),
+            IOSAvatarRenderBridge.headRollDegreesKey: NSNumber(value: 7.75),
+            IOSAvatarRenderBridge.leftEyeBlinkKey: NSNumber(value: 0.9),
+            IOSAvatarRenderBridge.rightEyeBlinkKey: NSNumber(value: 0.35),
+            IOSAvatarRenderBridge.jawOpenKey: NSNumber(value: 0.62),
+            IOSAvatarRenderBridge.mouthSmileKey: NSNumber(value: 0.48),
+        ])
+
+        #expect(state.headYawDegrees == 12.5)
+        #expect(state.headPitchDegrees == -4.25)
+        #expect(state.headRollDegrees == 7.75)
+        #expect(state.leftEyeBlink == 0.9)
+        #expect(state.rightEyeBlink == 0.35)
+        #expect(state.jawOpen == 0.62)
+        #expect(state.mouthSmile == 0.48)
+    }
+
+    @Test
+    func makeRenderStateDefaultsMissingPayloadFieldsToNeutral() {
+        let state = IOSAvatarRenderBridge.makeRenderState(from: [
+            IOSAvatarRenderBridge.jawOpenKey: NSNumber(value: 0.5),
+        ])
+
+        #expect(state.headYawDegrees == 0)
+        #expect(state.headPitchDegrees == 0)
+        #expect(state.headRollDegrees == 0)
+        #expect(state.leftEyeBlink == 0)
+        #expect(state.rightEyeBlink == 0)
+        #expect(state.jawOpen == 0.5)
+        #expect(state.mouthSmile == 0)
+    }
+
+    @Test
+    func handleAvatarRenderStateChangedForwardsMappedStateToRenderer() {
+        let renderer = SpyRenderStateRenderer()
+        let bridge = IOSAvatarRenderBridge(renderer: renderer)
+        let notification = Notification(
+            name: IOSAvatarRenderBridge.avatarRenderStateDidChangeNotification,
+            object: nil,
+            userInfo: [
+                IOSAvatarRenderBridge.headYawDegreesKey: NSNumber(value: -18),
+                IOSAvatarRenderBridge.leftEyeBlinkKey: NSNumber(value: 1),
+                IOSAvatarRenderBridge.jawOpenKey: NSNumber(value: 0.72),
+                IOSAvatarRenderBridge.mouthSmileKey: NSNumber(value: 0.31),
+            ]
+        )
+
+        bridge.handleAvatarRenderStateChanged(notification)
+
+        let state = renderer.latestState
+        #expect(state?.headYawDegrees == -18)
+        #expect(state?.headPitchDegrees == 0)
+        #expect(state?.leftEyeBlink == 1)
+        #expect(state?.rightEyeBlink == 0)
+        #expect(state?.jawOpen == 0.72)
+        #expect(state?.mouthSmile == 0.31)
+    }
+
+    @Test
+    func filamentRendererBridgeStoresLatestAvatarStateCopy() {
+        let bridge = VTCFilamentRendererBridge()
+        let state = VTCAvatarRenderState()
+        state.headYawDegrees = 22
+        state.headPitchDegrees = -6
+        state.headRollDegrees = 3
+        state.leftEyeBlink = 0.25
+        state.rightEyeBlink = 0.5
+        state.jawOpen = 0.75
+        state.mouthSmile = 1
+
+        bridge.updateAvatarState(state)
+        state.headYawDegrees = 99
+        state.jawOpen = 0
+
+        #expect(bridge.latestAvatarState.headYawDegrees == 22)
+        #expect(bridge.latestAvatarState.headPitchDegrees == -6)
+        #expect(bridge.latestAvatarState.headRollDegrees == 3)
+        #expect(bridge.latestAvatarState.leftEyeBlink == 0.25)
+        #expect(bridge.latestAvatarState.rightEyeBlink == 0.5)
+        #expect(bridge.latestAvatarState.jawOpen == 0.75)
+        #expect(bridge.latestAvatarState.mouthSmile == 1)
+    }
+}
+
+@MainActor
+private final class SpyRenderStateRenderer: IOSAvatarRenderStateApplying {
+    private(set) var latestState: VTCAvatarRenderState?
+
+    func applySelectedAvatar(_ payload: IOSVrmAssetPayload) {}
+
+    func clearAvatar() {}
+
+    func updateAvatarState(_ state: VTCAvatarRenderState) {
+        latestState = state
+    }
+}


### PR DESCRIPTION
## Summary
- Wired the iOS ARKit tracking path into the renderer bridge so head pose and facial expressions reach the native avatar state pipeline.
- Added a small render-state application protocol to decouple `IOSAvatarRenderBridge` from the concrete Filament renderer and make the bridge testable.
- Updated the Obj-C++ renderer bridge to retain the latest avatar state copy instead of dropping updates as a no-op.
- Added Swift tests covering payload mapping, neutral fallback for missing fields, and state-copy retention.

## Testing
- `./gradlew :composeApp:testDebugUnitTest` passed.
- `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build` passed.
- `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' test` passed.