### PR TITLE
Fix CameraViewModel zoom test and fake repository support

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
@@ -822,20 +822,21 @@ class CameraViewModelTest {
 
     @Test
     fun onCameraZoomChanged_appliesScaleChangeWithinBounds() = runTest {
+        val cameraRepository = FakeCameraRepository()
         val viewModel = CameraViewModel(
-            cameraRepository = FakeCameraRepository(),
+            cameraRepository = cameraRepository,
             permissionRepository = FakePermissionRepository(PermissionState.Unknown),
         )
-        assertEquals(DEFAULT_CAMERA_ZOOM_SCALE, viewModel.uiState.value.cameraZoomScale)
+        assertEquals(1f, viewModel.uiState.value.zoomUiState.currentCameraZoomRatio)
 
         viewModel.onCameraZoomChanged(2f)
-        assertEquals(2f, viewModel.uiState.value.cameraZoomScale)
+        assertEquals(2f, cameraRepository.setZoomRatioRequests.last())
 
         viewModel.onCameraZoomChanged(10f)
-        assertEquals(MAX_CAMERA_ZOOM_SCALE, viewModel.uiState.value.cameraZoomScale)
+        assertEquals(5f, cameraRepository.setZoomRatioRequests.last())
 
         viewModel.onCameraZoomChanged(0.1f)
-        assertEquals(MIN_CAMERA_ZOOM_SCALE, viewModel.uiState.value.cameraZoomScale)
+        assertEquals(1f, cameraRepository.setZoomRatioRequests.last())
     }
 
     @Test
@@ -932,6 +933,7 @@ class CameraViewModelTest {
         val startPreviewRequests = mutableListOf<CameraLensFacing>()
         val resolveInitialLensRequests = mutableListOf<CameraLensFacing>()
         val switchLensRequests = mutableListOf<CameraLensFacing>()
+        val setZoomRatioRequests = mutableListOf<Float>()
 
         override suspend fun startPreview(lensFacing: CameraLensFacing): Result<CameraLensFacing> {
             startPreviewCallCount += 1
@@ -985,6 +987,11 @@ class CameraViewModelTest {
                 minCameraZoomRatio = zoomUiState.minCameraZoomRatio,
                 maxCameraZoomRatio = zoomUiState.maxCameraZoomRatio
             )
+        }
+
+        override fun setZoomRatio(updatedZoomRatio: Float) {
+            setZoomRatioRequests += updatedZoomRatio
+            zoomUiState.value = zoomUiState.value.copy(currentCameraZoomRatio = updatedZoomRatio)
         }
 
         fun emitPreviewState(state: PreviewState) {


### PR DESCRIPTION
### Motivation
- The zoom state was refactored to be repository-driven (`CameraZoomUiState`) and the existing test referenced a removed UI field, so the test needed to validate repository interaction instead of a stale property.

### Description
- Updated `onCameraZoomChanged_appliesScaleChangeWithinBounds` in `composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt` to assert values recorded by the repository instead of the removed `cameraZoomScale` field.
- Added `setZoomRatioRequests` and implemented `setZoomRatio(updatedZoomRatio: Float)` in the test `FakeCameraRepository` to record zoom requests and update the fake `zoomUiState`.
- Adjusted initial assertion to read the repository-driven zoom value via `viewModel.uiState.value.zoomUiState.currentCameraZoomRatio`.

### Testing
- Attempted to run `./gradlew test --no-daemon`, but the run failed because Android SDK location is not configured (no `ANDROID_HOME` / `local.properties`) so unit tests could not be executed here.
- Attempted `./gradlew :composeApp:compileTestKotlinIosSimulatorArm64`, but dependency resolution failed with a `403` from Maven and the compilation did not complete.
- Ran `./gradlew :composeApp:tasks --all` successfully to inspect available test-related tasks.
- The code changes were committed locally (`Fix CameraViewModel zoom test and fake repository`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02a5a3d6e48330b9f163f985074e30)