### PR TITLE
Sync Codex mobile-coding-conventions skill with upstream

### DIFF
--- a/.claude/commands/mobile-coding-conventions.md
+++ b/.claude/commands/mobile-coding-conventions.md
@@ -1,0 +1,143 @@
+---
+description: Android/iOS/KMP のコーディング規約に従って実装・レビューする
+argument-hint: 実装対象、Android/iOS/KMP、確認したい観点を指定してください
+---
+
+実装対象: $ARGUMENTS
+
+以下の手順とチェックリストに従って、Android / iOS / KMP コードの実装またはレビューを行ってください。
+
+## 手順
+
+1. **対象を特定する**
+   - Android / iOS / KMP shared のどこを変更するかを明確にする
+   - UI 変更か、状態管理変更か、データ変換かを分ける
+
+2. **クロスカット規約を先に確認する**
+   - ユーザー向け文字列はリソース参照になっているか
+   - nullable 値を `!!` や強制アンラップで誤魔化していないか
+   - method の直前には機能・責務・失敗時の振る舞いを示すコメントがあるか
+   - package / file / type / method の命名が同じ責務を指しているか
+   - UI state とビジネスロジックが正しい層に置かれているか
+   - `catch` / `onFailure` / `try?` でエラーを握りつぶしていないか
+
+3. **プラットフォーム別レビューを適用する**
+   - **Kotlin / KMP**: ファイル構成、命名、整形、idiomatic Kotlin、public/shared API の明確さ
+   - **Swift / iOS**: API 命名、argument label、DocC、state 所有権、SwiftUI 設計
+
+4. **仕上げチェックを行う**
+   - ファイル末尾に空行があるか
+   - 異常系・失敗パスが考慮されているか
+
+---
+
+## Kotlin / KMP チェック
+
+### ファイル構成・命名
+- package とディレクトリ構成を一致させる
+- 単一宣言ファイルは宣言名と一致、複数宣言ファイルは役割を説明する UpperCamelCase にする
+- KMP: `commonMain` では suffix なし、`androidMain` / `iosMain` では source set suffix を付ける
+- `Manager` / `Wrapper` / `Util` のような意味の薄い名前を避ける
+- class 内の順序: property / init → secondary constructor → method → companion object
+
+### 命名規約
+- package: lowercase、class / object: UpperCamelCase、function / property / local variable: lowerCamelCase
+- `const` と deeply immutable な top-level / object `val` のみ SCREAMING_SNAKE_CASE
+- backing property は `_name` 形式
+- 略語: 2 文字 → `IO`、3 文字以上 → `Xml` / `Http`（先頭大文字のみ）
+- public / shared API と platform type を返す宣言では型を明示する
+
+### 整形
+- indent: 4 spaces、tab 禁止、opening brace は行末
+- binary operator / control flow keyword / named argument の `=` 前後に space
+- `.` / `?.` / `::` / nullable `?` 周りに不要な space を入れない
+- modifier 順は公式順に従う
+- declaration site の trailing comma を活用する
+
+### Idiomatic Kotlin
+- 単一式 function は expression body を優先する
+- `val` と immutable collection interface を優先する
+- default parameter を overload より優先する
+- binary condition → `if`、3 分岐以上 → `when`
+- nullable Boolean は `== true` / `== false` で明示する
+- `forEach` より `for` loop が読みやすい場面を優先する
+
+### KDoc
+- 長い KDoc は `/**` 形式、各行を `*` で揃える
+- `@param` / `@return` は長い補足が必要な場合のみ（通常は本文中に `[parameter]`）
+- public 以外でも、責務や副作用が読み取りにくい method には直前コメントを付ける
+
+---
+
+## Swift / iOS チェック
+
+### API 設計の基本
+- use site の clarity を最優先し、brevity を目的化しない
+- declaration 単体でなく実際の呼び出し形で API 名を評価する
+- free function より method / property を優先する
+
+### 命名・argument label
+- type / protocol: UpperCamelCase、それ以外: lowerCamelCase
+- acronym は Swift の case convention に合わせる（`utf8Bytes`、`isRepresentableAsASCII`）
+- first argument が文法上 base name の続きなら label を省略、そうでなければ付ける
+- preposition を含む意味なら label に役割を持たせる（`remove(at:)`、`move(from:to:)`）
+
+### Mutation / Boolean / Protocol
+- 副作用のない API: 名詞句や assertion、副作用のある API: 命令形の動詞句
+- mutating / nonmutating の pair を一貫させる（`sort` / `sorted`）
+- Boolean は `isEmpty` / `contains(_:)` のように assertion として読める形に
+- capability protocol は `-ing` / `-able`、ものを表す protocol は名詞
+
+### DocC
+- public な宣言には DocC コメントを書き、summary を 1 文断片で始める
+- `- Parameter:` / `- Returns:` / `- Throws:` / `- Note:` を必要に応じて使う
+- method の直前コメントで機能、利用条件、副作用、失敗時の扱いを示す
+
+---
+
+## 状態・責務の分離
+
+| 層 | Android | iOS |
+|---|---|---|
+| 意味のある画面 state / ロジック | ViewModel | ObservableObject |
+| 短命な UI state（開閉・フォーカス） | Compose 内 | View 内 |
+| UI | Jetpack Compose | SwiftUI |
+
+---
+
+## エラー・異常系
+
+- 権限拒否 / 入力不正 / 読み込み失敗 / パース失敗 / 空データを必ず洗う
+- `catch` / `runCatching` / `onFailure` / Swift の `try?` / `catch` でエラーを無言で捨てない
+- 失敗時: ログ・状態更新・再送出・Result 変換のいずれかで扱いを残す
+- 一時回避で握りつぶす場合は理由と影響範囲をコメントで明示する
+
+---
+
+## 出力フォーマット
+
+返答には必要に応じて以下を含めてください。
+
+- **Target**: Android / iOS / KMP のどこを実装するか
+- **UI framework**: Jetpack Compose / SwiftUI
+- **Kotlin style check**: ファイル構成・命名・整形・idiomatic Kotlin の確認結果
+- **Swift style check**: API naming・argument label・DocC・mutating 設計の確認結果
+- **State placement**: ViewModel / ObservableObject / View の責務分担
+- **Resource check**: 文字列リソース化の有無
+- **Null safety check**: `!!` / 強制アンラップの排除方針
+- **Method comment check**: method コメントと責務説明の確認結果
+- **Naming consistency check**: package・file・type・method の命名整合性
+- **Error paths**: 想定した異常系
+- **Swallowed error check**: 握りつぶしの有無と失敗時の扱い
+- **Final checklist**: 実装前後に確認した項目
+
+---
+
+## ガードレール
+
+- `Util` / `Manager` / `Wrapper` のような意味の薄い名前で責務を曖昧にしない
+- `!!` や強制アンラップを常用しない
+- error / exception を空の `catch` や無言の `onFailure` で握りつぶさない
+- Android の UI 層にロジックを寄せすぎない
+- iOS View に長寿命 state や画面意味を持つロジックを抱え込ませない
+- 正常系だけで完了扱いにしない

