### PR TITLE
feat(camera): ピンチアウトでカメラzoom倍率を変更できるよう実装

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
@@ -216,6 +216,8 @@ actual fun CameraPreviewHost(
                     preview,
                     analysis,
                 )
+                // AndroidCameraRepositoryをこの時だけキャストする。nullなら実行しない
+                (cameraRepository as? AndroidCameraRepository)?.onPlatformCameraControlReady(camera.cameraControl)
                 // 現在の倍率をLiveDataで監視する
                 val zoomLiveData = camera.cameraInfo.zoomState
                 val zoomObserver = Observer<ZoomState> { zoomState ->

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
@@ -4,13 +4,14 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.BitmapFactory
+import android.net.Uri
 import android.provider.OpenableColumns
-import androidx.camera.core.ExperimentalGetImage
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.camera.core.CameraSelector
+import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.Preview
+import androidx.camera.core.ZoomState
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.Image
@@ -47,13 +48,17 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Observer
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.example.vtubercamera_kmp_ver.avatar.render.AndroidFilamentAvatarHost
+import com.example.vtubercamera_kmp_ver.avatar.render.AvatarAssetLoadException
+import com.example.vtubercamera_kmp_ver.avatar.render.AvatarAssetLoadFailureKind
 import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
 import com.example.vtubercamera_kmp_ver.theme.spacing
 import com.google.common.util.concurrent.ListenableFuture
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import vtubercamera_kmp_ver.composeapp.generated.resources.Res
 import vtubercamera_kmp_ver.composeapp.generated.resources.avatar_preview_author_label
@@ -63,10 +68,9 @@ import vtubercamera_kmp_ver.composeapp.generated.resources.file_picker_open_fail
 import vtubercamera_kmp_ver.composeapp.generated.resources.file_picker_read_failed
 import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_invalid_format
 import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_read_failed
-import java.util.concurrent.Executor
 import java.util.concurrent.Executors
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 @Composable
 actual fun rememberCameraPermissionController(): CameraPermissionController {
@@ -206,12 +210,24 @@ actual fun CameraPreviewHost(
                     .also { it.setAnalyzer(analysisExecutor, faceTrackingAnalyzer) }
 
                 cameraProvider.unbindAll()
-                cameraProvider.bindToLifecycle(
+                val camera = cameraProvider.bindToLifecycle(
                     lifecycleOwner,
                     selector,
                     preview,
                     analysis,
                 )
+                // 現在の倍率をLiveDataで監視する
+                val zoomLiveData = camera.cameraInfo.zoomState
+                val zoomObserver = Observer<ZoomState> { zoomState ->
+                    cameraRepository.onPlatformZoomStateChanged(
+                        zoomUiState = CameraZoomUiState(
+                            currentCameraZoomRatio = zoomState.zoomRatio ,
+                            minCameraZoomRatio = zoomState.minZoomRatio ,
+                            maxCameraZoomRatio = zoomState.maxZoomRatio ,
+                        )
+                    )
+                }
+                zoomLiveData.observe(lifecycleOwner,zoomObserver)
 
                 (previewView.tag as? AndroidFaceTrackingAnalyzer)?.close()
                 previewView.tag = faceTrackingAnalyzer
@@ -324,7 +340,7 @@ actual fun AvatarPreviewOverlay(
 actual fun AvatarBodyOverlay(
     avatarSelection: AvatarSelectionData,
     avatarRenderState: AvatarRenderState,
-    onAvatarRenderLoadFailed: (AvatarAssetHandle, org.jetbrains.compose.resources.StringResource) -> Unit,
+    onAvatarRenderLoadFailed: (AvatarAssetHandle, StringResource) -> Unit,
     modifier: Modifier,
 ) {
     Box(
@@ -346,7 +362,7 @@ actual fun AvatarBodyOverlay(
 private fun AvatarRendererHostView(
     avatarSelection: AvatarSelectionData,
     avatarRenderState: AvatarRenderState,
-    onAvatarRenderLoadFailed: (AvatarAssetHandle, org.jetbrains.compose.resources.StringResource) -> Unit,
+    onAvatarRenderLoadFailed: (AvatarAssetHandle, StringResource) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AndroidFilamentAvatarHost(
@@ -369,7 +385,7 @@ private fun Context.hasCameraPermission(): Boolean {
     ) == PackageManager.PERMISSION_GRANTED
 }
 
-private fun Context.resolveDisplayName(uri: android.net.Uri): String? {
+private fun Context.resolveDisplayName(uri: Uri): String? {
     return contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
         ?.use { cursor ->
             val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
@@ -384,29 +400,30 @@ private fun Context.resolveDisplayName(uri: android.net.Uri): String? {
 private const val AVATAR_RENDERER_WIDTH_FRACTION = 0.68f
 private const val AVATAR_RENDERER_HEIGHT_FRACTION = 0.6f
 
-private fun Throwable.toFilePickerError(defaultMessageRes: org.jetbrains.compose.resources.StringResource = Res.string.vrm_error_read_failed): FilePickerResult.Error {
+private fun Throwable.toFilePickerError(defaultMessageRes: StringResource = Res.string.vrm_error_read_failed): FilePickerResult.Error {
     return when (this) {
         is FilePickerException -> FilePickerResult.Error(messageRes)
         else -> FilePickerResult.Error(defaultMessageRes)
     }
 }
 
-private fun com.example.vtubercamera_kmp_ver.avatar.render.AvatarAssetLoadException.toAvatarRenderErrorMessageRes():
-    org.jetbrains.compose.resources.StringResource {
+private fun AvatarAssetLoadException.toAvatarRenderErrorMessageRes():
+        StringResource {
     return when (kind) {
-        com.example.vtubercamera_kmp_ver.avatar.render.AvatarAssetLoadFailureKind.AssetUnavailable -> Res.string.vrm_error_read_failed
-        com.example.vtubercamera_kmp_ver.avatar.render.AvatarAssetLoadFailureKind.InvalidAsset -> Res.string.vrm_error_invalid_format
-        com.example.vtubercamera_kmp_ver.avatar.render.AvatarAssetLoadFailureKind.ResourceLoadFailed -> Res.string.vrm_error_read_failed
-        com.example.vtubercamera_kmp_ver.avatar.render.AvatarAssetLoadFailureKind.SceneSetupFailed -> Res.string.vrm_error_read_failed
+        AvatarAssetLoadFailureKind.AssetUnavailable -> Res.string.vrm_error_read_failed
+        AvatarAssetLoadFailureKind.InvalidAsset -> Res.string.vrm_error_invalid_format
+        AvatarAssetLoadFailureKind.ResourceLoadFailed -> Res.string.vrm_error_read_failed
+        AvatarAssetLoadFailureKind.SceneSetupFailed -> Res.string.vrm_error_read_failed
     }
 }
 
 @Composable
-private fun rememberAvatarBitmap(avatarPreview: AvatarPreviewData) = remember(avatarPreview.thumbnailBytes) {
-    avatarPreview.thumbnailBytes?.let { bytes ->
-        BitmapFactory.decodeByteArray(bytes, 0, bytes.size)?.asImageBitmap()
+private fun rememberAvatarBitmap(avatarPreview: AvatarPreviewData) =
+    remember(avatarPreview.thumbnailBytes) {
+        avatarPreview.thumbnailBytes?.let { bytes ->
+            BitmapFactory.decodeByteArray(bytes, 0, bytes.size)?.asImageBitmap()
+        }
     }
-}
 
 @Composable
 actual fun rememberCameraRepositories(
@@ -467,6 +484,6 @@ private suspend fun ListenableFuture<ProcessCameraProvider>.await(): ProcessCame
                     .onSuccess { continuation.resume(it) }
                     .onFailure { continuation.resumeWithException(it) }
             },
-            Executor { runnable -> runnable.run() },
+            { runnable -> runnable.run() },
         )
     }

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraRepository.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraRepository.kt
@@ -13,6 +13,7 @@ internal interface CameraLensAvailability {
 internal class AndroidCameraRepository(
     private val cameraAvailabilityProvider: suspend () -> CameraLensAvailability,
     private val previewState: MutableStateFlow<PreviewState> = MutableStateFlow(PreviewState.Preparing),
+    private val zoomUiState: MutableStateFlow<CameraZoomUiState> = MutableStateFlow(CameraZoomUiState())
 ) : CameraRepository {
     private var pendingLensFacing: CameraLensFacing? = null
 
@@ -69,6 +70,12 @@ internal class AndroidCameraRepository(
             pendingLensFacing = null
             previewState.value = PreviewState.Error(error)
         }
+    }
+
+    override fun observeZoomState():Flow<CameraZoomUiState> = zoomUiState
+
+    override fun onPlatformZoomStateChanged(zoomUiState: CameraZoomUiState) {
+        this.zoomUiState.value = zoomUiState
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraRepository.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraRepository.kt
@@ -1,5 +1,6 @@
 package com.example.vtubercamera_kmp_ver.camera
 
+import androidx.camera.core.CameraControl
 import androidx.camera.core.CameraInfoUnavailableException
 import androidx.camera.core.CameraSelector
 import androidx.camera.lifecycle.ProcessCameraProvider
@@ -16,6 +17,7 @@ internal class AndroidCameraRepository(
     private val zoomUiState: MutableStateFlow<CameraZoomUiState> = MutableStateFlow(CameraZoomUiState())
 ) : CameraRepository {
     private var pendingLensFacing: CameraLensFacing? = null
+    private var cameraControl: CameraControl? = null
 
     override suspend fun startPreview(lensFacing: CameraLensFacing): Result<CameraLensFacing> {
         val cameraAvailability = cameraAvailabilityProvider()
@@ -76,6 +78,14 @@ internal class AndroidCameraRepository(
 
     override fun onPlatformZoomStateChanged(zoomUiState: CameraZoomUiState) {
         this.zoomUiState.value = zoomUiState
+    }
+
+    override fun setZoomRatio(updatedZoomRatio: Float){
+        cameraControl?.setZoomRatio(updatedZoomRatio)
+    }
+
+     fun onPlatformCameraControlReady(cameraControl: CameraControl) {
+        this.cameraControl = cameraControl
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
 import com.example.vtubercamera_kmp_ver.theme.spacing
+import kotlin.math.roundToInt
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import vtubercamera_kmp_ver.composeapp.generated.resources.Res
@@ -137,10 +138,12 @@ fun CameraScreen(
             uiState.permissionState == PermissionState.Denied -> PermissionDeniedState(
                 onRequestPermission = onRequestPermission,
             )
+
             previewError != null -> CameraErrorState(
                 error = previewError.error,
                 onRetryPreview = onRetryPreview,
             )
+
             uiState.isPermissionGranted -> CameraPreviewState(
                 cameraRepository = cameraRepository,
                 uiState = uiState,
@@ -152,6 +155,7 @@ fun CameraScreen(
                 onLensFacingToggle = onLensFacingToggle,
                 onCameraZoomChanged = onCameraZoomChanged,
             )
+
             else -> LoadingState()
         }
 
@@ -222,7 +226,7 @@ private fun CameraPreviewState(
         CameraUiLayer(
             avatarPreview = avatarPreview,
             faceTracking = uiState.faceTracking,
-            zoomScale = uiState.cameraZoomScale,
+            zoomScale = uiState.zoomUiState.currentCameraZoomRatio,
             onOpenFilePicker = onOpenFilePicker,
             onLensFacingToggle = onLensFacingToggle,
         )
@@ -362,24 +366,32 @@ private fun BoxScope.CameraUiLayer(
     onOpenFilePicker: () -> Unit,
     onLensFacingToggle: () -> Unit,
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .align(Alignment.TopCenter)
-            .statusBarsPadding()
-            .padding(MaterialTheme.spacing.xl),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
+    Column(
+        modifier = Modifier.fillMaxWidth().align(Alignment.TopStart).padding(
+            MaterialTheme.spacing.xl
+        )
     ) {
-        Button(onClick = onOpenFilePicker) {
-            Text(stringResource(Res.string.file_picker_open_button))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Button(onClick = onOpenFilePicker) {
+                Text(stringResource(Res.string.file_picker_open_button))
+            }
+            Button(onClick = onLensFacingToggle) {
+                Text(stringResource(Res.string.camera_switch_button))
+            }
         }
-        if (zoomScale > DEFAULT_CAMERA_ZOOM_SCALE) {
-            ZoomIndicator(zoomScale = zoomScale)
-        }
-        Button(onClick = onLensFacingToggle) {
-            Text(stringResource(Res.string.camera_switch_button))
-        }
+        ZoomIndicator(
+            zoomScale = zoomScale,
+            modifier = Modifier.padding(vertical = MaterialTheme.spacing.md)
+        )
+        FaceTrackingOverlay(
+            faceTracking = faceTracking,
+        )
     }
     avatarPreview?.let { preview ->
         AvatarPreviewOverlay(
@@ -389,15 +401,7 @@ private fun BoxScope.CameraUiLayer(
                 .padding(MaterialTheme.spacing.xl),
         )
     }
-    FaceTrackingOverlay(
-        faceTracking = faceTracking,
-        modifier = Modifier
-            .align(Alignment.TopStart)
-            .padding(
-                start = MaterialTheme.spacing.xl,
-                top = MaterialTheme.spacing.xl * 5,
-            ),
-    )
+
 }
 
 @Composable
@@ -412,15 +416,26 @@ private fun ZoomIndicator(
         tonalElevation = MaterialTheme.spacing.xs,
     ) {
         Text(
-            text =zoomScale.toString(),
+            text = zoomScale.toZoomRatio(),
             modifier = Modifier.padding(
                 horizontal = MaterialTheme.spacing.md,
                 vertical = MaterialTheme.spacing.xs,
             ),
+            color = MaterialTheme.colorScheme.onSurface,
             style = MaterialTheme.typography.bodyMedium,
         )
     }
 }
+
+private fun Float.toZoomRatio(): String{
+    val roundedTenths = (this * ZOOM_RATIO_LABEL_RATIO).roundToInt()
+    val whole = roundedTenths /ZOOM_RATIO_LABEL_RATIO
+    val decimal = roundedTenths % ZOOM_RATIO_LABEL_RATIO
+
+    return "${whole}.${decimal}x"
+}
+
+private const val ZOOM_RATIO_LABEL_RATIO = 10
 
 @Composable
 private fun FaceTrackingOverlay(

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
@@ -412,7 +412,7 @@ private fun ZoomIndicator(
         tonalElevation = MaterialTheme.spacing.xs,
     ) {
         Text(
-            text = "%.1fx".format(zoomScale),
+            text =zoomScale.toString(),
             modifier = Modifier.padding(
                 horizontal = MaterialTheme.spacing.md,
                 vertical = MaterialTheme.spacing.xs,

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
@@ -1,6 +1,7 @@
 package com.example.vtubercamera_kmp_ver.camera
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -22,6 +23,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -95,6 +99,7 @@ fun CameraRoute(
         onFaceTrackingFrameChanged = cameraViewModel::onFaceTrackingFrameChanged,
         onLensFacingChanged = cameraViewModel::onLensFacingChanged,
         onLensFacingToggle = cameraViewModel::onToggleLensFacing,
+        onCameraZoomChanged = cameraViewModel::onCameraZoomChanged,
     )
 }
 
@@ -116,6 +121,7 @@ fun CameraScreen(
     onFaceTrackingFrameChanged: (NormalizedFaceFrame?) -> Unit,
     onLensFacingChanged: (CameraLensFacing) -> Unit,
     onLensFacingToggle: () -> Unit,
+    onCameraZoomChanged: (Float) -> Unit,
     modifier: Modifier = Modifier,
     rendererHost: CameraRendererHost = defaultCameraRendererHost,
 ) {
@@ -144,6 +150,7 @@ fun CameraScreen(
                 onFaceTrackingFrameChanged = onFaceTrackingFrameChanged,
                 onLensFacingChanged = onLensFacingChanged,
                 onLensFacingToggle = onLensFacingToggle,
+                onCameraZoomChanged = onCameraZoomChanged,
             )
             else -> LoadingState()
         }
@@ -182,6 +189,7 @@ private fun CameraPreviewState(
     onFaceTrackingFrameChanged: (NormalizedFaceFrame?) -> Unit,
     onLensFacingChanged: (CameraLensFacing) -> Unit,
     onLensFacingToggle: () -> Unit,
+    onCameraZoomChanged: (Float) -> Unit,
 ) {
     val avatarSelection = uiState.avatarSelection
     val avatarPreview = uiState.avatarPreview
@@ -190,6 +198,7 @@ private fun CameraPreviewState(
         CameraBackgroundLayer(
             cameraRepository = cameraRepository,
             lensFacing = uiState.lensFacing,
+            zoomScale = uiState.cameraZoomScale,
             onFaceTrackingFrameChanged = onFaceTrackingFrameChanged,
             onLensFacingChanged = onLensFacingChanged,
         )
@@ -200,9 +209,20 @@ private fun CameraPreviewState(
             onAvatarRenderLoadFailed = onAvatarRenderLoadFailed,
             rendererHost = rendererHost,
         )
+        // ピンチジェスチャーを検出する透明オーバーレイ。ボタンより下に配置して操作を妨げない。
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .pointerInput(Unit) {
+                    detectTransformGestures { _, _, zoomChange, _ ->
+                        onCameraZoomChanged(zoomChange)
+                    }
+                },
+        )
         CameraUiLayer(
             avatarPreview = avatarPreview,
             faceTracking = uiState.faceTracking,
+            zoomScale = uiState.cameraZoomScale,
             onOpenFilePicker = onOpenFilePicker,
             onLensFacingToggle = onLensFacingToggle,
         )
@@ -216,16 +236,28 @@ private fun CameraPreviewState(
 private fun CameraBackgroundLayer(
     cameraRepository: CameraRepository,
     lensFacing: CameraLensFacing,
+    zoomScale: Float,
     onFaceTrackingFrameChanged: (NormalizedFaceFrame?) -> Unit,
     onLensFacingChanged: (CameraLensFacing) -> Unit,
 ) {
-    CameraPreviewHost(
-        modifier = Modifier.fillMaxSize(),
-        cameraRepository = cameraRepository,
-        lensFacing = lensFacing,
-        onLensFacingChanged = onLensFacingChanged,
-        onFaceTrackingFrameChanged = onFaceTrackingFrameChanged,
-    )
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clipToBounds(),
+    ) {
+        CameraPreviewHost(
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    scaleX = zoomScale
+                    scaleY = zoomScale
+                },
+            cameraRepository = cameraRepository,
+            lensFacing = lensFacing,
+            onLensFacingChanged = onLensFacingChanged,
+            onFaceTrackingFrameChanged = onFaceTrackingFrameChanged,
+        )
+    }
 }
 
 /**
@@ -326,6 +358,7 @@ private fun DefaultAvatarRendererHost(
 private fun BoxScope.CameraUiLayer(
     avatarPreview: AvatarPreviewData?,
     faceTracking: FaceTrackingUiState,
+    zoomScale: Float,
     onOpenFilePicker: () -> Unit,
     onLensFacingToggle: () -> Unit,
 ) {
@@ -340,6 +373,9 @@ private fun BoxScope.CameraUiLayer(
     ) {
         Button(onClick = onOpenFilePicker) {
             Text(stringResource(Res.string.file_picker_open_button))
+        }
+        if (zoomScale > DEFAULT_CAMERA_ZOOM_SCALE) {
+            ZoomIndicator(zoomScale = zoomScale)
         }
         Button(onClick = onLensFacingToggle) {
             Text(stringResource(Res.string.camera_switch_button))
@@ -362,6 +398,28 @@ private fun BoxScope.CameraUiLayer(
                 top = MaterialTheme.spacing.xl * 5,
             ),
     )
+}
+
+@Composable
+private fun ZoomIndicator(
+    zoomScale: Float,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(MaterialTheme.spacing.md),
+        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.85f),
+        tonalElevation = MaterialTheme.spacing.xs,
+    ) {
+        Text(
+            text = "%.1fx".format(zoomScale),
+            modifier = Modifier.padding(
+                horizontal = MaterialTheme.spacing.md,
+                vertical = MaterialTheme.spacing.xs,
+            ),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraSharedDefinitions.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraSharedDefinitions.kt
@@ -79,6 +79,10 @@ interface CameraRepository {
     fun onPlatformPreviewStarted(lensFacing: CameraLensFacing)
 
     fun onPlatformPreviewError(lensFacing: CameraLensFacing, error: CameraError)
+
+    fun observeZoomState(): Flow<CameraZoomUiState>
+
+    fun onPlatformZoomStateChanged(zoomUiState: CameraZoomUiState)
 }
 
 interface PermissionRepository {

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraSharedDefinitions.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraSharedDefinitions.kt
@@ -83,6 +83,8 @@ interface CameraRepository {
     fun observeZoomState(): Flow<CameraZoomUiState>
 
     fun onPlatformZoomStateChanged(zoomUiState: CameraZoomUiState)
+
+    fun setZoomRatio(updatedZoomRatio: Float)
 }
 
 interface PermissionRepository {

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
@@ -15,6 +15,7 @@ data class CameraUiState(
     val avatarRenderState: AvatarRenderState = AvatarRenderState.Neutral,
     val filePickerErrorMessageRes: StringResource? = null,
     val cameraZoomScale: Float = DEFAULT_CAMERA_ZOOM_SCALE,
+    val zoomUiState: CameraZoomUiState = CameraZoomUiState()
 ) {
     val isPermissionGranted: Boolean
         get() = permissionState == PermissionState.Granted

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
@@ -14,6 +14,7 @@ data class CameraUiState(
     val avatarSelection: AvatarSelectionData? = null,
     val avatarRenderState: AvatarRenderState = AvatarRenderState.Neutral,
     val filePickerErrorMessageRes: StringResource? = null,
+    val cameraZoomScale: Float = DEFAULT_CAMERA_ZOOM_SCALE,
 ) {
     val isPermissionGranted: Boolean
         get() = permissionState == PermissionState.Granted
@@ -27,3 +28,7 @@ data class CameraUiState(
     val avatarPreview: AvatarPreviewData?
         get() = avatarSelection?.preview
 }
+
+internal const val DEFAULT_CAMERA_ZOOM_SCALE = 1f
+internal const val MIN_CAMERA_ZOOM_SCALE = 1f
+internal const val MAX_CAMERA_ZOOM_SCALE = 5f

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
@@ -29,6 +29,9 @@ class CameraViewModel(
         viewModelScope.launch {
             observePreviewState()
         }
+        viewModelScope.launch {
+            observeZoomState()
+        }
     }
 
     // 画面初期化時に権限状態を確認し、必要ならプレビュー開始やエラー反映を行う。
@@ -230,12 +233,12 @@ class CameraViewModel(
     // ピンチ操作によるズーム倍率の変化を UI 状態へ反映する。
     fun onCameraZoomChanged(scaleChange: Float) {
         _uiState.update { currentState ->
-            currentState.copy(
-                cameraZoomScale = (currentState.cameraZoomScale * scaleChange).coerceIn(
-                    minimumValue = MIN_CAMERA_ZOOM_SCALE,
-                    maximumValue = MAX_CAMERA_ZOOM_SCALE,
-                ),
-            )
+                currentState.copy(
+                    cameraZoomScale = (currentState.zoomUiState.currentCameraZoomRatio * scaleChange).coerceIn(
+                        minimumValue = currentState.zoomUiState.minCameraZoomRatio,
+                        maximumValue = currentState.zoomUiState.maxCameraZoomRatio,
+                    ),
+                )
         }
     }
 
@@ -260,6 +263,16 @@ class CameraViewModel(
                     previewState = previewState,
                     errorState = error,
                     message = error?.toCameraMessage(),
+                )
+            }
+        }
+    }
+
+    private suspend fun observeZoomState(){
+        cameraRepository.observeZoomState().collect { zoomUiState ->
+            _uiState.update { currentState ->
+                currentState.copy(
+                    zoomUiState = zoomUiState
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
@@ -232,14 +232,13 @@ class CameraViewModel(
 
     // ピンチ操作によるズーム倍率の変化を UI 状態へ反映する。
     fun onCameraZoomChanged(scaleChange: Float) {
-        _uiState.update { currentState ->
-                currentState.copy(
-                    cameraZoomScale = (currentState.zoomUiState.currentCameraZoomRatio * scaleChange).coerceIn(
-                        minimumValue = currentState.zoomUiState.minCameraZoomRatio,
-                        maximumValue = currentState.zoomUiState.maxCameraZoomRatio,
-                    ),
-                )
-        }
+        val zoomState = uiState.value.zoomUiState
+       cameraRepository.setZoomRatio(
+           (zoomState.currentCameraZoomRatio * scaleChange).coerceIn(
+               zoomState.minCameraZoomRatio,
+               zoomState.maxCameraZoomRatio
+           )
+       )
     }
 
     // ファイル選択エラー表示を閉じる。

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
@@ -227,6 +227,18 @@ class CameraViewModel(
         }
     }
 
+    // ピンチ操作によるズーム倍率の変化を UI 状態へ反映する。
+    fun onCameraZoomChanged(scaleChange: Float) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                cameraZoomScale = (currentState.cameraZoomScale * scaleChange).coerceIn(
+                    minimumValue = MIN_CAMERA_ZOOM_SCALE,
+                    maximumValue = MAX_CAMERA_ZOOM_SCALE,
+                ),
+            )
+        }
+    }
+
     // ファイル選択エラー表示を閉じる。
     fun onDismissFilePickerError() {
         _uiState.update { currentState ->

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraZoomUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraZoomUiState.kt
@@ -1,0 +1,10 @@
+package com.example.vtubercamera_kmp_ver.camera
+
+data class CameraZoomUiState(
+    val currentCameraZoomRatio: Float = 1.0f,
+    val minCameraZoomRatio:Float = 1.0f,
+    val maxCameraZoomRatio:Float = 1.0f,
+){
+    val canZoom: Boolean
+        get() = maxCameraZoomRatio > minCameraZoomRatio
+}

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
@@ -1,19 +1,14 @@
 package com.example.vtubercamera_kmp_ver.camera
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import com.example.vtubercamera_kmp_ver.avatar.state.AvatarTrackingStatus
 import com.example.vtubercamera_kmp_ver.avatar.mapping.VrmSpecVersion
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarTrackingStatus
 import com.example.vtubercamera_kmp_ver.avatar.vrm.VrmRuntimeAssetDescriptor
 import com.example.vtubercamera_kmp_ver.avatar.vrm.VrmRuntimeMeta
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -22,6 +17,11 @@ import kotlinx.coroutines.test.setMain
 import vtubercamera_kmp_ver.composeapp.generated.resources.Res
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_error_unknown
 import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_select_file
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 /**
  * Unit test stubs for [CameraViewModel] state-machine logic.
@@ -180,26 +180,27 @@ class CameraViewModelTest {
      * [CameraRepository.startPreview] must NOT be called.
      */
     @Test
-    fun initialize_whenPermissionDenied_setsPermissionDeniedErrorAndDoesNotStartPreview() = runTest {
-        val cameraRepository = FakeCameraRepository()
-        val permissionRepository = FakePermissionRepository(
-            checkCameraPermissionResult = PermissionState.Denied,
-        )
-        val viewModel = CameraViewModel(
-            cameraRepository = cameraRepository,
-            permissionRepository = permissionRepository,
-        )
+    fun initialize_whenPermissionDenied_setsPermissionDeniedErrorAndDoesNotStartPreview() =
+        runTest {
+            val cameraRepository = FakeCameraRepository()
+            val permissionRepository = FakePermissionRepository(
+                checkCameraPermissionResult = PermissionState.Denied,
+            )
+            val viewModel = CameraViewModel(
+                cameraRepository = cameraRepository,
+                permissionRepository = permissionRepository,
+            )
 
-        viewModel.initialize()
-        advanceUntilIdle()
+            viewModel.initialize()
+            advanceUntilIdle()
 
-        val uiState = viewModel.uiState.value
-        assertEquals(PermissionState.Denied, uiState.permissionState)
-        assertEquals(CameraError.PermissionDenied, uiState.errorState)
-        val previewState = assertIs<PreviewState.Error>(uiState.previewState)
-        assertEquals(CameraError.PermissionDenied, previewState.error)
-        assertEquals(0, cameraRepository.startPreviewCallCount)
-    }
+            val uiState = viewModel.uiState.value
+            assertEquals(PermissionState.Denied, uiState.permissionState)
+            assertEquals(CameraError.PermissionDenied, uiState.errorState)
+            val previewState = assertIs<PreviewState.Error>(uiState.previewState)
+            assertEquals(CameraError.PermissionDenied, previewState.error)
+            assertEquals(0, cameraRepository.startPreviewCallCount)
+        }
 
     /**
      * 「前回起動時は許可済みだったが、次回起動時までに OS 設定で拒否へ変更された」ケース。
@@ -215,39 +216,43 @@ class CameraViewModelTest {
      *   - [CameraRepository.startPreview] は呼び出されない。
      */
     @Test
-    fun initialize_whenPreviouslyGrantedButNowDenied_setsPermissionDeniedAndDoesNotStartPreview() = runTest {
-        val firstLaunchCameraRepository = FakeCameraRepository()
-        val firstLaunchPermissionRepository = FakePermissionRepository(
-            checkCameraPermissionResult = PermissionState.Granted,
-        )
-        val firstLaunchViewModel = CameraViewModel(
-            cameraRepository = firstLaunchCameraRepository,
-            permissionRepository = firstLaunchPermissionRepository,
-        )
-        firstLaunchViewModel.initialize()
-        advanceUntilIdle()
+    fun initialize_whenPreviouslyGrantedButNowDenied_setsPermissionDeniedAndDoesNotStartPreview() =
+        runTest {
+            val firstLaunchCameraRepository = FakeCameraRepository()
+            val firstLaunchPermissionRepository = FakePermissionRepository(
+                checkCameraPermissionResult = PermissionState.Granted,
+            )
+            val firstLaunchViewModel = CameraViewModel(
+                cameraRepository = firstLaunchCameraRepository,
+                permissionRepository = firstLaunchPermissionRepository,
+            )
+            firstLaunchViewModel.initialize()
+            advanceUntilIdle()
 
-        assertEquals(PermissionState.Granted, firstLaunchViewModel.uiState.value.permissionState)
-        assertEquals(1, firstLaunchCameraRepository.startPreviewCallCount)
+            assertEquals(
+                PermissionState.Granted,
+                firstLaunchViewModel.uiState.value.permissionState
+            )
+            assertEquals(1, firstLaunchCameraRepository.startPreviewCallCount)
 
-        val secondLaunchCameraRepository = FakeCameraRepository()
-        val secondLaunchPermissionRepository = FakePermissionRepository(
-            checkCameraPermissionResult = PermissionState.Denied,
-        )
-        val secondLaunchViewModel = CameraViewModel(
-            cameraRepository = secondLaunchCameraRepository,
-            permissionRepository = secondLaunchPermissionRepository,
-        )
-        secondLaunchViewModel.initialize()
-        advanceUntilIdle()
+            val secondLaunchCameraRepository = FakeCameraRepository()
+            val secondLaunchPermissionRepository = FakePermissionRepository(
+                checkCameraPermissionResult = PermissionState.Denied,
+            )
+            val secondLaunchViewModel = CameraViewModel(
+                cameraRepository = secondLaunchCameraRepository,
+                permissionRepository = secondLaunchPermissionRepository,
+            )
+            secondLaunchViewModel.initialize()
+            advanceUntilIdle()
 
-        val uiState = secondLaunchViewModel.uiState.value
-        assertEquals(PermissionState.Denied, uiState.permissionState)
-        assertEquals(CameraError.PermissionDenied, uiState.errorState)
-        val previewState = assertIs<PreviewState.Error>(uiState.previewState)
-        assertEquals(CameraError.PermissionDenied, previewState.error)
-        assertEquals(0, secondLaunchCameraRepository.startPreviewCallCount)
-    }
+            val uiState = secondLaunchViewModel.uiState.value
+            assertEquals(PermissionState.Denied, uiState.permissionState)
+            assertEquals(CameraError.PermissionDenied, uiState.errorState)
+            val previewState = assertIs<PreviewState.Error>(uiState.previewState)
+            assertEquals(CameraError.PermissionDenied, previewState.error)
+            assertEquals(0, secondLaunchCameraRepository.startPreviewCallCount)
+        }
 
     // ---------------------------------------------------------------------------
     // onPermissionStateChanged() – permission denied → granted (Settings recovery)
@@ -361,29 +366,30 @@ class CameraViewModelTest {
     }
 
     @Test
-    fun onPermissionStateChanged_fromUnknownToDenied_setsPermissionDeniedAndDoesNotStartPreview() = runTest {
-        val cameraRepository = FakeCameraRepository()
-        val permissionRepository = FakePermissionRepository(
-            checkCameraPermissionResult = PermissionState.Unknown,
-        )
-        val viewModel = CameraViewModel(
-            cameraRepository = cameraRepository,
-            permissionRepository = permissionRepository,
-        )
-        advanceUntilIdle()
+    fun onPermissionStateChanged_fromUnknownToDenied_setsPermissionDeniedAndDoesNotStartPreview() =
+        runTest {
+            val cameraRepository = FakeCameraRepository()
+            val permissionRepository = FakePermissionRepository(
+                checkCameraPermissionResult = PermissionState.Unknown,
+            )
+            val viewModel = CameraViewModel(
+                cameraRepository = cameraRepository,
+                permissionRepository = permissionRepository,
+            )
+            advanceUntilIdle()
 
-        viewModel.onPermissionStateChanged(isGranted = false, isChecking = false)
-        advanceUntilIdle()
+            viewModel.onPermissionStateChanged(isGranted = false, isChecking = false)
+            advanceUntilIdle()
 
-        val uiState = viewModel.uiState.value
-        assertEquals(PermissionState.Denied, uiState.permissionState)
-        assertEquals(CameraError.PermissionDenied, uiState.errorState)
-        val previewState = assertIs<PreviewState.Error>(uiState.previewState)
-        assertEquals(CameraError.PermissionDenied, previewState.error)
-        assertEquals(CameraMessageType.Error, uiState.message?.type)
-        assertEquals(0, cameraRepository.resolveInitialLensCallCount)
-        assertEquals(0, cameraRepository.startPreviewCallCount)
-    }
+            val uiState = viewModel.uiState.value
+            assertEquals(PermissionState.Denied, uiState.permissionState)
+            assertEquals(CameraError.PermissionDenied, uiState.errorState)
+            val previewState = assertIs<PreviewState.Error>(uiState.previewState)
+            assertEquals(CameraError.PermissionDenied, previewState.error)
+            assertEquals(CameraMessageType.Error, uiState.message?.type)
+            assertEquals(0, cameraRepository.resolveInitialLensCallCount)
+            assertEquals(0, cameraRepository.startPreviewCallCount)
+        }
 
     @Test
     fun observePreviewState_syncsPreparingShowingAndErrorToUiState() = runTest {
@@ -434,27 +440,28 @@ class CameraViewModelTest {
      * Verifies that [CameraRepositoryException.error] is extracted and not overwritten.
      */
     @Test
-    fun onRetryPreview_whenRepositoryThrowsCameraUnavailable_setsCameraUnavailableError() = runTest {
-        val cameraRepository = FakeCameraRepository(
-            startPreviewResult = Result.failure(
-                CameraRepositoryException(CameraError.CameraUnavailable),
-            ),
-        )
-        val viewModel = CameraViewModel(
-            cameraRepository = cameraRepository,
-            permissionRepository = FakePermissionRepository(PermissionState.Unknown),
-        )
-        advanceUntilIdle()
+    fun onRetryPreview_whenRepositoryThrowsCameraUnavailable_setsCameraUnavailableError() =
+        runTest {
+            val cameraRepository = FakeCameraRepository(
+                startPreviewResult = Result.failure(
+                    CameraRepositoryException(CameraError.CameraUnavailable),
+                ),
+            )
+            val viewModel = CameraViewModel(
+                cameraRepository = cameraRepository,
+                permissionRepository = FakePermissionRepository(PermissionState.Unknown),
+            )
+            advanceUntilIdle()
 
-        viewModel.onRetryPreview()
-        advanceUntilIdle()
+            viewModel.onRetryPreview()
+            advanceUntilIdle()
 
-        val uiState = viewModel.uiState.value
-        assertEquals(CameraError.CameraUnavailable, uiState.errorState)
-        val previewState = assertIs<PreviewState.Error>(uiState.previewState)
-        assertEquals(CameraError.CameraUnavailable, previewState.error)
-        assertEquals(1, cameraRepository.startPreviewCallCount)
-    }
+            val uiState = viewModel.uiState.value
+            assertEquals(CameraError.CameraUnavailable, uiState.errorState)
+            val previewState = assertIs<PreviewState.Error>(uiState.previewState)
+            assertEquals(CameraError.CameraUnavailable, previewState.error)
+            assertEquals(1, cameraRepository.startPreviewCallCount)
+        }
 
     /**
      * When [CameraRepository.startPreview] fails with a plain (non-[CameraRepositoryException])
@@ -462,25 +469,26 @@ class CameraViewModelTest {
      * [CameraError.PreviewInitializationFailed].
      */
     @Test
-    fun onRetryPreview_whenRepositoryThrowsGenericException_setsPreviewInitializationFailedError() = runTest {
-        val cameraRepository = FakeCameraRepository(
-            startPreviewResult = Result.failure(IllegalStateException("boom")),
-        )
-        val viewModel = CameraViewModel(
-            cameraRepository = cameraRepository,
-            permissionRepository = FakePermissionRepository(PermissionState.Unknown),
-        )
-        advanceUntilIdle()
+    fun onRetryPreview_whenRepositoryThrowsGenericException_setsPreviewInitializationFailedError() =
+        runTest {
+            val cameraRepository = FakeCameraRepository(
+                startPreviewResult = Result.failure(IllegalStateException("boom")),
+            )
+            val viewModel = CameraViewModel(
+                cameraRepository = cameraRepository,
+                permissionRepository = FakePermissionRepository(PermissionState.Unknown),
+            )
+            advanceUntilIdle()
 
-        viewModel.onRetryPreview()
-        advanceUntilIdle()
+            viewModel.onRetryPreview()
+            advanceUntilIdle()
 
-        val uiState = viewModel.uiState.value
-        assertEquals(CameraError.PreviewInitializationFailed, uiState.errorState)
-        val previewState = assertIs<PreviewState.Error>(uiState.previewState)
-        assertEquals(CameraError.PreviewInitializationFailed, previewState.error)
-        assertEquals(1, cameraRepository.startPreviewCallCount)
-    }
+            val uiState = viewModel.uiState.value
+            assertEquals(CameraError.PreviewInitializationFailed, uiState.errorState)
+            val previewState = assertIs<PreviewState.Error>(uiState.previewState)
+            assertEquals(CameraError.PreviewInitializationFailed, previewState.error)
+            assertEquals(1, cameraRepository.startPreviewCallCount)
+        }
 
     // ---------------------------------------------------------------------------
     // onToggleLensFacing() – error type preserved from repository
@@ -669,8 +677,10 @@ class CameraViewModelTest {
             cameraRepository = FakeCameraRepository(),
             permissionRepository = FakePermissionRepository(PermissionState.Unknown),
         )
-        val firstSelection = createAvatarSelectionData("first.vrm", "Avatar A", byteArrayOf(1, 2, 3))
-        val secondSelection = createAvatarSelectionData("second.vrm", "Avatar B", byteArrayOf(4, 5, 6))
+        val firstSelection =
+            createAvatarSelectionData("first.vrm", "Avatar A", byteArrayOf(1, 2, 3))
+        val secondSelection =
+            createAvatarSelectionData("second.vrm", "Avatar B", byteArrayOf(4, 5, 6))
 
         try {
             viewModel.onFilePicked(FilePickerResult.Success(firstSelection))
@@ -681,7 +691,10 @@ class CameraViewModelTest {
 
             viewModel.onFilePicked(FilePickerResult.Error(Res.string.vrm_error_select_file))
             advanceUntilIdle()
-            assertEquals(Res.string.vrm_error_select_file, viewModel.uiState.value.filePickerErrorMessageRes)
+            assertEquals(
+                Res.string.vrm_error_select_file,
+                viewModel.uiState.value.filePickerErrorMessageRes
+            )
 
             viewModel.onFilePicked(FilePickerResult.Success(secondSelection))
             advanceUntilIdle()
@@ -729,7 +742,10 @@ class CameraViewModelTest {
 
         viewModel.onFilePicked(FilePickerResult.Error(Res.string.vrm_error_select_file))
         advanceUntilIdle()
-        assertEquals(Res.string.vrm_error_select_file, viewModel.uiState.value.filePickerErrorMessageRes)
+        assertEquals(
+            Res.string.vrm_error_select_file,
+            viewModel.uiState.value.filePickerErrorMessageRes
+        )
 
         viewModel.onDismissFilePickerError()
         advanceUntilIdle()
@@ -737,32 +753,34 @@ class CameraViewModelTest {
     }
 
     @Test
-    fun onAvatarRenderLoadFailed_whenCurrentHandle_matchesClearsSelectionAndRemovesAsset() = runTest {
-        val viewModel = CameraViewModel(
-            cameraRepository = FakeCameraRepository(),
-            permissionRepository = FakePermissionRepository(PermissionState.Unknown),
-        )
-        val selection = createAvatarSelectionData("active.vrm", "Avatar C", byteArrayOf(7, 8, 9))
-
-        try {
-            viewModel.onFilePicked(FilePickerResult.Success(selection))
-            advanceUntilIdle()
-            assertNotNull(AvatarAssetStore.load(selection.assetHandle))
-
-            viewModel.onAvatarRenderLoadFailed(
-                failedAssetHandle = selection.assetHandle,
-                messageRes = Res.string.camera_error_unknown,
+    fun onAvatarRenderLoadFailed_whenCurrentHandle_matchesClearsSelectionAndRemovesAsset() =
+        runTest {
+            val viewModel = CameraViewModel(
+                cameraRepository = FakeCameraRepository(),
+                permissionRepository = FakePermissionRepository(PermissionState.Unknown),
             )
-            advanceUntilIdle()
+            val selection =
+                createAvatarSelectionData("active.vrm", "Avatar C", byteArrayOf(7, 8, 9))
 
-            val uiState = viewModel.uiState.value
-            assertNull(uiState.avatarSelection)
-            assertEquals(Res.string.camera_error_unknown, uiState.filePickerErrorMessageRes)
-            assertNull(AvatarAssetStore.load(selection.assetHandle))
-        } finally {
-            AvatarAssetStore.remove(selection.assetHandle)
+            try {
+                viewModel.onFilePicked(FilePickerResult.Success(selection))
+                advanceUntilIdle()
+                assertNotNull(AvatarAssetStore.load(selection.assetHandle))
+
+                viewModel.onAvatarRenderLoadFailed(
+                    failedAssetHandle = selection.assetHandle,
+                    messageRes = Res.string.camera_error_unknown,
+                )
+                advanceUntilIdle()
+
+                val uiState = viewModel.uiState.value
+                assertNull(uiState.avatarSelection)
+                assertEquals(Res.string.camera_error_unknown, uiState.filePickerErrorMessageRes)
+                assertNull(AvatarAssetStore.load(selection.assetHandle))
+            } finally {
+                AvatarAssetStore.remove(selection.assetHandle)
+            }
         }
-    }
 
     @Test
     fun onAvatarRenderLoadFailed_whenHandleIsStale_ignoresAndKeepsCurrentSelection() = runTest {
@@ -770,8 +788,10 @@ class CameraViewModelTest {
             cameraRepository = FakeCameraRepository(),
             permissionRepository = FakePermissionRepository(PermissionState.Unknown),
         )
-        val staleSelection = createAvatarSelectionData("stale.vrm", "Avatar Stale", byteArrayOf(11, 12))
-        val currentSelection = createAvatarSelectionData("current.vrm", "Avatar Current", byteArrayOf(13, 14))
+        val staleSelection =
+            createAvatarSelectionData("stale.vrm", "Avatar Stale", byteArrayOf(11, 12))
+        val currentSelection =
+            createAvatarSelectionData("current.vrm", "Avatar Current", byteArrayOf(13, 14))
 
         try {
             viewModel.onFilePicked(FilePickerResult.Success(staleSelection))
@@ -891,11 +911,14 @@ class CameraViewModelTest {
     )
 
     private class FakeCameraRepository(
-        private val resolveInitialLensResult: Result<CameraLensFacing> = Result.success(CameraLensFacing.Back),
+        private val resolveInitialLensResult: Result<CameraLensFacing> = Result.success(
+            CameraLensFacing.Back
+        ),
         private val startPreviewResult: Result<CameraLensFacing>? = null,
         private val switchLensResult: Result<CameraLensFacing> = Result.success(CameraLensFacing.Front),
     ) : CameraRepository {
         private val previewState = MutableStateFlow<PreviewState>(PreviewState.Preparing)
+        private val zoomUiState = MutableStateFlow(CameraZoomUiState())
 
         var startPreviewCallCount: Int = 0
             private set
@@ -950,6 +973,18 @@ class CameraViewModelTest {
 
         override fun onPlatformPreviewError(lensFacing: CameraLensFacing, error: CameraError) {
             previewState.value = PreviewState.Error(error)
+        }
+
+        override fun observeZoomState(): Flow<CameraZoomUiState> {
+            return zoomUiState.asStateFlow()
+        }
+
+        override fun onPlatformZoomStateChanged(zoomUiState: CameraZoomUiState) {
+            this.zoomUiState.value = CameraZoomUiState(
+                currentCameraZoomRatio = zoomUiState.currentCameraZoomRatio,
+                minCameraZoomRatio = zoomUiState.minCameraZoomRatio,
+                maxCameraZoomRatio = zoomUiState.maxCameraZoomRatio
+            )
         }
 
         fun emitPreviewState(state: PreviewState) {

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
@@ -822,20 +822,21 @@ class CameraViewModelTest {
 
     @Test
     fun onCameraZoomChanged_appliesScaleChangeWithinBounds() = runTest {
+        val cameraRepository = FakeCameraRepository()
         val viewModel = CameraViewModel(
-            cameraRepository = FakeCameraRepository(),
+            cameraRepository = cameraRepository,
             permissionRepository = FakePermissionRepository(PermissionState.Unknown),
         )
-        assertEquals(DEFAULT_CAMERA_ZOOM_SCALE, viewModel.uiState.value.cameraZoomScale)
+        assertEquals(1f, viewModel.uiState.value.zoomUiState.currentCameraZoomRatio)
 
         viewModel.onCameraZoomChanged(2f)
-        assertEquals(2f, viewModel.uiState.value.cameraZoomScale)
+        assertEquals(2f, cameraRepository.setZoomRatioRequests.last())
 
         viewModel.onCameraZoomChanged(10f)
-        assertEquals(MAX_CAMERA_ZOOM_SCALE, viewModel.uiState.value.cameraZoomScale)
+        assertEquals(5f, cameraRepository.setZoomRatioRequests.last())
 
         viewModel.onCameraZoomChanged(0.1f)
-        assertEquals(MIN_CAMERA_ZOOM_SCALE, viewModel.uiState.value.cameraZoomScale)
+        assertEquals(1f, cameraRepository.setZoomRatioRequests.last())
     }
 
     @Test
@@ -932,6 +933,7 @@ class CameraViewModelTest {
         val startPreviewRequests = mutableListOf<CameraLensFacing>()
         val resolveInitialLensRequests = mutableListOf<CameraLensFacing>()
         val switchLensRequests = mutableListOf<CameraLensFacing>()
+        val setZoomRatioRequests = mutableListOf<Float>()
 
         override suspend fun startPreview(lensFacing: CameraLensFacing): Result<CameraLensFacing> {
             startPreviewCallCount += 1
@@ -985,6 +987,11 @@ class CameraViewModelTest {
                 minCameraZoomRatio = zoomUiState.minCameraZoomRatio,
                 maxCameraZoomRatio = zoomUiState.maxCameraZoomRatio
             )
+        }
+
+        override fun setZoomRatio(updatedZoomRatio: Float) {
+            setZoomRatioRequests += updatedZoomRatio
+            zoomUiState.value = zoomUiState.value.copy(currentCameraZoomRatio = updatedZoomRatio)
         }
 
         fun emitPreviewState(state: PreviewState) {

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
@@ -796,6 +796,28 @@ class CameraViewModelTest {
         }
     }
 
+    // ---------------------------------------------------------------------------
+    // onCameraZoomChanged()
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun onCameraZoomChanged_appliesScaleChangeWithinBounds() = runTest {
+        val viewModel = CameraViewModel(
+            cameraRepository = FakeCameraRepository(),
+            permissionRepository = FakePermissionRepository(PermissionState.Unknown),
+        )
+        assertEquals(DEFAULT_CAMERA_ZOOM_SCALE, viewModel.uiState.value.cameraZoomScale)
+
+        viewModel.onCameraZoomChanged(2f)
+        assertEquals(2f, viewModel.uiState.value.cameraZoomScale)
+
+        viewModel.onCameraZoomChanged(10f)
+        assertEquals(MAX_CAMERA_ZOOM_SCALE, viewModel.uiState.value.cameraZoomScale)
+
+        viewModel.onCameraZoomChanged(0.1f)
+        assertEquals(MIN_CAMERA_ZOOM_SCALE, viewModel.uiState.value.cameraZoomScale)
+    }
+
     @Test
     fun releaseCurrentAvatarAsset_removesCurrentAvatarAssetHandle() = runTest {
         val viewModel = CameraViewModel(

--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
@@ -204,6 +204,13 @@ actual fun CameraPreviewHost(
                         onLensFacingChanged(resolvedLens)
                     }
                     cameraRepository.onPlatformPreviewStarted(resolvedLens)
+                    // AVFoundation セッション開始後にデバイスのズーム能力をリポジトリへ登録する。
+                    // ARKit 使用時は sessionManager にデバイスがないため null を渡す。
+                    if (!usesFaceTracking) {
+                        (cameraRepository as? IOSCameraRepository)?.onPlatformCameraDeviceReady(
+                            sessionManager.currentDevice()
+                        )
+                    }
                 } else {
                     cameraRepository.onPlatformPreviewError(
                         lensFacing = resolvedLens,
@@ -214,6 +221,8 @@ actual fun CameraPreviewHost(
         }
 
         if (usesFaceTracking) {
+            // ARKit に切り替える際はデバイス参照を解放してズーム状態を初期値に戻す。
+            (cameraRepository as? IOSCameraRepository)?.onPlatformCameraDeviceReady(null)
             faceTrackingSessionManager.stopPreview()
             sessionManager.stopPreview {
                 if (!isDisposed) {
@@ -442,6 +451,9 @@ private class IOSCameraSessionManager {
     fun bindPreview(to: CameraPreviewContainerView) {
         to.bindPreviewLayer(previewLayer)
     }
+
+    // 現在セッションに登録されているカメラデバイスを返す。
+    fun currentDevice(): AVCaptureDevice? = currentInput?.device
 
     // 指定レンズでカメラ入力を構成し、プレビュー開始結果をコールバックする。
     fun startPreview(

--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraRepository.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraRepository.kt
@@ -2,14 +2,17 @@ package com.example.vtubercamera_kmp_ver.camera
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import platform.AVFoundation.AVCaptureDevice
 
 internal typealias IOSCameraLensAvailability = (CameraLensFacing) -> Boolean
 
 internal class IOSCameraRepository(
     private val hasLens: IOSCameraLensAvailability,
     private val previewState: MutableStateFlow<PreviewState> = MutableStateFlow(PreviewState.Preparing),
+    private val zoomState: MutableStateFlow<CameraZoomUiState> = MutableStateFlow(CameraZoomUiState()),
 ) : CameraRepository {
     private var pendingLensFacing: CameraLensFacing? = null
+    private var currentDevice: AVCaptureDevice? = null
 
     // プレビュー開始前の状態を整え、利用可能なレンズを解決する。
     override suspend fun startPreview(lensFacing: CameraLensFacing): Result<CameraLensFacing> {
@@ -61,6 +64,45 @@ internal class IOSCameraRepository(
         if (pendingLensFacing == lensFacing) {
             pendingLensFacing = null
             previewState.value = PreviewState.Error(error)
+        }
+    }
+
+    override fun observeZoomState(): Flow<CameraZoomUiState> = zoomState
+
+    override fun onPlatformZoomStateChanged(zoomUiState: CameraZoomUiState) {
+        zoomState.value = zoomUiState
+    }
+
+    // AVCaptureDevice.videoZoomFactor を使って実際のカメラズームを適用する。
+    override fun setZoomRatio(updatedZoomRatio: Float) {
+        val device = currentDevice ?: return
+        val clamped = updatedZoomRatio.toDouble().coerceIn(
+            device.minAvailableVideoZoomFactor,
+            device.maxAvailableVideoZoomFactor,
+        )
+        if (device.lockForConfiguration(null)) {
+            device.videoZoomFactor = clamped
+            device.unlockForConfiguration()
+            zoomState.value = CameraZoomUiState(
+                currentCameraZoomRatio = clamped.toFloat(),
+                minCameraZoomRatio = device.minAvailableVideoZoomFactor.toFloat(),
+                maxCameraZoomRatio = device.maxAvailableVideoZoomFactor.toFloat(),
+            )
+        }
+    }
+
+    // AVFoundation セッション開始後にデバイスを登録し、ズーム能力を公開する。
+    // ARKit 使用時は device=null を渡してズーム状態を初期値に戻す。
+    fun onPlatformCameraDeviceReady(device: AVCaptureDevice?) {
+        currentDevice = device
+        zoomState.value = if (device != null) {
+            CameraZoomUiState(
+                currentCameraZoomRatio = device.videoZoomFactor.toFloat(),
+                minCameraZoomRatio = device.minAvailableVideoZoomFactor.toFloat(),
+                maxCameraZoomRatio = device.maxAvailableVideoZoomFactor.toFloat(),
+            )
+        } else {
+            CameraZoomUiState()
         }
     }
 }


### PR DESCRIPTION
- CameraUiState に cameraZoomScale を追加（デフォルト1x、最大5x）
- CameraViewModel に onCameraZoomChanged でスケール変化量を受け取り
  MIN/MAX 範囲内に収める処理を追加
- CameraScreen の CameraBackgroundLayer で graphicsLayer による
  ビジュアルズームを適用し、透明オーバーレイでピンチジェスチャーを検出
- ズーム中（1x超）は ZoomIndicator を UI 上部に表示
- onCameraZoomChanged の単体テストを追加

https://claude.ai/code/session_016nXs2ubYisP6v7cQ8xHCqC