### PR TITLE
docs: readme と仕様書を実装状況に同期

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ VTuberCamera の Kotlin Multiplatform 版リポジトリです。Android と iOS
 - カメラ権限確認と権限リクエスト
 - CameraX によるリアルタイムプレビュー
 - フロント / バックカメラ切り替え
+- ピンチ操作によるカメラズーム制御（ズームインジケーター表示込み）
 - ドキュメントファイルピッカー起動
 - ML Kit Face Detection による face tracking 解析と共有 state 反映
+- face tracking 結果をアバター表情・ボーン状態へマッピング
 - Filament renderer による VRM avatar 表示基盤
 - Compose Multiplatform ベースのカメラ画面
 
@@ -22,19 +24,25 @@ VTuberCamera の Kotlin Multiplatform 版リポジトリです。Android と iOS
 
 - Compose Multiplatform host + AVFoundation によるネイティブカメラプレビュー
 - TrueDepth 対応デバイスの前面カメラで ARKit face tracking
-
 - カメラ権限確認と権限リクエスト
 - フロント / バックカメラ切り替え
+- ピンチ操作によるカメラズーム制御
 - `UIDocumentPickerViewController` によるファイル選択
 - SwiftUI + Filament による avatar view ホスト
+- avatar render state を Filament ブリッジへ伝達
 
 ### 共有コードで扱っているもの
 
 - Compose Multiplatform のアプリ入口
 - カメラ画面の基本 UI
-- `CameraViewModel` による画面状態管理
+- `CameraViewModel` による画面状態管理（権限・プレビュー・ズーム・アバター状態を一元管理）
 - レンズ向き状態 (`Back` / `Front`)
+- ズーム状態 (`CameraZoomUiState`) と zoom ratio の更新
 - face tracking の共有表示モデルと avatar 反映 state
+- GLB / VRM バイナリのパース (`VrmExtensionParser` / `VrmAvatarParser`)
+- VRM モーフターゲット・エクスプレッション定義の正規化 (`VrmSpecNormalizer` / `VrmExpressionMap`)
+- face tracking → アバター表情・ボーン状態へのマッピング (`FaceToAvatarMapper` / `AvatarMotionSmoother`)
+- アバターアセット管理 (`AvatarAssetStore`)
 - 権限文言のリソース管理
 
 ### まだ未実装の主な機能
@@ -42,7 +50,6 @@ VTuberCamera の Kotlin Multiplatform 版リポジトリです。Android と iOS
 - 写真撮影
 - 撮影画像の保存 / 削除
 - フラッシュ制御
-- ズーム制御
 - ギャラリー関連機能
 - face tracking と avatar renderer をつないだ AR / VRM の end-to-end 統合
 
@@ -65,9 +72,9 @@ VTuberCamera の Kotlin Multiplatform 版リポジトリです。Android と iOS
 
 Gradle Version Catalog で主に以下を管理しています。
 
-- 共通: Kotlin Coroutines, Compose Multiplatform, Lifecycle Compose, Kotlin Test, Turbine
-- Android: CameraX (`camera-core`, `camera-camera2`, `camera-lifecycle`, `camera-view`), Activity Compose, ExifInterface
-- iOS: AVFoundation, ARKit, SwiftUI, UIKit
+- 共通: Kotlin Coroutines, Compose Multiplatform, Lifecycle Compose, kotlinx-serialization-json, Kotlin Test, Turbine
+- Android: CameraX (`camera-core`, `camera-camera2`, `camera-lifecycle`, `camera-view`), Activity Compose, ExifInterface, ML Kit Face Detection, Filament (`filament-android`, `filament-utils-android`, `gltfio-android`)
+- iOS: AVFoundation, ARKit, SwiftUI, UIKit, Filament
 
 依存関係の詳細は [gradle/libs.versions.toml](./gradle/libs.versions.toml) を参照してください。
 