--- a/.codex/mobile-coding-conventions/SKILL.md
+++ b/.codex/mobile-coding-conventions/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mobile-coding-conventions
-description: Guide Android, iOS, and KMP implementation with this repo's mobile coding conventions. Use when writing, reviewing, or refactoring Kotlin or Swift code and you need checks for official naming and formatting, source file organization, method comments, naming consistency, swallowed errors, string resources, null safety, MVVM or ObservableObject responsibilities, Jetpack Compose or SwiftUI patterns, error handling, and final newline.
+description: 'Guide Kotlin and Swift implementation with repo coding conventions. Use when writing, reviewing, or refactoring Android, iOS, or KMP code and you need checks for Kotlin official naming, file organization, formatting, idiomatic language usage, method comments, naming consistency, swallowed errors, Swift API naming and documentation design, string resources, null safety, MVVM, ViewModel or ObservableObject responsibilities, Jetpack Compose, SwiftUI, error handling, and final newline.'
+argument-hint: '実装対象、Android/iOS/KMP、確認したい観点を指定してください'
 ---
 
 # Mobile Coding Conventions

--- a/.codex/mobile-coding-conventions/references/conventions.md
+++ b/.codex/mobile-coding-conventions/references/conventions.md
@@ -10,6 +10,10 @@ Keep this file aligned with the upstream repo skill when the conventions change.
 - Swift checks
 - Kotlin checks
 - Recommended procedure
+- Quality checks
+- Guardrails
+- Output format
+- Example prompts
 
 ## What This Guidance Covers
 
@@ -99,6 +103,22 @@ Keep this file aligned with the upstream repo skill when the conventions change.
 - `catch` した error / exception を無言で捨てず、少なくともログ、状態更新、再送出、Result への変換のいずれかで扱う
 - `runCatching`、`onFailure`、callback の failure branch、Swift の `try?` や `catch` でも同様に、失敗が観測可能か確認する
 - 一時回避で握りつぶす場合は理由と影響範囲をコメントで明示し、恒久化しない
