### PR TITLE
ci: add Update Gradle Wrapper workflow with PR creation permissions

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,22 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    # Monday 09:00 JST / Monday 00:00 UTC
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes "GitHub Actions is not permitted to create or approve pull
requests" by explicitly granting contents: write and pull-requests: write
permissions. Runs weekly on Monday mornings (JST).

https://claude.ai/code/session_01Nhb75zRFgLBYgefkVfUeZp