--- a/docs/KMP_IMPLEMENTATION_SPEC.ja.md
+++ b/docs/KMP_IMPLEMENTATION_SPEC.ja.md
@@ -1,32 +1,43 @@
 # KMP 実装仕様（現状同期版）
 
-最終同期日: 2026-04-17
+最終同期日: 2026-05-15
 
 この文書は `README.md` と実装コードを基準に、KMP camera MVP の「現時点で実装済み」と「計画中」を分離して記述します。
 
-## 1. 現在の確定実装（2026-04-17 時点）
+## 1. 現在の確定実装（2026-05-15 時点）
 
 ### 1.1 共通 (`composeApp/src/commonMain`)
 
 - Compose Multiplatform ベースの camera 画面構成 (`CameraRoute` / `CameraScreen`)
-- `CameraViewModel` による権限・プレビュー状態・レンズ向きの状態管理
+- `CameraViewModel` による権限・プレビュー状態・レンズ向き・ズーム・アバター状態の一元管理
 - face tracking 表示用の共有モデル (`NormalizedFaceFrame` / `FaceTrackingUiState`)
-- ファイルピッカー結果を反映する avatar preview UI（静的 overlay）
+- ズーム状態管理 (`CameraZoomUiState`) と zoom ratio 更新 API
+- ファイルピッカー結果を反映する avatar preview UI
+- GLB / VRM バイナリのパース (`VrmExtensionParser` / `VrmAvatarParser`)
+- VRM モーフターゲット・エクスプレッション定義の正規化 (`VrmSpecNormalizer` / `VrmExpressionMap`)
+- face tracking → アバター表情・ボーン状態へのマッピング (`FaceToAvatarMapper` / `AvatarMotionSmoother`)
+- アバターアセット管理 (`AvatarAssetStore`)
 
 ### 1.2 Android (`composeApp/src/androidMain`)
 
 - CameraX によるリアルタイム camera preview
 - カメラ権限確認と permission request
 - フロント / バック camera の切り替え
+- ピンチ操作によるズーム制御（`setZoomRatio` / ズームインジケーター）
 - `OpenDocument` を使ったファイル選択
 - ML Kit Face Detection を使った face tracking 解析と共有 state への反映
+- face tracking 結果をアバター状態へマッピング (`AndroidFaceTrackingToAvatarMapper`)
+- Filament renderer による VRM avatar 表示基盤
 
 ### 1.3 iOS
 
-- 実 camera 実装の中心は `composeApp/src/iosMain` の `CameraPreviewHost`（AVFoundation + UIKitView）
+- 実 camera 実装の中心は `composeApp/src/iosMain` の `IOSCameraPreview`（AVFoundation + UIKitView）
 - カメラ権限確認と permission request
 - フロント / バック camera の切り替え
+- ピンチ操作によるズーム制御
 - `UIDocumentPickerViewController` によるファイル選択
+- TrueDepth 対応デバイスの前面カメラで ARKit face tracking
+- avatar render state を Filament ブリッジへ伝達 (`IOSAvatarRenderInterop` / `IOSAvatarRenderBridge.swift`)
 - `iosApp` は Compose のホストアプリ（`MainViewController` 起動）
 
 ## 2. 未実装 / 計画中（Phase 1 以降）
@@ -36,10 +47,8 @@
 - 写真撮影
 - 撮影画像の保存 / 削除
 - フラッシュ制御
-- ズーム制御
 - ギャラリー連携
-- AR / VRM / Filament の本格描画連携
-- iOS 側の face tracking 実装（現状は Android 側中心）
+- face tracking と avatar renderer をつないだ AR / VRM の end-to-end 統合
 
 ## 3. 共有とプラットフォーム責務の整理
 


### PR DESCRIPTION
ズーム制御の実装完了、VRM パーサー/face-to-avatar マッピング/アバター
アセット管理の共有コード追加、依存ライブラリの追記 (ML Kit,
Filament, kotlinx-serialization-json) を反映。
「未実装」リストからズーム制御を削除。