+
+### 12. Swift の naming と API design をどう揃えるか
+
+- use site の明確さを最優先し、短さより clarity を優先する
+- type / protocol は UpperCamelCase、property / method / parameter / enum case は lowerCamelCase にする
+- parameter や associated type は型名ではなく役割で命名し、曖昧な `data`、`value`、`manager` の乱用を避ける
+- fluent に読める base name と argument label を選び、意味が分からなくなる unlabeled call を避ける
+- mutating と nonmutating の pair は `sort` / `sorted`、`formUnion` / `union` のように意味と副作用が対で分かる命名にする
+
+### 13. Swift の documentation と API surface をどう揃えるか
+
+- public な型や意味のある宣言には DocC コメントを書き、summary から始める
+- method / initializer / subscript / property は「何をするか」「何を返すか」「何にアクセスするか」を summary で表す
+- default parameter は method family の乱立より優先し、よく使う既定値を後ろ側の parameter に寄せる
+- Boolean property / method は `is`、`has`、assertion として読める名前にする
+- capability を表す protocol は `able`、`ible`、`ing` で終える候補を検討し、もの自体を表す protocol は名詞にする
 
 ## Swift Checks
 
@@ -201,12 +221,12 @@ Keep this file aligned with the upstream repo skill when the conventions change.
    - 既存コードの命名と整形が大きく崩れないように合わせる
    - Kotlin は package / directory、ファイル名、class layout、modifier 順、annotation 位置、trailing comma を確認する
    - KMP では `commonMain` と platform source set でファイル suffix の付け方を確認する
-- 単一式 function の expression body、`val` 優先、immutable collection interface、default parameter、named argument の活用余地を確認する
-- public / shared API と platform type 周りでは明示型、KDoc、visibility の明確さを確認する
-- method の直前コメントで機能と責務が読み取れるか確認する
-- package、file、type、method の命名が責務と一致し、レイヤーやドメインのズレがないか確認する
-- Swift は use site で読んだときの明確さ、base name と argument label の自然さ、mutating / nonmutating の対称性を確認する
-- Swift の Boolean / protocol / factory / initializer 命名、DocC summary、default parameter の配置を確認する
+   - 単一式 function の expression body、`val` 優先、immutable collection interface、default parameter、named argument の活用余地を確認する
+   - public / shared API と platform type 周りでは明示型、KDoc、visibility の明確さを確認する
+   - method の直前コメントで機能と責務が読み取れるか確認する
+   - package、file、type、method の命名が責務と一致し、レイヤーやドメインのズレがないか確認する
+   - Swift は use site で読んだときの明確さ、base name と argument label の自然さ、mutating / nonmutating の対称性を確認する
+   - Swift の Boolean / protocol / factory / initializer 命名、DocC summary、default parameter の配置を確認する
 
 3. 文字列を洗い出す
    - 画面表示、エラー表示、ボタン文言、プレースホルダ、空状態の文言を確認する
@@ -219,10 +239,10 @@ Keep this file aligned with the upstream repo skill when the conventions change.
    - SwiftUI View は描画と user action の橋渡しに集中させる
 
 5. null safe と異常系を実装する
-- `!!` や強制アンラップを避ける
-- null、空、失敗、例外、権限拒否などの分岐を明示する
-- 成功時だけでなく失敗時の戻り先、表示、ログを決める
-- error / exception を catch したら、握りつぶさずログ、状態更新、再送出、Result 変換などで扱いを残す
+   - `!!` や強制アンラップを避ける
+   - null、空、失敗、例外、権限拒否などの分岐を明示する
+   - 成功時だけでなく失敗時の戻り先、表示、ログを決める
+   - error / exception を catch したら、握りつぶさずログ、状態更新、再送出、Result 変換などで扱いを残す
 
 6. MVVM と declarative UI の前提を崩していないか確認する
    - View がロジック過多になっていないか確認する
@@ -230,6 +250,79 @@ Keep this file aligned with the upstream repo skill when the conventions change.
    - Compose / SwiftUI らしい state-driven な構造になっているか確認する
 
 7. 仕上げを確認する
