### PR TITLE
Configure release build signing

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -86,6 +86,7 @@ android {
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
     compileOptions {


### PR DESCRIPTION
## Summary
- Configure the release build type to use the debug signing config.

## Changes
- Add signingConfig to the composeApp release build type.

## Test Plan
- Not run (PR uses the already-pushed origin/buildRelease change only; local untracked .codex/config.toml was left untouched).

## Related Issues
- None