### PR TITLE
[codex] Ensure iOS avatar selection replay

### DIFF
--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSAvatarRenderInterop.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSAvatarRenderInterop.kt
@@ -19,6 +19,8 @@ internal object IOSAvatarRenderInterop {
         "com.example.vtubercamera_kmp_ver.avatar.selectionDidChange"
     const val avatarSelectionDidClearNotification =
         "com.example.vtubercamera_kmp_ver.avatar.selectionDidClear"
+    const val avatarSelectionReplayRequestedNotification =
+        "com.example.vtubercamera_kmp_ver.avatar.selectionReplayRequested"
     const val avatarRenderStateDidChangeNotification =
         "com.example.vtubercamera_kmp_ver.avatar.renderStateDidChange"
 

--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
@@ -62,6 +62,7 @@ import platform.CoreGraphics.CGRectZero
 import platform.Foundation.NSData
 import platform.Foundation.NSDate
 import platform.Foundation.NSError
+import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSNumber
 import platform.Foundation.NSURL
 import platform.Foundation.create
@@ -287,8 +288,17 @@ actual fun AvatarBodyOverlay(
         }
     }
 
-    DisposableEffect(Unit) {
+    DisposableEffect(avatarSelection.assetHandle) {
+        val replayObserver = NSNotificationCenter.defaultCenter.addObserverForName(
+            name = IOSAvatarRenderInterop.avatarSelectionReplayRequestedNotification,
+            `object` = null,
+            queue = null,
+        ) {
+            IOSAvatarRenderInterop.publishSelectedAvatar(avatarSelection)
+        }
+
         onDispose {
+            NSNotificationCenter.defaultCenter.removeObserver(replayObserver)
             IOSAvatarRenderInterop.publishClearedAvatar()
         }
     }

--- a/iosApp/iosApp/AvatarRender/IOSAvatarRenderBridge.swift
+++ b/iosApp/iosApp/AvatarRender/IOSAvatarRenderBridge.swift
@@ -13,6 +13,8 @@ final class IOSAvatarRenderBridge {
         Notification.Name("com.example.vtubercamera_kmp_ver.avatar.selectionDidChange")
     static let avatarSelectionDidClearNotification =
         Notification.Name("com.example.vtubercamera_kmp_ver.avatar.selectionDidClear")
+    static let avatarSelectionReplayRequestedNotification =
+        Notification.Name("com.example.vtubercamera_kmp_ver.avatar.selectionReplayRequested")
     static let avatarRenderStateDidChangeNotification =
         Notification.Name("com.example.vtubercamera_kmp_ver.avatar.renderStateDidChange")
 
@@ -64,6 +66,7 @@ final class IOSAvatarRenderBridge {
                 self?.handleAvatarRenderStateChanged(notification)
             }
         ]
+        center.post(name: Self.avatarSelectionReplayRequestedNotification, object: nil)
     }
 
     /// Stops listening to shared Compose avatar-render notifications.

--- a/iosApp/iosAppTests/IOSAvatarRenderBridgeTests.swift
+++ b/iosApp/iosAppTests/IOSAvatarRenderBridgeTests.swift
@@ -67,6 +67,28 @@ struct IOSAvatarRenderBridgeTests {
     }
 
     @Test
+    func connectRequestsCurrentAvatarSelectionReplay() {
+        let renderer = SpyRenderStateRenderer()
+        let bridge = IOSAvatarRenderBridge(renderer: renderer)
+        var didRequestReplay = false
+        let observer = NotificationCenter.default.addObserver(
+            forName: IOSAvatarRenderBridge.avatarSelectionReplayRequestedNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            didRequestReplay = true
+        }
+        defer {
+            NotificationCenter.default.removeObserver(observer)
+            bridge.disconnect()
+        }
+
+        bridge.connect()
+
+        #expect(didRequestReplay)
+    }
+
+    @Test
     func filamentRendererBridgeStoresLatestAvatarStateCopy() {
         let bridge = VTCFilamentRendererBridge()
         let state = VTCAvatarRenderState()


### PR DESCRIPTION
## Summary

- Add an iOS avatar-selection replay notification so the Swift renderer can request the latest selected avatar after connecting.
- Re-publish the current Compose iOS avatar selection when that replay request is received.
- Cover the replay request behavior in `IOSAvatarRenderBridgeTests`.

## Why

The iOS renderer listens through NotificationCenter from a separate SwiftUI layer. If the renderer connected after Compose had already published the selected avatar, the native avatar view could miss the selection payload and fail to show the avatar preview. Android hosts its renderer directly in Compose and does not have the same notification ordering gap.

## Validation

- `./gradlew :composeApp:compileKotlinIosSimulatorArm64`
- `xcodebuild test -project iosApp/iosApp.xcodeproj -scheme iosAppTest -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2'`