-- ファイル末尾に空行を入れる
-- method コメントが責務と失敗時の扱いを説明できているか見直す
-- package 名と method 名、class 名が乖離していないか見直す
+   - ファイル末尾に空行を入れる
+   - 異常系を含む最低限のテストや確認観点を用意する
+   - 命名、責務、リソース参照、state 配置に矛盾がないか見直す
+   - method コメントが責務と失敗時の扱いを説明できているか見直す
+   - package 名と method 名、class 名が乖離していないか見直す
+   - Kotlin の不要な `: Unit`、semicolon、冗長な overload、mutable 型宣言が残っていないか見直す
+   - formatter で崩れないか、trailing comma と改行位置が一定か確認する
+   - Swift の DocC summary、argument label、mutating / nonmutating pair、Boolean / protocol 命名に不自然さがないか見直す
+   - error / exception の握りつぶしや、失敗時の無言 return が残っていないか確認する
+
+## Quality Checks
+
+- Kotlin / Swift の書き方が公式ガイドラインと既存コードスタイルから大きく逸脱していない
+- Kotlin の package / directory、ファイル名、class layout、overload 配置が公式ガイドに沿っている
+- Kotlin の命名、modifier 順、annotation 位置、space / 改行ルールが崩れていない
+- method の直前コメントで機能、利用条件、副作用が把握できる
+- package、directory、file、type、method の命名が同じ責務やドメインを指している
+- public / shared API の型、KDoc / DocC、visibility が必要な範囲で明示されている
+- expression body、default parameter、immutable collection など idiomatic Kotlin の選択ができている
+- Swift の base name と argument label が use site で自然に読める
+- Swift の Boolean / protocol / mutating API 命名が副作用や役割を正しく表している
+- Swift の DocC summary と markup が public API の契約説明に使えている
+- Swift の default parameter と overload 設計が過剰な API family を避けている
+- ユーザー向け文字列がリソース参照になっている
+- `!!` や強制アンラップを安易に使っていない
+- Android ではロジックが ViewModel にあり、UI は表示責務に留まっている
+- iOS では一時 UI state と意味のある画面 state が適切に分離されている
+- UI が Jetpack Compose / SwiftUI ベースで実装されている
+- 異常系や失敗パスが考慮されている
+- error / exception を握りつぶさず、観測可能な失敗処理が残っている
+- ファイル末尾に空行がある
+
+## Guardrails
+
+- package 構成と source file 名を場当たり的に決めない
+- `Util`、`Manager`、`Wrapper` のような意味の薄い名前で責務を曖昧にしない
+- package 名と型名、method 名の責務がズレたまま放置しない
+- mutable である必要がない値を `var` や mutable collection で宣言しない
+- 不要な `: Unit`、semicolon、冗長な overload、過剰な scope function 連鎖を残さない
+- platform type を public API に推論任せで流さない
+- Swift API を declaration だけで良しとせず、call site の自然さを確認する
+- Swift で役割が不明な unlabeled parameter、Boolean 名、protocol 名を放置しない
+- Swift で return type だけに依存した overload や method family の乱立を作らない
+- 文字列の直書きを残さない
+- `!!` や強制アンラップを常用しない
+- error / exception を空の `catch`、無言の `onFailure`、理由不明の `try?` で握りつぶさない
+- Android の UI 層にロジックを寄せすぎない
+- iOS View に長寿命 state や画面意味を持つロジックを抱え込ませない
+- 宣言的 UI を前提にしつつ、既存実装との整合性を壊さない
+- 正常系だけで完了扱いにしない
+
+## Output Format
+
+返答には必要に応じて以下を含める。
+
+- Target: Android / iOS / KMP のどこを実装するか
+- UI framework: Jetpack Compose / SwiftUI のどちらを使うか
+- Kotlin style check: source file 構成、命名、整形、idiomatic Kotlin の確認結果
+- Swift style check: API naming、argument label、DocC、mutating / nonmutating 設計の確認結果
+- State placement: ViewModel / ObservableObject / View の責務分担
+- Resource check: 文字列リソース化の有無
+- Null safety check: `!!` / 強制アンラップの排除方針
+- Documentation/API check: public / shared API の型、visibility、KDoc / DocC の確認結果
+- Method comment check: method の機能コメントと責務説明の確認結果
+- Naming consistency check: package、file、type、method の命名整合性
+- Error paths: 想定した異常系
+- Swallowed error check: 握りつぶしの有無と失敗時の扱い
+- Final checklist: 実装前後に確認した項目
+
+## Example Prompts
+
+- `/mobile-coding-conventions Android の Camera 画面を実装する。文字列リソース化と ViewModel 責務も見ながら進めて`
+- `/mobile-coding-conventions iOS の SwiftUI 画面で state の置き場所を確認しながら実装したい`
+- `/mobile-coding-conventions KMP で UI とロジックの分離、null safe、異常系考慮をチェックしながらコードを書いて`
+- `/mobile-coding-conventions KMP の Kotlin ファイル構成、命名、expression body、trailing comma を公式規約ベースで確認しながら実装して`
+- `/mobile-coding-conventions iOS の SwiftUI 実装で API 名、argument label、DocC、mutating / nonmutating の命名を公式規約ベースで確認して`


### PR DESCRIPTION
- Update SKILL.md frontmatter: align description with upstream wording,
  add argument-hint field
- Add Decision Points 12–13 (Swift naming and documentation design)
  to conventions.md
- Fix indentation in Recommended Procedure steps 2, 5, 7
- Add Quality Checks, Guardrails, Output Format, and Example Prompts
  sections to conventions.md to fully mirror the upstream skill

https://claude.ai/code/session_01Y3VvE6zNLTSdyUwZt5JoP9