### PR TITLE
Split CameraViewModel into per-domain controllers (#149)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
@@ -140,7 +140,7 @@ fun CameraScreen(
     modifier: Modifier = Modifier,
     rendererHost: CameraRendererHost = defaultCameraRendererHost,
 ) {
-    val previewError = uiState.previewState as? PreviewState.Error
+    val previewError = uiState.session.previewState as? PreviewState.Error
 
     Box(
         modifier = modifier
@@ -149,7 +149,7 @@ fun CameraScreen(
     ) {
         when {
             uiState.isPermissionChecking -> LoadingState()
-            uiState.permissionState == PermissionState.Denied -> PermissionDeniedState(
+            uiState.permission.permissionState == PermissionState.Denied -> PermissionDeniedState(
                 onRequestPermission = onRequestPermission,
             )
 
@@ -175,7 +175,7 @@ fun CameraScreen(
             else -> LoadingState()
         }
 
-        uiState.message?.let { message ->
+        uiState.session.message?.let { message ->
             CameraMessageBanner(
                 message = message,
                 modifier = Modifier
@@ -184,7 +184,7 @@ fun CameraScreen(
             )
         }
 
-        uiState.filePickerErrorMessageRes?.let { messageRes ->
+        uiState.avatarSelection.filePickerErrorMessageRes?.let { messageRes ->
             AlertDialog(
                 onDismissRequest = onDismissFilePickerError,
                 title = { Text(stringResource(Res.string.avatar_error_dialog_title)) },
@@ -213,21 +213,21 @@ private fun CameraPreviewState(
     themeMode: ThemeMode,
     onThemeModeToggle: () -> Unit,
 ) {
-    val avatarSelection = uiState.avatarSelection
+    val avatarSelection = uiState.avatarSelection.avatarSelection
     val avatarPreview = uiState.avatarPreview
 
     Box(modifier = Modifier.fillMaxSize()) {
         CameraBackgroundLayer(
             cameraRepository = cameraRepository,
-            lensFacing = uiState.lensFacing,
-            zoomScale = uiState.cameraZoomScale,
+            lensFacing = uiState.session.lensFacing,
+            zoomScale = DEFAULT_CAMERA_ZOOM_SCALE,
             onFaceTrackingFrameChanged = onFaceTrackingFrameChanged,
             onLensFacingChanged = onLensFacingChanged,
         )
         CameraRendererLayer(
             avatarSelection = avatarSelection,
             avatarPreview = avatarPreview,
-            avatarRenderState = uiState.avatarRenderState,
+            avatarRenderState = uiState.avatarRender,
             onAvatarRenderLoadFailed = onAvatarRenderLoadFailed,
             rendererHost = rendererHost,
         )
@@ -244,7 +244,7 @@ private fun CameraPreviewState(
         CameraUiLayer(
             avatarPreview = avatarPreview,
             faceTracking = uiState.faceTracking,
-            zoomScale = uiState.zoomUiState.currentCameraZoomRatio,
+            zoomScale = uiState.zoom.currentCameraZoomRatio,
             onOpenFilePicker = onOpenFilePicker,
             onLensFacingToggle = onLensFacingToggle,
             themeMode = themeMode,

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
@@ -1,33 +1,30 @@
 package com.example.vtubercamera_kmp_ver.camera
 
 import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
-import org.jetbrains.compose.resources.StringResource
+import com.example.vtubercamera_kmp_ver.camera.avatar.AvatarSelectionUiState
+import com.example.vtubercamera_kmp_ver.camera.permission.CameraPermissionUiState
+import com.example.vtubercamera_kmp_ver.camera.session.CameraSessionUiState
 
-// カメラ画面で描画する共有 UI 状態をまとめて保持する。
+// カメラ画面で描画する共有 UI 状態を、ドメインごとの sub-state を束ねて保持する。
 data class CameraUiState(
-    val lensFacing: CameraLensFacing = CameraLensFacing.Back,
-    val permissionState: PermissionState = PermissionState.Unknown,
-    val previewState: PreviewState = PreviewState.Preparing,
-    val errorState: CameraError? = null,
-    val message: CameraMessage? = null,
+    val session: CameraSessionUiState = CameraSessionUiState(),
+    val permission: CameraPermissionUiState = CameraPermissionUiState(),
+    val zoom: CameraZoomUiState = CameraZoomUiState(),
     val faceTracking: FaceTrackingUiState = FaceTrackingUiState(),
-    val avatarSelection: AvatarSelectionData? = null,
-    val avatarRenderState: AvatarRenderState = AvatarRenderState.Neutral,
-    val filePickerErrorMessageRes: StringResource? = null,
-    val cameraZoomScale: Float = DEFAULT_CAMERA_ZOOM_SCALE,
-    val zoomUiState: CameraZoomUiState = CameraZoomUiState()
+    val avatarRender: AvatarRenderState = AvatarRenderState.Neutral,
+    val avatarSelection: AvatarSelectionUiState = AvatarSelectionUiState(),
 ) {
     val isPermissionGranted: Boolean
-        get() = permissionState == PermissionState.Granted
+        get() = permission.permissionState == PermissionState.Granted
 
     val isPermissionChecking: Boolean
-        get() = permissionState == PermissionState.Unknown
+        get() = permission.permissionState == PermissionState.Unknown
 
     val hasError: Boolean
-        get() = errorState != null || previewState is PreviewState.Error
+        get() = session.errorState != null || session.previewState is PreviewState.Error
 
     val avatarPreview: AvatarPreviewData?
-        get() = avatarSelection?.preview
+        get() = avatarSelection.avatarSelection?.preview
 }
 
 internal const val DEFAULT_CAMERA_ZOOM_SCALE = 1f

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
@@ -2,307 +2,146 @@ package com.example.vtubercamera_kmp_ver.camera
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.vtubercamera_kmp_ver.avatar.mapping.FaceToAvatarMapper
-import kotlin.math.roundToInt
+import com.example.vtubercamera_kmp_ver.camera.avatar.AvatarSelectionController
+import com.example.vtubercamera_kmp_ver.camera.facetracking.FaceTrackingPresenter
+import com.example.vtubercamera_kmp_ver.camera.permission.CameraPermissionCoordinator
+import com.example.vtubercamera_kmp_ver.camera.permission.PermissionChange
+import com.example.vtubercamera_kmp_ver.camera.session.CameraSessionController
+import com.example.vtubercamera_kmp_ver.camera.zoom.CameraZoomController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
-import vtubercamera_kmp_ver.composeapp.generated.resources.Res
-import vtubercamera_kmp_ver.composeapp.generated.resources.camera_error_permission_denied
-import vtubercamera_kmp_ver.composeapp.generated.resources.camera_error_retrying_preview
-import vtubercamera_kmp_ver.composeapp.generated.resources.camera_error_switching_lens
 
-// 共有のカメラ状態、権限遷移、プレビュー開始、ファイル選択結果をまとめて制御する。
+// ドメインごとの controller / presenter を束ねるカメラ画面の薄い coordinator。
 class CameraViewModel(
-    private val cameraRepository: CameraRepository,
-    private val permissionRepository: PermissionRepository,
+    cameraRepository: CameraRepository,
+    permissionRepository: PermissionRepository,
 ) : ViewModel() {
-    private val faceToAvatarMapper = FaceToAvatarMapper()
-    private var currentAvatarAssetHandle: AvatarAssetHandle? = null
+    private val sessionController = CameraSessionController(
+        cameraRepository = cameraRepository,
+        scope = viewModelScope,
+    )
+    private val permissionCoordinator = CameraPermissionCoordinator(
+        permissionRepository = permissionRepository,
+        scope = viewModelScope,
+    ).apply {
+        onPermissionChanged = ::applyPermissionChange
+        onPermissionRequested = sessionController::clearError
+    }
+    private val zoomController = CameraZoomController(
+        cameraRepository = cameraRepository,
+        scope = viewModelScope,
+    )
+    private val faceTrackingPresenter = FaceTrackingPresenter()
+    private val avatarSelectionController = AvatarSelectionController()
+
     private val _uiState = MutableStateFlow(CameraUiState())
     val uiState: StateFlow<CameraUiState> = _uiState.asStateFlow()
 
+    // controller の同期 update 直後に uiState.value が見えるよう、Unconfined で per-controller collect する。
+    // viewModelScope の Job を共有しているため、ViewModel cleared 時にまとめて cancel される。
+    private val mirrorScope = CoroutineScope(
+        viewModelScope.coroutineContext + Dispatchers.Unconfined,
+    )
+
     init {
-        viewModelScope.launch {
-            observePreviewState()
-        }
-        viewModelScope.launch {
-            observeZoomState()
-        }
-    }
-
-    // 画面初期化時に権限状態を確認し、必要ならプレビュー開始やエラー反映を行う。
-    fun initialize() {
-        viewModelScope.launch {
-            val permissionState = permissionRepository.checkCameraPermission()
-            _uiState.update { it.copy(permissionState = permissionState) }
-
-            if (permissionState == PermissionState.Granted) {
-                startCameraPreview()
-            } else if (permissionState == PermissionState.Denied) {
-                setError(CameraError.PermissionDenied)
+        mirrorScope.launch {
+            sessionController.state.collect { session ->
+                _uiState.update { it.copy(session = session) }
             }
         }
-    }
-
-    // カメラ権限の再要求フローを開始し、UI の一時状態を整える。
-    fun onRequestPermission() {
-        viewModelScope.launch {
-            _uiState.update { state ->
-                state.copy(
-                    permissionState = PermissionState.Unknown,
-                    errorState = null,
-                    message = null,
-                    previewState = state.previewState,
-                )
-            }
-            permissionRepository.requestCameraPermission()
-        }
-    }
-
-    // プレビュー再試行時の案内メッセージを出しつつ開始処理をやり直す。
-    fun onRetryPreview() {
-        viewModelScope.launch {
-            _uiState.update {
-                it.copy(
-                    previewState = PreviewState.Preparing,
-                    errorState = null,
-                    message = CameraMessage(
-                        type = CameraMessageType.Guide,
-                        messageRes = Res.string.camera_error_retrying_preview,
-                    ),
-                )
-            }
-            cameraRepository.startPreview(_uiState.value.lensFacing)
-                .onSuccess { resolvedLens ->
-                    _uiState.update { it.copy(lensFacing = resolvedLens, message = null) }
-                }
-                .onFailure {
-                    setError(it.toCameraError(CameraError.PreviewInitializationFailed))
-                }
-        }
-    }
-
-    // 実際に選択されたレンズ向きを UI 状態へ反映する。
-    fun onLensFacingChanged(lensFacing: CameraLensFacing) {
-        _uiState.update { currentState ->
-            currentState.copy(
-                lensFacing = lensFacing,
-            )
-        }
-    }
-
-    // ネイティブ側から受け取った権限状態の変化を UI 状態へ反映する。
-    fun onPermissionStateChanged(
-        isGranted: Boolean,
-        isChecking: Boolean,
-    ) {
-        val permissionState = when {
-            isChecking -> PermissionState.Unknown
-            isGranted -> PermissionState.Granted
-            else -> PermissionState.Denied
-        }
-        val previousPermissionState = _uiState.value.permissionState
-        _uiState.update { currentState ->
-            when (permissionState) {
-                PermissionState.Denied -> currentState.copy(
-                    permissionState = permissionState,
-                    errorState = CameraError.PermissionDenied,
-                    previewState = PreviewState.Error(CameraError.PermissionDenied),
-                    message = CameraMessage(
-                        type = CameraMessageType.Error,
-                        messageRes = Res.string.camera_error_permission_denied,
-                    ),
-                )
-                PermissionState.Granted -> currentState.copy(
-                    permissionState = permissionState,
-                    errorState = null,
-                    message = null,
-                    previewState = PreviewState.Preparing,
-                )
-                PermissionState.Unknown -> currentState.copy(
-                    permissionState = permissionState,
-                    errorState = null,
-                    message = null,
-                    previewState = if (currentState.previewState is PreviewState.Error) {
-                        PreviewState.Preparing
-                    } else {
-                        currentState.previewState
-                    },
-                )
+        mirrorScope.launch {
+            permissionCoordinator.state.collect { permission ->
+                _uiState.update { it.copy(permission = permission) }
             }
         }
-        if (permissionState == PermissionState.Granted && previousPermissionState != PermissionState.Granted) {
-            viewModelScope.launch {
-                startCameraPreview()
+        mirrorScope.launch {
+            zoomController.state.collect { zoom ->
+                _uiState.update { it.copy(zoom = zoom) }
             }
         }
-    }
-
-    // 前後カメラの切り替え要求を発行し、切り替え中の状態を表示する。
-    fun onToggleLensFacing() {
-        viewModelScope.launch {
-            val currentLens = _uiState.value.lensFacing
-            _uiState.update { state ->
-                state.copy(
-                    previewState = PreviewState.Preparing,
-                    message = CameraMessage(
-                        type = CameraMessageType.Guide,
-                        messageRes = Res.string.camera_error_switching_lens,
-                    ),
-                )
-            }
-
-            cameraRepository.switchLens(currentLens)
-                .onSuccess { switchedLens ->
-                    _uiState.update { state ->
-                        state.copy(
-                            lensFacing = switchedLens,
-                            errorState = null,
-                            message = null,
-                        )
-                    }
-                }
-                .onFailure {
-                    setError(CameraError.LensSwitchFailed)
-                }
-        }
-    }
-
-    // 顔トラッキング結果を画面表示用の状態へ変換して保持する。
-    fun onFaceTrackingFrameChanged(frame: NormalizedFaceFrame?) {
-        _uiState.update { currentState ->
-            val avatarRenderState = faceToAvatarMapper.map(
-                frame = frame,
-                previousState = currentState.avatarRenderState,
-            )
-            currentState.copy(
-                faceTracking = FaceTrackingUiState(
-                    isTracking = frame != null,
-                    frame = frame,
-                    display = frame?.toDisplayState(),
-                ),
-                avatarRenderState = avatarRenderState,
-            )
-        }
-    }
-
-    // ファイルピッカーの結果に応じてアバタープレビューやエラーを更新する。
-    fun onFilePicked(result: FilePickerResult) {
-        when (result) {
-            is FilePickerResult.Success -> {
-                currentAvatarAssetHandle?.let(AvatarAssetStore::remove)
-                currentAvatarAssetHandle = result.avatarSelection.assetHandle
-                _uiState.update { currentState ->
-                    currentState.copy(
-                        avatarSelection = result.avatarSelection,
-                        filePickerErrorMessageRes = null,
+        mirrorScope.launch {
+            faceTrackingPresenter.state.collect { presenter ->
+                _uiState.update {
+                    it.copy(
+                        faceTracking = presenter.faceTracking,
+                        avatarRender = presenter.avatarRender,
                     )
                 }
             }
-            is FilePickerResult.Error -> _uiState.update { currentState ->
-                currentState.copy(
-                    filePickerErrorMessageRes = result.messageRes,
-                )
+        }
+        mirrorScope.launch {
+            avatarSelectionController.state.collect { avatarSelection ->
+                _uiState.update { it.copy(avatarSelection = avatarSelection) }
             }
-            FilePickerResult.Cancelled -> Unit
         }
     }
 
-    // renderer 側の avatar 読み込み失敗を UI エラーへ変換し、現在の選択を解除する。
+    fun initialize() {
+        permissionCoordinator.initialize()
+    }
+
+    fun onRequestPermission() {
+        permissionCoordinator.onRequestPermission()
+    }
+
+    fun onRetryPreview() {
+        sessionController.onRetryPreview()
+    }
+
+    fun onLensFacingChanged(lensFacing: CameraLensFacing) {
+        sessionController.onLensFacingChanged(lensFacing)
+    }
+
+    fun onPermissionStateChanged(isGranted: Boolean, isChecking: Boolean) {
+        permissionCoordinator.onPermissionStateChanged(isGranted, isChecking)
+    }
+
+    fun onToggleLensFacing() {
+        sessionController.onToggleLensFacing()
+    }
+
+    fun onFaceTrackingFrameChanged(frame: NormalizedFaceFrame?) {
+        faceTrackingPresenter.onFaceTrackingFrameChanged(frame)
+    }
+
+    fun onFilePicked(result: FilePickerResult) {
+        avatarSelectionController.onFilePicked(result)
+    }
+
     fun onAvatarRenderLoadFailed(
         failedAssetHandle: AvatarAssetHandle,
         messageRes: StringResource,
     ) {
-        if (currentAvatarAssetHandle != failedAssetHandle) {
-            return
-        }
-        currentAvatarAssetHandle?.let(AvatarAssetStore::remove)
-        currentAvatarAssetHandle = null
-        _uiState.update { currentState ->
-            currentState.copy(
-                avatarSelection = null,
-                filePickerErrorMessageRes = messageRes,
-            )
-        }
+        avatarSelectionController.onAvatarRenderLoadFailed(failedAssetHandle, messageRes)
     }
 
-    // ピンチ操作によるズーム倍率の変化を UI 状態へ反映する。
     fun onCameraZoomChanged(scaleChange: Float) {
-        val zoomState = uiState.value.zoomUiState
-       cameraRepository.setZoomRatio(
-           (zoomState.currentCameraZoomRatio * scaleChange).coerceIn(
-               zoomState.minCameraZoomRatio,
-               zoomState.maxCameraZoomRatio
-           )
-       )
+        zoomController.onCameraZoomChanged(scaleChange)
     }
 
-    // ファイル選択エラー表示を閉じる。
     fun onDismissFilePickerError() {
-        _uiState.update { currentState ->
-            currentState.copy(filePickerErrorMessageRes = null)
-        }
+        avatarSelectionController.onDismissFilePickerError()
     }
 
     internal fun releaseCurrentAvatarAsset() {
-        currentAvatarAssetHandle?.let(AvatarAssetStore::remove)
-        currentAvatarAssetHandle = null
+        avatarSelectionController.release()
     }
 
-    // リポジトリのプレビュー状態を監視して UI 状態へ同期する。
-    private suspend fun observePreviewState() {
-        cameraRepository.observePreviewState().collect { previewState ->
-            _uiState.update { currentState ->
-                val error = (previewState as? PreviewState.Error)?.error
-                currentState.copy(
-                    previewState = previewState,
-                    errorState = error,
-                    message = error?.toCameraMessage(),
-                )
+    private fun applyPermissionChange(change: PermissionChange) {
+        when (change) {
+            PermissionChange.GrantedEntered -> {
+                sessionController.clearErrorAndPrepare()
+                viewModelScope.launch { sessionController.start() }
             }
-        }
-    }
-
-    private suspend fun observeZoomState(){
-        cameraRepository.observeZoomState().collect { zoomUiState ->
-            _uiState.update { currentState ->
-                currentState.copy(
-                    zoomUiState = zoomUiState
-                )
-            }
-        }
-    }
-
-    // 利用可能な初期レンズを解決したうえでカメラプレビュー開始を依頼する。
-    private suspend fun startCameraPreview() {
-        val initialLensResult = cameraRepository.resolveInitialLens(_uiState.value.lensFacing)
-        if (initialLensResult.isFailure) {
-            setError(initialLensResult.exceptionOrNull().toCameraError(CameraError.CameraUnavailable))
-            return
-        }
-        val initialLens = initialLensResult.getOrDefault(_uiState.value.lensFacing)
-        _uiState.update { it.copy(lensFacing = initialLens) }
-        cameraRepository.startPreview(initialLens)
-            .onSuccess { resolvedLens ->
-                _uiState.update { it.copy(lensFacing = resolvedLens) }
-            }
-            .onFailure {
-                setError(it.toCameraError(CameraError.PreviewInitializationFailed))
-            }
-    }
-
-    // カメラ関連エラーを UI のエラー表示状態へ集約して反映する。
-    private fun setError(error: CameraError) {
-        _uiState.update { currentState ->
-            currentState.copy(
-                previewState = PreviewState.Error(error),
-                errorState = error,
-                message = error.toCameraMessage(),
-            )
+            PermissionChange.GrantedRefreshed -> sessionController.clearErrorAndPrepare()
+            PermissionChange.DeniedReceived -> sessionController.setError(CameraError.PermissionDenied)
+            PermissionChange.UnknownReceived -> sessionController.resetPreviewIfErrored()
         }
     }
 
@@ -311,22 +150,3 @@ class CameraViewModel(
         super.onCleared()
     }
 }
-
-// リポジトリ由来の例外から共通のカメラエラー種別を取り出す。
-private fun Throwable?.toCameraError(fallback: CameraError): CameraError =
-    (this as? CameraRepositoryException)?.error ?: fallback
-
-// 顔トラッキングの生データを画面表示用ラベル付き状態へ変換する。
-private fun NormalizedFaceFrame.toDisplayState(): FaceTrackingDisplayState =
-    FaceTrackingDisplayState(
-        headYawLabel = "${headYawDegrees.roundToInt()} deg",
-        headPitchLabel = "${headPitchDegrees.roundToInt()} deg",
-        headRollLabel = "${headRollDegrees.roundToInt()} deg",
-        leftEyeBlinkLabel = leftEyeBlink.asPercentLabel(),
-        rightEyeBlinkLabel = rightEyeBlink.asPercentLabel(),
-        jawOpenLabel = jawOpen.asPercentLabel(),
-        mouthSmileLabel = mouthSmile.asPercentLabel(),
-    )
-
-// 0 から 1 の値をパーセント表記へ整形する。
-private fun Float.asPercentLabel(): String = "${(coerceIn(0f, 1f) * 100).roundToInt()}%"

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/avatar/AvatarSelectionController.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/avatar/AvatarSelectionController.kt
@@ -1,0 +1,67 @@
+package com.example.vtubercamera_kmp_ver.camera.avatar
+
+import com.example.vtubercamera_kmp_ver.camera.AvatarAssetHandle
+import com.example.vtubercamera_kmp_ver.camera.AvatarAssetStore
+import com.example.vtubercamera_kmp_ver.camera.FilePickerResult
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import org.jetbrains.compose.resources.StringResource
+
+// アバター選択ファイルの状態と AvatarAssetStore 上のリソース寿命を一元管理する。
+class AvatarSelectionController {
+    private val _state = MutableStateFlow(AvatarSelectionUiState())
+    val state: StateFlow<AvatarSelectionUiState> = _state.asStateFlow()
+
+    private var currentAvatarAssetHandle: AvatarAssetHandle? = null
+
+    // ファイルピッカーの結果に応じてアバタープレビューやエラーを更新する。
+    fun onFilePicked(result: FilePickerResult) {
+        when (result) {
+            is FilePickerResult.Success -> {
+                currentAvatarAssetHandle?.let(AvatarAssetStore::remove)
+                currentAvatarAssetHandle = result.avatarSelection.assetHandle
+                _state.update {
+                    it.copy(
+                        avatarSelection = result.avatarSelection,
+                        filePickerErrorMessageRes = null,
+                    )
+                }
+            }
+            is FilePickerResult.Error -> _state.update {
+                it.copy(filePickerErrorMessageRes = result.messageRes)
+            }
+            FilePickerResult.Cancelled -> Unit
+        }
+    }
+
+    // renderer 側の avatar 読み込み失敗を UI エラーへ変換し、現在の選択を解除する。
+    fun onAvatarRenderLoadFailed(
+        failedAssetHandle: AvatarAssetHandle,
+        messageRes: StringResource,
+    ) {
+        if (currentAvatarAssetHandle != failedAssetHandle) {
+            return
+        }
+        currentAvatarAssetHandle?.let(AvatarAssetStore::remove)
+        currentAvatarAssetHandle = null
+        _state.update {
+            it.copy(
+                avatarSelection = null,
+                filePickerErrorMessageRes = messageRes,
+            )
+        }
+    }
+
+    // ファイル選択エラー表示を閉じる。
+    fun onDismissFilePickerError() {
+        _state.update { it.copy(filePickerErrorMessageRes = null) }
+    }
+
+    // 現在保持しているアバターアセットを AvatarAssetStore から解放する。
+    fun release() {
+        currentAvatarAssetHandle?.let(AvatarAssetStore::remove)
+        currentAvatarAssetHandle = null
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/avatar/AvatarSelectionUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/avatar/AvatarSelectionUiState.kt
@@ -1,0 +1,10 @@
+package com.example.vtubercamera_kmp_ver.camera.avatar
+
+import com.example.vtubercamera_kmp_ver.camera.AvatarSelectionData
+import org.jetbrains.compose.resources.StringResource
+
+// 現在選択中のアバター情報とファイル選択エラーの表示メッセージを保持する。
+data class AvatarSelectionUiState(
+    val avatarSelection: AvatarSelectionData? = null,
+    val filePickerErrorMessageRes: StringResource? = null,
+)

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/facetracking/FaceTrackingPresenter.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/facetracking/FaceTrackingPresenter.kt
@@ -1,0 +1,58 @@
+package com.example.vtubercamera_kmp_ver.camera.facetracking
+
+import com.example.vtubercamera_kmp_ver.avatar.mapping.FaceToAvatarMapper
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
+import com.example.vtubercamera_kmp_ver.camera.FaceTrackingDisplayState
+import com.example.vtubercamera_kmp_ver.camera.FaceTrackingUiState
+import com.example.vtubercamera_kmp_ver.camera.NormalizedFaceFrame
+import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+// 顔トラッキングの生フレームを画面表示用ラベルと avatar render state へ変換する。
+class FaceTrackingPresenter(
+    private val faceToAvatarMapper: FaceToAvatarMapper = FaceToAvatarMapper(),
+) {
+    private val _state = MutableStateFlow(FaceTrackingPresenterState())
+    val state: StateFlow<FaceTrackingPresenterState> = _state.asStateFlow()
+
+    fun onFaceTrackingFrameChanged(frame: NormalizedFaceFrame?) {
+        _state.update { current ->
+            val nextAvatarRender = faceToAvatarMapper.map(
+                frame = frame,
+                previousState = current.avatarRender,
+            )
+            FaceTrackingPresenterState(
+                faceTracking = FaceTrackingUiState(
+                    isTracking = frame != null,
+                    frame = frame,
+                    display = frame?.toDisplayState(),
+                ),
+                avatarRender = nextAvatarRender,
+            )
+        }
+    }
+}
+
+// 顔トラッキング表示状態と avatar render state をまとめて伝えるための内部状態。
+data class FaceTrackingPresenterState(
+    val faceTracking: FaceTrackingUiState = FaceTrackingUiState(),
+    val avatarRender: AvatarRenderState = AvatarRenderState.Neutral,
+)
+
+// 顔トラッキングの生データを画面表示用ラベル付き状態へ変換する。
+private fun NormalizedFaceFrame.toDisplayState(): FaceTrackingDisplayState =
+    FaceTrackingDisplayState(
+        headYawLabel = "${headYawDegrees.roundToInt()} deg",
+        headPitchLabel = "${headPitchDegrees.roundToInt()} deg",
+        headRollLabel = "${headRollDegrees.roundToInt()} deg",
+        leftEyeBlinkLabel = leftEyeBlink.asPercentLabel(),
+        rightEyeBlinkLabel = rightEyeBlink.asPercentLabel(),
+        jawOpenLabel = jawOpen.asPercentLabel(),
+        mouthSmileLabel = mouthSmile.asPercentLabel(),
+    )
+
+// 0 から 1 の値をパーセント表記へ整形する。
+private fun Float.asPercentLabel(): String = "${(coerceIn(0f, 1f) * 100).roundToInt()}%"

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/permission/CameraPermissionCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/permission/CameraPermissionCoordinator.kt
@@ -1,0 +1,87 @@
+package com.example.vtubercamera_kmp_ver.camera.permission
+
+import com.example.vtubercamera_kmp_ver.camera.PermissionRepository
+import com.example.vtubercamera_kmp_ver.camera.PermissionState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+// 権限状態の変化を表す型。CameraViewModel が session 側の同期/非同期エフェクトを wiring する。
+sealed interface PermissionChange {
+    // 非 Granted → Granted への遷移。CameraSession を新規に開始する必要がある。
+    data object GrantedEntered : PermissionChange
+
+    // 既に Granted の状態で再度 Granted を受け取った場合。preview 表示はリセットするが session は起動済み。
+    data object GrantedRefreshed : PermissionChange
+
+    // Denied への遷移、または初回 Denied 受信。
+    data object DeniedReceived : PermissionChange
+
+    // Unknown への遷移 (権限ダイアログ表示中など)。
+    data object UnknownReceived : PermissionChange
+}
+
+// カメラ権限の確認・要求と、その状態遷移に応じた他ドメインへの通知を仲介する。
+class CameraPermissionCoordinator(
+    private val permissionRepository: PermissionRepository,
+    private val scope: CoroutineScope,
+) {
+    private val _state = MutableStateFlow(CameraPermissionUiState())
+    val state: StateFlow<CameraPermissionUiState> = _state.asStateFlow()
+
+    // 権限状態の遷移を通知するコールバック。CameraViewModel が各 change を session 側 API へ wiring する。
+    var onPermissionChanged: (PermissionChange) -> Unit = {}
+
+    // Request 開始時に呼ばれる。CameraViewModel が session.clearError() を wiring する。
+    var onPermissionRequested: () -> Unit = {}
+
+    // 画面初期化時に権限状態を確認し、対応する遷移コールバックを発火する。
+    fun initialize() {
+        scope.launch {
+            val previousState = _state.value.permissionState
+            val nextState = permissionRepository.checkCameraPermission()
+            _state.update { it.copy(permissionState = nextState) }
+            dispatchChange(previousState, nextState)
+        }
+    }
+
+    // カメラ権限の再要求フローを開始する。Unknown 表示 + 同期コールバック + 非同期要求。
+    fun onRequestPermission() {
+        _state.update { it.copy(permissionState = PermissionState.Unknown) }
+        onPermissionRequested()
+        scope.launch {
+            permissionRepository.requestCameraPermission()
+        }
+    }
+
+    // ネイティブ側から受け取った権限状態の変化を反映し、必要な遷移コールバックを同期的に発火する。
+    fun onPermissionStateChanged(
+        isGranted: Boolean,
+        isChecking: Boolean,
+    ) {
+        val nextState = when {
+            isChecking -> PermissionState.Unknown
+            isGranted -> PermissionState.Granted
+            else -> PermissionState.Denied
+        }
+        val previousState = _state.value.permissionState
+        _state.update { it.copy(permissionState = nextState) }
+        dispatchChange(previousState, nextState)
+    }
+
+    private fun dispatchChange(previous: PermissionState, next: PermissionState) {
+        val change = when (next) {
+            PermissionState.Granted -> if (previous == PermissionState.Granted) {
+                PermissionChange.GrantedRefreshed
+            } else {
+                PermissionChange.GrantedEntered
+            }
+            PermissionState.Denied -> PermissionChange.DeniedReceived
+            PermissionState.Unknown -> PermissionChange.UnknownReceived
+        }
+        onPermissionChanged(change)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/permission/CameraPermissionUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/permission/CameraPermissionUiState.kt
@@ -1,0 +1,8 @@
+package com.example.vtubercamera_kmp_ver.camera.permission
+
+import com.example.vtubercamera_kmp_ver.camera.PermissionState
+
+// カメラ権限の確認・要求の進行状態を保持する。
+data class CameraPermissionUiState(
+    val permissionState: PermissionState = PermissionState.Unknown,
+)

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/session/CameraSessionController.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/session/CameraSessionController.kt
@@ -1,0 +1,168 @@
+package com.example.vtubercamera_kmp_ver.camera.session
+
+import com.example.vtubercamera_kmp_ver.camera.CameraError
+import com.example.vtubercamera_kmp_ver.camera.CameraLensFacing
+import com.example.vtubercamera_kmp_ver.camera.CameraMessage
+import com.example.vtubercamera_kmp_ver.camera.CameraMessageType
+import com.example.vtubercamera_kmp_ver.camera.CameraRepository
+import com.example.vtubercamera_kmp_ver.camera.CameraRepositoryException
+import com.example.vtubercamera_kmp_ver.camera.PreviewState
+import com.example.vtubercamera_kmp_ver.camera.toCameraMessage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import vtubercamera_kmp_ver.composeapp.generated.resources.Res
+import vtubercamera_kmp_ver.composeapp.generated.resources.camera_error_retrying_preview
+import vtubercamera_kmp_ver.composeapp.generated.resources.camera_error_switching_lens
+
+// カメラセッションのライフサイクル (preview start / retry / lens 切替 / repository state 同期) を担う。
+class CameraSessionController(
+    private val cameraRepository: CameraRepository,
+    private val scope: CoroutineScope,
+) {
+    private val _state = MutableStateFlow(CameraSessionUiState())
+    val state: StateFlow<CameraSessionUiState> = _state.asStateFlow()
+
+    init {
+        scope.launch { observePreviewState() }
+    }
+
+    // 初期レンズを解決したうえでカメラプレビュー開始を依頼する。
+    suspend fun start() {
+        val initialLensResult = cameraRepository.resolveInitialLens(_state.value.lensFacing)
+        if (initialLensResult.isFailure) {
+            setError(initialLensResult.exceptionOrNull().toCameraError(CameraError.CameraUnavailable))
+            return
+        }
+        val initialLens = initialLensResult.getOrDefault(_state.value.lensFacing)
+        _state.update { it.copy(lensFacing = initialLens) }
+        cameraRepository.startPreview(initialLens)
+            .onSuccess { resolvedLens ->
+                _state.update { it.copy(lensFacing = resolvedLens) }
+            }
+            .onFailure {
+                setError(it.toCameraError(CameraError.PreviewInitializationFailed))
+            }
+    }
+
+    // プレビュー再試行時の案内メッセージを出しつつ開始処理をやり直す。
+    fun onRetryPreview() {
+        scope.launch {
+            _state.update {
+                it.copy(
+                    previewState = PreviewState.Preparing,
+                    errorState = null,
+                    message = CameraMessage(
+                        type = CameraMessageType.Guide,
+                        messageRes = Res.string.camera_error_retrying_preview,
+                    ),
+                )
+            }
+            cameraRepository.startPreview(_state.value.lensFacing)
+                .onSuccess { resolvedLens ->
+                    _state.update { it.copy(lensFacing = resolvedLens, message = null) }
+                }
+                .onFailure {
+                    setError(it.toCameraError(CameraError.PreviewInitializationFailed))
+                }
+        }
+    }
+
+    // 前後カメラの切り替え要求を発行し、切り替え中の状態を表示する。
+    fun onToggleLensFacing() {
+        scope.launch {
+            val currentLens = _state.value.lensFacing
+            _state.update { current ->
+                current.copy(
+                    previewState = PreviewState.Preparing,
+                    message = CameraMessage(
+                        type = CameraMessageType.Guide,
+                        messageRes = Res.string.camera_error_switching_lens,
+                    ),
+                )
+            }
+
+            cameraRepository.switchLens(currentLens)
+                .onSuccess { switchedLens ->
+                    _state.update { current ->
+                        current.copy(
+                            lensFacing = switchedLens,
+                            errorState = null,
+                            message = null,
+                        )
+                    }
+                }
+                .onFailure {
+                    setError(CameraError.LensSwitchFailed)
+                }
+        }
+    }
+
+    // 実際に選択されたレンズ向きを UI 状態へ反映する。
+    fun onLensFacingChanged(lensFacing: CameraLensFacing) {
+        _state.update { it.copy(lensFacing = lensFacing) }
+    }
+
+    // 権限の再要求などプレビューを継続したまま、付帯するエラー表示だけ消したい場合の同期エントリ。
+    fun clearError() {
+        _state.update { it.copy(errorState = null, message = null) }
+    }
+
+    // 権限が Denied→Granted へ復帰した直後など、エラーを消してプレビュー準備中扱いに戻すための同期エントリ。
+    fun clearErrorAndPrepare() {
+        _state.update {
+            it.copy(
+                previewState = PreviewState.Preparing,
+                errorState = null,
+                message = null,
+            )
+        }
+    }
+
+    // 権限が Unknown へ戻った際、エラー表示中であればプレビュー準備中扱いへリセットする同期エントリ。
+    fun resetPreviewIfErrored() {
+        _state.update { current ->
+            if (current.previewState is PreviewState.Error) {
+                current.copy(
+                    previewState = PreviewState.Preparing,
+                    errorState = null,
+                    message = null,
+                )
+            } else {
+                current
+            }
+        }
+    }
+
+    // カメラ関連エラーをセッション状態へ集約して反映する。
+    fun setError(error: CameraError) {
+        _state.update {
+            it.copy(
+                previewState = PreviewState.Error(error),
+                errorState = error,
+                message = error.toCameraMessage(),
+            )
+        }
+    }
+
+    // リポジトリのプレビュー状態を監視してセッション状態へ同期する。
+    private suspend fun observePreviewState() {
+        cameraRepository.observePreviewState().collect { previewState ->
+            _state.update { current ->
+                val error = (previewState as? PreviewState.Error)?.error
+                current.copy(
+                    previewState = previewState,
+                    errorState = error,
+                    message = error?.toCameraMessage(),
+                )
+            }
+        }
+    }
+}
+
+// リポジトリ由来の例外から共通のカメラエラー種別を取り出す。
+private fun Throwable?.toCameraError(fallback: CameraError): CameraError =
+    (this as? CameraRepositoryException)?.error ?: fallback

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/session/CameraSessionUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/session/CameraSessionUiState.kt
@@ -1,0 +1,14 @@
+package com.example.vtubercamera_kmp_ver.camera.session
+
+import com.example.vtubercamera_kmp_ver.camera.CameraError
+import com.example.vtubercamera_kmp_ver.camera.CameraLensFacing
+import com.example.vtubercamera_kmp_ver.camera.CameraMessage
+import com.example.vtubercamera_kmp_ver.camera.PreviewState
+
+// プレビュー / レンズ / セッションエラー / 案内メッセージなどカメラセッション固有の UI 状態。
+data class CameraSessionUiState(
+    val lensFacing: CameraLensFacing = CameraLensFacing.Back,
+    val previewState: PreviewState = PreviewState.Preparing,
+    val errorState: CameraError? = null,
+    val message: CameraMessage? = null,
+)

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/zoom/CameraZoomController.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/zoom/CameraZoomController.kt
@@ -1,0 +1,39 @@
+package com.example.vtubercamera_kmp_ver.camera.zoom
+
+import com.example.vtubercamera_kmp_ver.camera.CameraRepository
+import com.example.vtubercamera_kmp_ver.camera.CameraZoomUiState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+// カメラズーム倍率の取得 / 反映を担い、repository の zoom state を UI へ同期する。
+class CameraZoomController(
+    private val cameraRepository: CameraRepository,
+    private val scope: CoroutineScope,
+) {
+    private val _state = MutableStateFlow(CameraZoomUiState())
+    val state: StateFlow<CameraZoomUiState> = _state.asStateFlow()
+
+    init {
+        scope.launch { observeZoomState() }
+    }
+
+    // ピンチ操作によるズーム倍率の変化を repository へ反映する。
+    fun onCameraZoomChanged(scaleChange: Float) {
+        val zoomState = _state.value
+        cameraRepository.setZoomRatio(
+            (zoomState.currentCameraZoomRatio * scaleChange).coerceIn(
+                zoomState.minCameraZoomRatio,
+                zoomState.maxCameraZoomRatio,
+            ),
+        )
+    }
+
+    private suspend fun observeZoomState() {
+        cameraRepository.observeZoomState().collect { zoomUiState ->
+            _state.value = zoomUiState
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModelTest.kt
@@ -4,11 +4,10 @@ import com.example.vtubercamera_kmp_ver.avatar.mapping.VrmSpecVersion
 import com.example.vtubercamera_kmp_ver.avatar.state.AvatarTrackingStatus
 import com.example.vtubercamera_kmp_ver.avatar.vrm.VrmRuntimeAssetDescriptor
 import com.example.vtubercamera_kmp_ver.avatar.vrm.VrmRuntimeMeta
+import com.example.vtubercamera_kmp_ver.camera.testing.FakeCameraRepository
+import com.example.vtubercamera_kmp_ver.camera.testing.FakePermissionRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -91,7 +90,7 @@ import kotlin.test.assertNull
  * 10. **File selection fails (unsupported format / IO error) → error message shown**
  *    - Steps: tap the file-picker button → select a file that cannot be parsed as VRM/GLB.
  *    - Expected: CameraViewModel.onFilePicked(FilePickerResult.Error(...)) is called;
- *                uiState.filePickerErrorMessageRes is set to the appropriate StringResource;
+ *                uiState.avatarSelection.filePickerErrorMessageRes is set to the appropriate StringResource;
  *                onDismissFilePickerError() clears it.
  */
 // Collects pending unit-test scenarios for the shared camera state machine.
@@ -116,7 +115,7 @@ class CameraViewModelTest {
     /**
      * When [PermissionRepository.checkCameraPermission] returns [PermissionState.Granted],
      * [CameraViewModel.initialize] must resolve the initial lens and call
-     * [CameraRepository.startPreview], leaving [CameraUiState.previewState] as
+     * [CameraRepository.startPreview], leaving [CameraUiState.session.previewState] as
      * [PreviewState.Preparing] (and eventually [PreviewState.Showing] once the platform signals
      * success via [CameraRepository.onPlatformPreviewStarted]).
      */
@@ -138,11 +137,11 @@ class CameraViewModelTest {
         advanceUntilIdle()
 
         val uiState = viewModel.uiState.value
-        assertEquals(PermissionState.Granted, uiState.permissionState)
-        assertEquals(CameraLensFacing.Front, uiState.lensFacing)
-        assertEquals(PreviewState.Showing, uiState.previewState)
-        assertNull(uiState.errorState)
-        assertNull(uiState.message)
+        assertEquals(PermissionState.Granted, uiState.permission.permissionState)
+        assertEquals(CameraLensFacing.Front, uiState.session.lensFacing)
+        assertEquals(PreviewState.Showing, uiState.session.previewState)
+        assertNull(uiState.session.errorState)
+        assertNull(uiState.session.message)
         assertEquals(1, cameraRepository.resolveInitialLensCallCount)
         assertEquals(listOf(CameraLensFacing.Back), cameraRepository.resolveInitialLensRequests)
         assertEquals(1, cameraRepository.startPreviewCallCount)
@@ -164,18 +163,18 @@ class CameraViewModelTest {
         advanceUntilIdle()
 
         val uiState = viewModel.uiState.value
-        assertEquals(PermissionState.Unknown, uiState.permissionState)
-        assertEquals(PreviewState.Preparing, uiState.previewState)
-        assertNull(uiState.errorState)
-        assertNull(uiState.message)
+        assertEquals(PermissionState.Unknown, uiState.permission.permissionState)
+        assertEquals(PreviewState.Preparing, uiState.session.previewState)
+        assertNull(uiState.session.errorState)
+        assertNull(uiState.session.message)
         assertEquals(0, cameraRepository.resolveInitialLensCallCount)
         assertEquals(0, cameraRepository.startPreviewCallCount)
     }
 
     /**
      * When [PermissionRepository.checkCameraPermission] returns [PermissionState.Denied],
-     * [CameraViewModel.initialize] must set [CameraUiState.errorState] to
-     * [CameraError.PermissionDenied] and [CameraUiState.previewState] to
+     * [CameraViewModel.initialize] must set [CameraUiState.session.errorState] to
+     * [CameraError.PermissionDenied] and [CameraUiState.session.previewState] to
      * [PreviewState.Error(CameraError.PermissionDenied)].
      * [CameraRepository.startPreview] must NOT be called.
      */
@@ -195,9 +194,9 @@ class CameraViewModelTest {
             advanceUntilIdle()
 
             val uiState = viewModel.uiState.value
-            assertEquals(PermissionState.Denied, uiState.permissionState)
-            assertEquals(CameraError.PermissionDenied, uiState.errorState)
-            val previewState = assertIs<PreviewState.Error>(uiState.previewState)
+            assertEquals(PermissionState.Denied, uiState.permission.permissionState)
+            assertEquals(CameraError.PermissionDenied, uiState.session.errorState)
+            val previewState = assertIs<PreviewState.Error>(uiState.session.previewState)
             assertEquals(CameraError.PermissionDenied, previewState.error)
             assertEquals(0, cameraRepository.startPreviewCallCount)
         }
@@ -211,8 +210,8 @@ class CameraViewModelTest {
      *     [PermissionState.Denied] を返す。
      *
      * Then:
-     *   - [CameraViewModel.initialize] は [CameraUiState.permissionState] を Denied に更新し、
-     *     [CameraUiState.errorState] / [CameraUiState.previewState] を PermissionDenied に設定する。
+     *   - [CameraViewModel.initialize] は [CameraUiState.permission.permissionState] を Denied に更新し、
+     *     [CameraUiState.session.errorState] / [CameraUiState.session.previewState] を PermissionDenied に設定する。
      *   - [CameraRepository.startPreview] は呼び出されない。
      */
     @Test
@@ -231,7 +230,7 @@ class CameraViewModelTest {
 
             assertEquals(
                 PermissionState.Granted,
-                firstLaunchViewModel.uiState.value.permissionState
+                firstLaunchViewModel.uiState.value.permission.permissionState
             )
             assertEquals(1, firstLaunchCameraRepository.startPreviewCallCount)
 
@@ -247,9 +246,9 @@ class CameraViewModelTest {
             advanceUntilIdle()
 
             val uiState = secondLaunchViewModel.uiState.value
-            assertEquals(PermissionState.Denied, uiState.permissionState)
-            assertEquals(CameraError.PermissionDenied, uiState.errorState)
-            val previewState = assertIs<PreviewState.Error>(uiState.previewState)
+            assertEquals(PermissionState.Denied, uiState.permission.permissionState)
+            assertEquals(CameraError.PermissionDenied, uiState.session.errorState)
+            val previewState = assertIs<PreviewState.Error>(uiState.session.previewState)
             assertEquals(CameraError.PermissionDenied, previewState.error)
             assertEquals(0, secondLaunchCameraRepository.startPreviewCallCount)
         }
@@ -261,8 +260,8 @@ class CameraViewModelTest {
     /**
      * When permission transitions from [PermissionState.Denied] to [PermissionState.Granted],
      * [CameraViewModel.onPermissionStateChanged] must:
-     *   1. Reset [CameraUiState.previewState] to [PreviewState.Preparing].
-     *   2. Clear [CameraUiState.errorState] and [CameraUiState.message].
+     *   1. Reset [CameraUiState.session.previewState] to [PreviewState.Preparing].
+     *   2. Clear [CameraUiState.session.errorState] and [CameraUiState.session.message].
      *   3. Launch [CameraRepository.resolveInitialLens] + [CameraRepository.startPreview]
      *      (mirroring the initialize() flow).
      *
@@ -282,25 +281,25 @@ class CameraViewModelTest {
 
         viewModel.onPermissionStateChanged(isGranted = false, isChecking = false)
         val deniedState = viewModel.uiState.value
-        assertEquals(PermissionState.Denied, deniedState.permissionState)
-        assertEquals(CameraError.PermissionDenied, deniedState.errorState)
-        assertIs<PreviewState.Error>(deniedState.previewState)
+        assertEquals(PermissionState.Denied, deniedState.permission.permissionState)
+        assertEquals(CameraError.PermissionDenied, deniedState.session.errorState)
+        assertIs<PreviewState.Error>(deniedState.session.previewState)
 
         viewModel.onPermissionStateChanged(isGranted = true, isChecking = false)
         val recoveringState = viewModel.uiState.value
-        assertEquals(PermissionState.Granted, recoveringState.permissionState)
-        assertEquals(PreviewState.Preparing, recoveringState.previewState)
-        assertNull(recoveringState.errorState)
-        assertNull(recoveringState.message)
+        assertEquals(PermissionState.Granted, recoveringState.permission.permissionState)
+        assertEquals(PreviewState.Preparing, recoveringState.session.previewState)
+        assertNull(recoveringState.session.errorState)
+        assertNull(recoveringState.session.message)
         assertEquals(0, cameraRepository.startPreviewCallCount)
 
         advanceUntilIdle()
 
         val recoveredState = viewModel.uiState.value
-        assertEquals(PermissionState.Granted, recoveredState.permissionState)
-        assertEquals(PreviewState.Showing, recoveredState.previewState)
-        assertNull(recoveredState.errorState)
-        assertNull(recoveredState.message)
+        assertEquals(PermissionState.Granted, recoveredState.permission.permissionState)
+        assertEquals(PreviewState.Showing, recoveredState.session.previewState)
+        assertNull(recoveredState.session.errorState)
+        assertNull(recoveredState.session.message)
         assertEquals(1, cameraRepository.resolveInitialLensCallCount)
         assertEquals(1, cameraRepository.startPreviewCallCount)
     }
@@ -328,16 +327,16 @@ class CameraViewModelTest {
         advanceUntilIdle()
 
         val uiState = viewModel.uiState.value
-        assertEquals(PermissionState.Granted, uiState.permissionState)
-        assertEquals(PreviewState.Preparing, uiState.previewState)
+        assertEquals(PermissionState.Granted, uiState.permission.permissionState)
+        assertEquals(PreviewState.Preparing, uiState.session.previewState)
         assertEquals(1, cameraRepository.resolveInitialLensCallCount)
         assertEquals(1, cameraRepository.startPreviewCallCount)
     }
 
     /**
      * When permission transitions to [PermissionState.Unknown] from a [PreviewState.Error] state,
-     * [CameraUiState.previewState] must be reset to [PreviewState.Preparing] and
-     * [CameraUiState.errorState] must be cleared.
+     * [CameraUiState.session.previewState] must be reset to [PreviewState.Preparing] and
+     * [CameraUiState.session.errorState] must be cleared.
      */
     @Test
     fun onPermissionStateChanged_toUnknownFromError_resetsPreviewStateToPreparing() = runTest {
@@ -352,16 +351,16 @@ class CameraViewModelTest {
         advanceUntilIdle()
 
         viewModel.onPermissionStateChanged(isGranted = false, isChecking = false)
-        assertEquals(CameraError.PermissionDenied, viewModel.uiState.value.errorState)
-        assertIs<PreviewState.Error>(viewModel.uiState.value.previewState)
+        assertEquals(CameraError.PermissionDenied, viewModel.uiState.value.session.errorState)
+        assertIs<PreviewState.Error>(viewModel.uiState.value.session.previewState)
 
         viewModel.onPermissionStateChanged(isGranted = false, isChecking = true)
 
         val uiState = viewModel.uiState.value
-        assertEquals(PermissionState.Unknown, uiState.permissionState)
-        assertEquals(PreviewState.Preparing, uiState.previewState)
-        assertNull(uiState.errorState)
-        assertNull(uiState.message)
+        assertEquals(PermissionState.Unknown, uiState.permission.permissionState)
+        assertEquals(PreviewState.Preparing, uiState.session.previewState)
+        assertNull(uiState.session.errorState)
+        assertNull(uiState.session.message)
         assertEquals(0, cameraRepository.startPreviewCallCount)
     }
 
@@ -382,11 +381,11 @@ class CameraViewModelTest {
             advanceUntilIdle()
 
             val uiState = viewModel.uiState.value
-            assertEquals(PermissionState.Denied, uiState.permissionState)
-            assertEquals(CameraError.PermissionDenied, uiState.errorState)
-            val previewState = assertIs<PreviewState.Error>(uiState.previewState)
+            assertEquals(PermissionState.Denied, uiState.permission.permissionState)
+            assertEquals(CameraError.PermissionDenied, uiState.session.errorState)
+            val previewState = assertIs<PreviewState.Error>(uiState.session.previewState)
             assertEquals(CameraError.PermissionDenied, previewState.error)
-            assertEquals(CameraMessageType.Error, uiState.message?.type)
+            assertEquals(CameraMessageType.Error, uiState.session.message?.type)
             assertEquals(0, cameraRepository.resolveInitialLensCallCount)
             assertEquals(0, cameraRepository.startPreviewCallCount)
         }
@@ -406,25 +405,25 @@ class CameraViewModelTest {
         cameraRepository.emitPreviewState(PreviewState.Showing)
         advanceUntilIdle()
 
-        assertEquals(PreviewState.Showing, viewModel.uiState.value.previewState)
-        assertNull(viewModel.uiState.value.errorState)
-        assertNull(viewModel.uiState.value.message)
+        assertEquals(PreviewState.Showing, viewModel.uiState.value.session.previewState)
+        assertNull(viewModel.uiState.value.session.errorState)
+        assertNull(viewModel.uiState.value.session.message)
 
         cameraRepository.emitPreviewState(PreviewState.Error(CameraError.CameraUnavailable))
         advanceUntilIdle()
 
         val errorState = viewModel.uiState.value
-        assertIs<PreviewState.Error>(errorState.previewState)
-        assertEquals(CameraError.CameraUnavailable, errorState.errorState)
-        assertEquals(CameraMessageType.Error, errorState.message?.type)
+        assertIs<PreviewState.Error>(errorState.session.previewState)
+        assertEquals(CameraError.CameraUnavailable, errorState.session.errorState)
+        assertEquals(CameraMessageType.Error, errorState.session.message?.type)
 
         cameraRepository.emitPreviewState(PreviewState.Preparing)
         advanceUntilIdle()
 
         val preparingState = viewModel.uiState.value
-        assertEquals(PreviewState.Preparing, preparingState.previewState)
-        assertNull(preparingState.errorState)
-        assertNull(preparingState.message)
+        assertEquals(PreviewState.Preparing, preparingState.session.previewState)
+        assertNull(preparingState.session.errorState)
+        assertNull(preparingState.session.message)
     }
 
     // ---------------------------------------------------------------------------
@@ -434,7 +433,7 @@ class CameraViewModelTest {
     /**
      * When [CameraRepository.startPreview] fails with
      * [CameraRepositoryException(CameraError.CameraUnavailable)],
-     * [CameraViewModel.onRetryPreview] must set [CameraUiState.errorState] to
+     * [CameraViewModel.onRetryPreview] must set [CameraUiState.session.errorState] to
      * [CameraError.CameraUnavailable] — NOT the generic [CameraError.PreviewInitializationFailed].
      *
      * Verifies that [CameraRepositoryException.error] is extracted and not overwritten.
@@ -457,8 +456,8 @@ class CameraViewModelTest {
             advanceUntilIdle()
 
             val uiState = viewModel.uiState.value
-            assertEquals(CameraError.CameraUnavailable, uiState.errorState)
-            val previewState = assertIs<PreviewState.Error>(uiState.previewState)
+            assertEquals(CameraError.CameraUnavailable, uiState.session.errorState)
+            val previewState = assertIs<PreviewState.Error>(uiState.session.previewState)
             assertEquals(CameraError.CameraUnavailable, previewState.error)
             assertEquals(1, cameraRepository.startPreviewCallCount)
         }
@@ -484,8 +483,8 @@ class CameraViewModelTest {
             advanceUntilIdle()
 
             val uiState = viewModel.uiState.value
-            assertEquals(CameraError.PreviewInitializationFailed, uiState.errorState)
-            val previewState = assertIs<PreviewState.Error>(uiState.previewState)
+            assertEquals(CameraError.PreviewInitializationFailed, uiState.session.errorState)
+            val previewState = assertIs<PreviewState.Error>(uiState.session.previewState)
             assertEquals(CameraError.PreviewInitializationFailed, previewState.error)
             assertEquals(1, cameraRepository.startPreviewCallCount)
         }
@@ -497,7 +496,7 @@ class CameraViewModelTest {
     /**
      * When [CameraRepository.switchLens] fails with
      * [CameraRepositoryException(CameraError.LensSwitchFailed)],
-     * [CameraViewModel.onToggleLensFacing] must set [CameraUiState.errorState] to
+     * [CameraViewModel.onToggleLensFacing] must set [CameraUiState.session.errorState] to
      * [CameraError.LensSwitchFailed].
      */
     @Test
@@ -510,14 +509,14 @@ class CameraViewModelTest {
             permissionRepository = FakePermissionRepository(PermissionState.Unknown),
         )
         advanceUntilIdle()
-        assertEquals(CameraLensFacing.Back, viewModel.uiState.value.lensFacing)
+        assertEquals(CameraLensFacing.Back, viewModel.uiState.value.session.lensFacing)
 
         viewModel.onToggleLensFacing()
         advanceUntilIdle()
 
         val uiState = viewModel.uiState.value
-        assertEquals(CameraLensFacing.Front, uiState.lensFacing)
-        assertNull(uiState.errorState)
+        assertEquals(CameraLensFacing.Front, uiState.session.lensFacing)
+        assertNull(uiState.session.errorState)
         assertEquals(1, cameraRepository.switchLensCallCount)
         assertEquals(listOf(CameraLensFacing.Back), cameraRepository.switchLensRequests)
     }
@@ -539,8 +538,8 @@ class CameraViewModelTest {
         advanceUntilIdle()
 
         val uiState = viewModel.uiState.value
-        assertEquals(CameraError.LensSwitchFailed, uiState.errorState)
-        val previewState = assertIs<PreviewState.Error>(uiState.previewState)
+        assertEquals(CameraError.LensSwitchFailed, uiState.session.errorState)
+        val previewState = assertIs<PreviewState.Error>(uiState.session.previewState)
         assertEquals(CameraError.LensSwitchFailed, previewState.error)
         assertEquals(1, cameraRepository.switchLensCallCount)
     }
@@ -620,7 +619,7 @@ class CameraViewModelTest {
         viewModel.onFaceTrackingFrameChanged(lowConfidenceFrame)
         advanceUntilIdle()
 
-        val avatarState = viewModel.uiState.value.avatarRenderState
+        val avatarState = viewModel.uiState.value.avatarRender
         assertEquals(AvatarTrackingStatus.Lost, avatarState.trackingStatus)
         assertEquals(0.2f, avatarState.trackingConfidence)
         assertEquals(201L, avatarState.sourceTimestampMillis)
@@ -645,19 +644,19 @@ class CameraViewModelTest {
 
         viewModel.onFaceTrackingFrameChanged(firstFrame)
         advanceUntilIdle()
-        val trackedState = viewModel.uiState.value.avatarRenderState
+        val trackedState = viewModel.uiState.value.avatarRender
         assertEquals(AvatarTrackingStatus.Tracking, trackedState.trackingStatus)
         assertEquals(300L, trackedState.sourceTimestampMillis)
 
         viewModel.onFaceTrackingFrameChanged(secondFrame)
         advanceUntilIdle()
-        val lostState = viewModel.uiState.value.avatarRenderState
+        val lostState = viewModel.uiState.value.avatarRender
         assertEquals(AvatarTrackingStatus.Lost, lostState.trackingStatus)
         assertEquals(301L, lostState.sourceTimestampMillis)
 
         viewModel.onFaceTrackingFrameChanged(null)
         advanceUntilIdle()
-        val notTrackedState = viewModel.uiState.value.avatarRenderState
+        val notTrackedState = viewModel.uiState.value.avatarRender
         assertEquals(AvatarTrackingStatus.NotTracked, notTrackedState.trackingStatus)
         assertEquals(301L, notTrackedState.sourceTimestampMillis)
     }
@@ -669,7 +668,7 @@ class CameraViewModelTest {
     /**
      * When [CameraViewModel.onFilePicked] receives [FilePickerResult.Success],
      * [CameraUiState.avatarPreview] must be updated with the parsed avatar data and
-     * [CameraUiState.filePickerErrorMessageRes] must be null.
+     * [CameraUiState.avatarSelection.filePickerErrorMessageRes] must be null.
      */
     @Test
     fun onFilePicked_success_updatesAvatarPreviewAndClearsError() = runTest {
@@ -686,21 +685,21 @@ class CameraViewModelTest {
             viewModel.onFilePicked(FilePickerResult.Success(firstSelection))
             advanceUntilIdle()
             assertEquals(firstSelection.preview, viewModel.uiState.value.avatarPreview)
-            assertNull(viewModel.uiState.value.filePickerErrorMessageRes)
+            assertNull(viewModel.uiState.value.avatarSelection.filePickerErrorMessageRes)
             assertNotNull(AvatarAssetStore.load(firstSelection.assetHandle))
 
             viewModel.onFilePicked(FilePickerResult.Error(Res.string.vrm_error_select_file))
             advanceUntilIdle()
             assertEquals(
                 Res.string.vrm_error_select_file,
-                viewModel.uiState.value.filePickerErrorMessageRes
+                viewModel.uiState.value.avatarSelection.filePickerErrorMessageRes
             )
 
             viewModel.onFilePicked(FilePickerResult.Success(secondSelection))
             advanceUntilIdle()
             val uiState = viewModel.uiState.value
             assertEquals(secondSelection.preview, uiState.avatarPreview)
-            assertNull(uiState.filePickerErrorMessageRes)
+            assertNull(uiState.avatarSelection.filePickerErrorMessageRes)
             assertNull(AvatarAssetStore.load(firstSelection.assetHandle))
             assertNotNull(AvatarAssetStore.load(secondSelection.assetHandle))
         } finally {
@@ -730,7 +729,7 @@ class CameraViewModelTest {
 
     /**
      * When [CameraViewModel.onFilePicked] receives [FilePickerResult.Error],
-     * [CameraUiState.filePickerErrorMessageRes] must be set to the error's [StringResource].
+     * [CameraUiState.avatarSelection.filePickerErrorMessageRes] must be set to the error's [StringResource].
      * A subsequent call to [CameraViewModel.onDismissFilePickerError] must set it back to null.
      */
     @Test
@@ -744,12 +743,12 @@ class CameraViewModelTest {
         advanceUntilIdle()
         assertEquals(
             Res.string.vrm_error_select_file,
-            viewModel.uiState.value.filePickerErrorMessageRes
+            viewModel.uiState.value.avatarSelection.filePickerErrorMessageRes
         )
 
         viewModel.onDismissFilePickerError()
         advanceUntilIdle()
-        assertNull(viewModel.uiState.value.filePickerErrorMessageRes)
+        assertNull(viewModel.uiState.value.avatarSelection.filePickerErrorMessageRes)
     }
 
     @Test
@@ -774,8 +773,8 @@ class CameraViewModelTest {
                 advanceUntilIdle()
 
                 val uiState = viewModel.uiState.value
-                assertNull(uiState.avatarSelection)
-                assertEquals(Res.string.camera_error_unknown, uiState.filePickerErrorMessageRes)
+                assertNull(uiState.avatarSelection.avatarSelection)
+                assertEquals(Res.string.camera_error_unknown, uiState.avatarSelection.filePickerErrorMessageRes)
                 assertNull(AvatarAssetStore.load(selection.assetHandle))
             } finally {
                 AvatarAssetStore.remove(selection.assetHandle)
@@ -807,8 +806,8 @@ class CameraViewModelTest {
             advanceUntilIdle()
 
             val uiState = viewModel.uiState.value
-            assertEquals(currentSelection, uiState.avatarSelection)
-            assertNull(uiState.filePickerErrorMessageRes)
+            assertEquals(currentSelection, uiState.avatarSelection.avatarSelection)
+            assertNull(uiState.avatarSelection.filePickerErrorMessageRes)
             assertNotNull(AvatarAssetStore.load(currentSelection.assetHandle))
         } finally {
             AvatarAssetStore.remove(staleSelection.assetHandle)
@@ -828,7 +827,7 @@ class CameraViewModelTest {
             permissionRepository = FakePermissionRepository(PermissionState.Unknown),
         )
         advanceUntilIdle()
-        assertEquals(1f, viewModel.uiState.value.zoomUiState.currentCameraZoomRatio)
+        assertEquals(1f, viewModel.uiState.value.zoom.currentCameraZoomRatio)
 
         viewModel.onCameraZoomChanged(2f)
         assertEquals(2f, cameraRepository.setZoomRatioRequests.last())
@@ -912,109 +911,4 @@ class CameraViewModelTest {
         mouthSmile = mouthSmile,
     )
 
-    private class FakeCameraRepository(
-        private val resolveInitialLensResult: Result<CameraLensFacing> = Result.success(
-            CameraLensFacing.Back
-        ),
-        private val startPreviewResult: Result<CameraLensFacing>? = null,
-        private val switchLensResult: Result<CameraLensFacing> = Result.success(CameraLensFacing.Front),
-    ) : CameraRepository {
-        private val previewState = MutableStateFlow<PreviewState>(PreviewState.Preparing)
-        private val zoomUiState = MutableStateFlow(
-            CameraZoomUiState(
-                currentCameraZoomRatio = 1f,
-                minCameraZoomRatio = 1f,
-                maxCameraZoomRatio = 5f,
-            ),
-        )
-
-        var startPreviewCallCount: Int = 0
-            private set
-
-        var resolveInitialLensCallCount: Int = 0
-            private set
-
-        var switchLensCallCount: Int = 0
-            private set
-
-        val startPreviewRequests = mutableListOf<CameraLensFacing>()
-        val resolveInitialLensRequests = mutableListOf<CameraLensFacing>()
-        val switchLensRequests = mutableListOf<CameraLensFacing>()
-        val setZoomRatioRequests = mutableListOf<Float>()
-
-        override suspend fun startPreview(lensFacing: CameraLensFacing): Result<CameraLensFacing> {
-            startPreviewCallCount += 1
-            startPreviewRequests += lensFacing
-            val result = startPreviewResult ?: Result.success(lensFacing)
-            if (result.isSuccess) {
-                previewState.value = PreviewState.Showing
-            }
-            return result
-        }
-
-        override suspend fun stopPreview() {
-            previewState.value = PreviewState.Preparing
-        }
-
-        override suspend fun switchLens(current: CameraLensFacing): Result<CameraLensFacing> {
-            switchLensCallCount += 1
-            switchLensRequests += current
-            val result = switchLensResult
-            if (result.isSuccess) {
-                previewState.value = PreviewState.Showing
-            }
-            return result
-        }
-
-        override suspend fun resolveInitialLens(preferred: CameraLensFacing): Result<CameraLensFacing> {
-            resolveInitialLensCallCount += 1
-            resolveInitialLensRequests += preferred
-            return resolveInitialLensResult
-        }
-
-        override fun observePreviewState(): Flow<PreviewState> {
-            return previewState.asStateFlow()
-        }
-
-        override fun onPlatformPreviewStarted(lensFacing: CameraLensFacing) {
-            previewState.value = PreviewState.Showing
-        }
-
-        override fun onPlatformPreviewError(lensFacing: CameraLensFacing, error: CameraError) {
-            previewState.value = PreviewState.Error(error)
-        }
-
-        override fun observeZoomState(): Flow<CameraZoomUiState> {
-            return zoomUiState.asStateFlow()
-        }
-
-        override fun onPlatformZoomStateChanged(zoomUiState: CameraZoomUiState) {
-            this.zoomUiState.value = CameraZoomUiState(
-                currentCameraZoomRatio = zoomUiState.currentCameraZoomRatio,
-                minCameraZoomRatio = zoomUiState.minCameraZoomRatio,
-                maxCameraZoomRatio = zoomUiState.maxCameraZoomRatio
-            )
-        }
-
-        override fun setZoomRatio(updatedZoomRatio: Float) {
-            setZoomRatioRequests += updatedZoomRatio
-            zoomUiState.value = zoomUiState.value.copy(currentCameraZoomRatio = updatedZoomRatio)
-        }
-
-        fun emitPreviewState(state: PreviewState) {
-            previewState.value = state
-        }
-    }
-
-    private class FakePermissionRepository(
-        private val checkCameraPermissionResult: PermissionState,
-    ) : PermissionRepository {
-        override suspend fun checkCameraPermission(): PermissionState {
-            return checkCameraPermissionResult
-        }
-
-        override suspend fun requestCameraPermission(): PermissionState {
-            return checkCameraPermissionResult
-        }
-    }
 }

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/avatar/AvatarSelectionControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/avatar/AvatarSelectionControllerTest.kt
@@ -1,0 +1,169 @@
+package com.example.vtubercamera_kmp_ver.camera.avatar
+
+import com.example.vtubercamera_kmp_ver.avatar.mapping.VrmSpecVersion
+import com.example.vtubercamera_kmp_ver.avatar.vrm.VrmRuntimeAssetDescriptor
+import com.example.vtubercamera_kmp_ver.avatar.vrm.VrmRuntimeMeta
+import com.example.vtubercamera_kmp_ver.camera.AvatarAssetStore
+import com.example.vtubercamera_kmp_ver.camera.AvatarPreviewData
+import com.example.vtubercamera_kmp_ver.camera.AvatarSelectionData
+import com.example.vtubercamera_kmp_ver.camera.FilePickerResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import vtubercamera_kmp_ver.composeapp.generated.resources.Res
+import vtubercamera_kmp_ver.composeapp.generated.resources.camera_error_unknown
+import vtubercamera_kmp_ver.composeapp.generated.resources.vrm_error_select_file
+
+class AvatarSelectionControllerTest {
+
+    @Test
+    fun onFilePicked_success_replacesSelectionAndRemovesPreviousHandle() {
+        val controller = AvatarSelectionController()
+        val first = createSelection("first.vrm", "Avatar A", byteArrayOf(1, 2, 3))
+        val second = createSelection("second.vrm", "Avatar B", byteArrayOf(4, 5, 6))
+
+        try {
+            controller.onFilePicked(FilePickerResult.Success(first))
+            assertEquals(first, controller.state.value.avatarSelection)
+            assertNotNull(AvatarAssetStore.load(first.assetHandle))
+
+            controller.onFilePicked(FilePickerResult.Success(second))
+            assertEquals(second, controller.state.value.avatarSelection)
+            assertNull(AvatarAssetStore.load(first.assetHandle))
+            assertNotNull(AvatarAssetStore.load(second.assetHandle))
+        } finally {
+            AvatarAssetStore.remove(first.assetHandle)
+            AvatarAssetStore.remove(second.assetHandle)
+        }
+    }
+
+    @Test
+    fun onFilePicked_error_setsFilePickerErrorMessageRes() {
+        val controller = AvatarSelectionController()
+
+        controller.onFilePicked(FilePickerResult.Error(Res.string.vrm_error_select_file))
+
+        assertEquals(
+            Res.string.vrm_error_select_file,
+            controller.state.value.filePickerErrorMessageRes,
+        )
+    }
+
+    @Test
+    fun onFilePicked_cancelled_keepsStateUnchanged() {
+        val controller = AvatarSelectionController()
+        val stateBefore = controller.state.value
+
+        controller.onFilePicked(FilePickerResult.Cancelled)
+
+        assertEquals(stateBefore, controller.state.value)
+    }
+
+    @Test
+    fun onAvatarRenderLoadFailed_whenHandleMatches_clearsSelectionAndRemovesAsset() {
+        val controller = AvatarSelectionController()
+        val selection = createSelection("active.vrm", "Avatar C", byteArrayOf(7, 8, 9))
+
+        try {
+            controller.onFilePicked(FilePickerResult.Success(selection))
+            assertNotNull(AvatarAssetStore.load(selection.assetHandle))
+
+            controller.onAvatarRenderLoadFailed(
+                failedAssetHandle = selection.assetHandle,
+                messageRes = Res.string.camera_error_unknown,
+            )
+
+            assertNull(controller.state.value.avatarSelection)
+            assertEquals(
+                Res.string.camera_error_unknown,
+                controller.state.value.filePickerErrorMessageRes,
+            )
+            assertNull(AvatarAssetStore.load(selection.assetHandle))
+        } finally {
+            AvatarAssetStore.remove(selection.assetHandle)
+        }
+    }
+
+    @Test
+    fun onAvatarRenderLoadFailed_whenHandleStale_keepsCurrentSelection() {
+        val controller = AvatarSelectionController()
+        val stale = createSelection("stale.vrm", "Avatar Stale", byteArrayOf(11, 12))
+        val current = createSelection("current.vrm", "Avatar Current", byteArrayOf(13, 14))
+
+        try {
+            controller.onFilePicked(FilePickerResult.Success(stale))
+            controller.onFilePicked(FilePickerResult.Success(current))
+            assertNull(AvatarAssetStore.load(stale.assetHandle))
+            assertNotNull(AvatarAssetStore.load(current.assetHandle))
+
+            controller.onAvatarRenderLoadFailed(
+                failedAssetHandle = stale.assetHandle,
+                messageRes = Res.string.camera_error_unknown,
+            )
+
+            assertEquals(current, controller.state.value.avatarSelection)
+            assertNull(controller.state.value.filePickerErrorMessageRes)
+            assertNotNull(AvatarAssetStore.load(current.assetHandle))
+        } finally {
+            AvatarAssetStore.remove(stale.assetHandle)
+            AvatarAssetStore.remove(current.assetHandle)
+        }
+    }
+
+    @Test
+    fun onDismissFilePickerError_clearsErrorMessage() {
+        val controller = AvatarSelectionController()
+        controller.onFilePicked(FilePickerResult.Error(Res.string.vrm_error_select_file))
+
+        controller.onDismissFilePickerError()
+
+        assertNull(controller.state.value.filePickerErrorMessageRes)
+    }
+
+    @Test
+    fun release_removesCurrentAvatarAssetHandle() {
+        val controller = AvatarSelectionController()
+        val selection = createSelection("active.vrm", "Avatar D", byteArrayOf(21, 22))
+
+        try {
+            controller.onFilePicked(FilePickerResult.Success(selection))
+            assertNotNull(AvatarAssetStore.load(selection.assetHandle))
+
+            controller.release()
+
+            assertNull(AvatarAssetStore.load(selection.assetHandle))
+        } finally {
+            AvatarAssetStore.remove(selection.assetHandle)
+        }
+    }
+
+    private fun createSelection(
+        fileName: String,
+        avatarName: String,
+        assetBytes: ByteArray,
+    ): AvatarSelectionData {
+        val handle = AvatarAssetStore.store(assetBytes)
+        return AvatarSelectionData(
+            preview = AvatarPreviewData(
+                fileName = fileName,
+                avatarName = avatarName,
+                authorName = "Unit Test",
+                vrmVersion = "1.0",
+                thumbnailBytes = byteArrayOf(1, 9, 9, 0),
+            ),
+            assetHandle = handle,
+            runtimeDescriptor = VrmRuntimeAssetDescriptor(
+                specVersion = VrmSpecVersion.Vrm1,
+                rawSpecVersion = "1.0",
+                assetVersion = "2.0",
+                meta = VrmRuntimeMeta(
+                    avatarName = avatarName,
+                    authors = listOf("Unit Test"),
+                    version = "1.0",
+                ),
+                thumbnailImageIndex = null,
+            ),
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/facetracking/FaceTrackingPresenterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/facetracking/FaceTrackingPresenterTest.kt
@@ -1,0 +1,109 @@
+package com.example.vtubercamera_kmp_ver.camera.facetracking
+
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarTrackingStatus
+import com.example.vtubercamera_kmp_ver.camera.NormalizedFaceFrame
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class FaceTrackingPresenterTest {
+
+    @Test
+    fun onFaceTrackingFrameChanged_withFrame_formatsLabelsAndMarksTracking() {
+        val presenter = FaceTrackingPresenter()
+        val frame = NormalizedFaceFrame(
+            timestampMillis = 100L,
+            trackingConfidence = 0.9f,
+            headYawDegrees = 12.4f,
+            headPitchDegrees = -8.6f,
+            headRollDegrees = 30.2f,
+            leftEyeBlink = -0.1f,
+            rightEyeBlink = 0.453f,
+            jawOpen = 1.3f,
+            mouthSmile = 0.995f,
+        )
+
+        presenter.onFaceTrackingFrameChanged(frame)
+
+        val display = assertNotNull(presenter.state.value.faceTracking.display)
+        assertEquals("12 deg", display.headYawLabel)
+        assertEquals("-9 deg", display.headPitchLabel)
+        assertEquals("30 deg", display.headRollLabel)
+        assertEquals("0%", display.leftEyeBlinkLabel)
+        assertEquals("45%", display.rightEyeBlinkLabel)
+        assertEquals("100%", display.jawOpenLabel)
+        assertEquals("100%", display.mouthSmileLabel)
+        assertEquals(true, presenter.state.value.faceTracking.isTracking)
+    }
+
+    @Test
+    fun onFaceTrackingFrameChanged_withNullFrame_clearsDisplayAndMarksNotTracking() {
+        val presenter = FaceTrackingPresenter()
+        presenter.onFaceTrackingFrameChanged(
+            NormalizedFaceFrame(
+                timestampMillis = 1L,
+                trackingConfidence = 0.9f,
+                headYawDegrees = 0f,
+                headPitchDegrees = 0f,
+                headRollDegrees = 0f,
+                leftEyeBlink = 0f,
+                rightEyeBlink = 0f,
+                jawOpen = 0f,
+                mouthSmile = 0f,
+            ),
+        )
+
+        presenter.onFaceTrackingFrameChanged(null)
+
+        assertFalse(presenter.state.value.faceTracking.isTracking)
+        assertNull(presenter.state.value.faceTracking.frame)
+        assertNull(presenter.state.value.faceTracking.display)
+        assertEquals(
+            AvatarTrackingStatus.NotTracked,
+            presenter.state.value.avatarRender.trackingStatus,
+        )
+    }
+
+    @Test
+    fun onFaceTrackingFrameChanged_lowConfidence_transitionsToLost() {
+        val presenter = FaceTrackingPresenter()
+        presenter.onFaceTrackingFrameChanged(
+            NormalizedFaceFrame(
+                timestampMillis = 100L,
+                trackingConfidence = 0.95f,
+                headYawDegrees = 5f,
+                headPitchDegrees = 5f,
+                headRollDegrees = 5f,
+                leftEyeBlink = 0f,
+                rightEyeBlink = 0f,
+                jawOpen = 0f,
+                mouthSmile = 0f,
+            ),
+        )
+        assertEquals(
+            AvatarTrackingStatus.Tracking,
+            presenter.state.value.avatarRender.trackingStatus,
+        )
+
+        presenter.onFaceTrackingFrameChanged(
+            NormalizedFaceFrame(
+                timestampMillis = 101L,
+                trackingConfidence = 0.2f,
+                headYawDegrees = 5f,
+                headPitchDegrees = 5f,
+                headRollDegrees = 5f,
+                leftEyeBlink = 0f,
+                rightEyeBlink = 0f,
+                jawOpen = 0f,
+                mouthSmile = 0f,
+            ),
+        )
+
+        assertEquals(
+            AvatarTrackingStatus.Lost,
+            presenter.state.value.avatarRender.trackingStatus,
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/permission/CameraPermissionCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/permission/CameraPermissionCoordinatorTest.kt
@@ -1,0 +1,133 @@
+package com.example.vtubercamera_kmp_ver.camera.permission
+
+import com.example.vtubercamera_kmp_ver.camera.PermissionState
+import com.example.vtubercamera_kmp_ver.camera.testing.FakePermissionRepository
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CameraPermissionCoordinatorTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun initialize_whenGranted_emitsGrantedEntered() = runTest {
+        val coordinator = CameraPermissionCoordinator(
+            permissionRepository = FakePermissionRepository(PermissionState.Granted),
+            scope = this,
+        )
+        val events = mutableListOf<PermissionChange>()
+        coordinator.onPermissionChanged = { events += it }
+
+        coordinator.initialize()
+        advanceUntilIdle()
+
+        assertEquals(PermissionState.Granted, coordinator.state.value.permissionState)
+        assertEquals(listOf(PermissionChange.GrantedEntered), events)
+    }
+
+    @Test
+    fun initialize_whenDenied_emitsDeniedReceived() = runTest {
+        val coordinator = CameraPermissionCoordinator(
+            permissionRepository = FakePermissionRepository(PermissionState.Denied),
+            scope = this,
+        )
+        val events = mutableListOf<PermissionChange>()
+        coordinator.onPermissionChanged = { events += it }
+
+        coordinator.initialize()
+        advanceUntilIdle()
+
+        assertEquals(PermissionState.Denied, coordinator.state.value.permissionState)
+        assertEquals(listOf(PermissionChange.DeniedReceived), events)
+    }
+
+    @Test
+    fun onPermissionStateChanged_fromDeniedToGranted_emitsGrantedEntered() = runTest {
+        val coordinator = CameraPermissionCoordinator(
+            permissionRepository = FakePermissionRepository(PermissionState.Unknown),
+            scope = this,
+        )
+        val events = mutableListOf<PermissionChange>()
+        coordinator.onPermissionChanged = { events += it }
+
+        coordinator.onPermissionStateChanged(isGranted = false, isChecking = false)
+        coordinator.onPermissionStateChanged(isGranted = true, isChecking = false)
+
+        assertEquals(PermissionState.Granted, coordinator.state.value.permissionState)
+        assertEquals(
+            listOf(PermissionChange.DeniedReceived, PermissionChange.GrantedEntered),
+            events,
+        )
+    }
+
+    @Test
+    fun onPermissionStateChanged_grantedAgain_emitsGrantedRefreshed() = runTest {
+        val coordinator = CameraPermissionCoordinator(
+            permissionRepository = FakePermissionRepository(PermissionState.Granted),
+            scope = this,
+        )
+        val events = mutableListOf<PermissionChange>()
+        coordinator.onPermissionChanged = { events += it }
+        coordinator.initialize()
+        advanceUntilIdle()
+
+        coordinator.onPermissionStateChanged(isGranted = true, isChecking = false)
+
+        assertEquals(
+            listOf(PermissionChange.GrantedEntered, PermissionChange.GrantedRefreshed),
+            events,
+        )
+    }
+
+    @Test
+    fun onPermissionStateChanged_isChecking_emitsUnknownReceived() = runTest {
+        val coordinator = CameraPermissionCoordinator(
+            permissionRepository = FakePermissionRepository(PermissionState.Denied),
+            scope = this,
+        )
+        val events = mutableListOf<PermissionChange>()
+        coordinator.onPermissionChanged = { events += it }
+
+        coordinator.onPermissionStateChanged(isGranted = false, isChecking = true)
+
+        assertEquals(PermissionState.Unknown, coordinator.state.value.permissionState)
+        assertEquals(listOf(PermissionChange.UnknownReceived), events)
+    }
+
+    @Test
+    fun onRequestPermission_setsUnknown_andInvokesRequestedCallback() = runTest {
+        val coordinator = CameraPermissionCoordinator(
+            permissionRepository = FakePermissionRepository(PermissionState.Granted),
+            scope = this,
+        )
+        coordinator.onPermissionStateChanged(isGranted = false, isChecking = false)
+        assertEquals(PermissionState.Denied, coordinator.state.value.permissionState)
+
+        var requestedCount = 0
+        coordinator.onPermissionRequested = { requestedCount += 1 }
+
+        coordinator.onRequestPermission()
+
+        assertEquals(PermissionState.Unknown, coordinator.state.value.permissionState)
+        assertEquals(1, requestedCount)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/permission/CameraPermissionCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/permission/CameraPermissionCoordinatorTest.kt
@@ -41,7 +41,7 @@ class CameraPermissionCoordinatorTest {
         advanceUntilIdle()
 
         assertEquals(PermissionState.Granted, coordinator.state.value.permissionState)
-        assertEquals(listOf(PermissionChange.GrantedEntered), events)
+        assertEquals(listOf<PermissionChange>(PermissionChange.GrantedEntered), events)
     }
 
     @Test
@@ -57,7 +57,7 @@ class CameraPermissionCoordinatorTest {
         advanceUntilIdle()
 
         assertEquals(PermissionState.Denied, coordinator.state.value.permissionState)
-        assertEquals(listOf(PermissionChange.DeniedReceived), events)
+        assertEquals(listOf<PermissionChange>(PermissionChange.DeniedReceived), events)
     }
 
     @Test
@@ -110,7 +110,7 @@ class CameraPermissionCoordinatorTest {
         coordinator.onPermissionStateChanged(isGranted = false, isChecking = true)
 
         assertEquals(PermissionState.Unknown, coordinator.state.value.permissionState)
-        assertEquals(listOf(PermissionChange.UnknownReceived), events)
+        assertEquals(listOf<PermissionChange>(PermissionChange.UnknownReceived), events)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/session/CameraSessionControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/session/CameraSessionControllerTest.kt
@@ -15,7 +15,10 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -41,7 +44,7 @@ class CameraSessionControllerTest {
             resolveInitialLensResult = Result.success(CameraLensFacing.Front),
             startPreviewResult = Result.success(CameraLensFacing.Front),
         )
-        val controller = CameraSessionController(cameraRepository, backgroundScope)
+        val controller = CameraSessionController(cameraRepository, controllerScope())
         advanceUntilIdle()
 
         controller.start()
@@ -59,7 +62,7 @@ class CameraSessionControllerTest {
         val cameraRepository = FakeCameraRepository(
             resolveInitialLensResult = Result.failure(IllegalStateException("no camera")),
         )
-        val controller = CameraSessionController(cameraRepository, backgroundScope)
+        val controller = CameraSessionController(cameraRepository, controllerScope())
         advanceUntilIdle()
 
         controller.start()
@@ -79,7 +82,7 @@ class CameraSessionControllerTest {
                     CameraRepositoryException(CameraError.CameraUnavailable),
                 ),
             )
-            val controller = CameraSessionController(cameraRepository, backgroundScope)
+            val controller = CameraSessionController(cameraRepository, controllerScope())
             advanceUntilIdle()
 
             controller.onRetryPreview()
@@ -96,7 +99,7 @@ class CameraSessionControllerTest {
             val cameraRepository = FakeCameraRepository(
                 startPreviewResult = Result.failure(IllegalStateException("boom")),
             )
-            val controller = CameraSessionController(cameraRepository, backgroundScope)
+            val controller = CameraSessionController(cameraRepository, controllerScope())
             advanceUntilIdle()
 
             controller.onRetryPreview()
@@ -113,7 +116,7 @@ class CameraSessionControllerTest {
         val cameraRepository = FakeCameraRepository(
             switchLensResult = Result.success(CameraLensFacing.Front),
         )
-        val controller = CameraSessionController(cameraRepository, backgroundScope)
+        val controller = CameraSessionController(cameraRepository, controllerScope())
         advanceUntilIdle()
         assertEquals(CameraLensFacing.Back, controller.state.value.lensFacing)
 
@@ -133,7 +136,7 @@ class CameraSessionControllerTest {
                 CameraRepositoryException(CameraError.LensSwitchFailed),
             ),
         )
-        val controller = CameraSessionController(cameraRepository, backgroundScope)
+        val controller = CameraSessionController(cameraRepository, controllerScope())
         advanceUntilIdle()
 
         controller.onToggleLensFacing()
@@ -147,7 +150,7 @@ class CameraSessionControllerTest {
     @Test
     fun observePreviewState_syncsErrorAndMessageFromRepository() = runTest {
         val cameraRepository = FakeCameraRepository()
-        val controller = CameraSessionController(cameraRepository, backgroundScope)
+        val controller = CameraSessionController(cameraRepository, controllerScope())
         advanceUntilIdle()
 
         cameraRepository.emitPreviewState(PreviewState.Error(CameraError.CameraUnavailable))
@@ -170,7 +173,7 @@ class CameraSessionControllerTest {
 
     @Test
     fun clearErrorAndPrepare_clearsErrorAndSetsPreviewPreparing() = runTest {
-        val controller = CameraSessionController(FakeCameraRepository(), backgroundScope)
+        val controller = CameraSessionController(FakeCameraRepository(), controllerScope())
         advanceUntilIdle()
         controller.setError(CameraError.PermissionDenied)
 
@@ -183,7 +186,7 @@ class CameraSessionControllerTest {
 
     @Test
     fun resetPreviewIfErrored_clearsErrorOnlyWhenInErrorState() = runTest {
-        val controller = CameraSessionController(FakeCameraRepository(), backgroundScope)
+        val controller = CameraSessionController(FakeCameraRepository(), controllerScope())
         advanceUntilIdle()
 
         controller.resetPreviewIfErrored()
@@ -195,4 +198,7 @@ class CameraSessionControllerTest {
         assertEquals(PreviewState.Preparing, controller.state.value.previewState)
         assertNull(controller.state.value.errorState)
     }
+
+    private fun TestScope.controllerScope(): CoroutineScope =
+        CoroutineScope(backgroundScope.coroutineContext + UnconfinedTestDispatcher(testScheduler))
 }

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/session/CameraSessionControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/session/CameraSessionControllerTest.kt
@@ -1,0 +1,198 @@
+package com.example.vtubercamera_kmp_ver.camera.session
+
+import com.example.vtubercamera_kmp_ver.camera.CameraError
+import com.example.vtubercamera_kmp_ver.camera.CameraLensFacing
+import com.example.vtubercamera_kmp_ver.camera.CameraMessageType
+import com.example.vtubercamera_kmp_ver.camera.CameraRepositoryException
+import com.example.vtubercamera_kmp_ver.camera.PreviewState
+import com.example.vtubercamera_kmp_ver.camera.testing.FakeCameraRepository
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CameraSessionControllerTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun start_whenResolveAndStartSucceed_updatesLensFacingAndShowsPreview() = runTest {
+        val cameraRepository = FakeCameraRepository(
+            resolveInitialLensResult = Result.success(CameraLensFacing.Front),
+            startPreviewResult = Result.success(CameraLensFacing.Front),
+        )
+        val controller = CameraSessionController(cameraRepository, backgroundScope)
+        advanceUntilIdle()
+
+        controller.start()
+        advanceUntilIdle()
+
+        assertEquals(CameraLensFacing.Front, controller.state.value.lensFacing)
+        assertEquals(PreviewState.Showing, controller.state.value.previewState)
+        assertNull(controller.state.value.errorState)
+        assertEquals(1, cameraRepository.resolveInitialLensCallCount)
+        assertEquals(1, cameraRepository.startPreviewCallCount)
+    }
+
+    @Test
+    fun start_whenResolveInitialLensFails_setsCameraUnavailableError() = runTest {
+        val cameraRepository = FakeCameraRepository(
+            resolveInitialLensResult = Result.failure(IllegalStateException("no camera")),
+        )
+        val controller = CameraSessionController(cameraRepository, backgroundScope)
+        advanceUntilIdle()
+
+        controller.start()
+        advanceUntilIdle()
+
+        assertEquals(CameraError.CameraUnavailable, controller.state.value.errorState)
+        val previewState = assertIs<PreviewState.Error>(controller.state.value.previewState)
+        assertEquals(CameraError.CameraUnavailable, previewState.error)
+        assertEquals(0, cameraRepository.startPreviewCallCount)
+    }
+
+    @Test
+    fun onRetryPreview_whenStartPreviewFailsWithCameraRepositoryException_preservesErrorType() =
+        runTest {
+            val cameraRepository = FakeCameraRepository(
+                startPreviewResult = Result.failure(
+                    CameraRepositoryException(CameraError.CameraUnavailable),
+                ),
+            )
+            val controller = CameraSessionController(cameraRepository, backgroundScope)
+            advanceUntilIdle()
+
+            controller.onRetryPreview()
+            advanceUntilIdle()
+
+            assertEquals(CameraError.CameraUnavailable, controller.state.value.errorState)
+            val previewState = assertIs<PreviewState.Error>(controller.state.value.previewState)
+            assertEquals(CameraError.CameraUnavailable, previewState.error)
+        }
+
+    @Test
+    fun onRetryPreview_whenStartPreviewFailsWithGenericException_fallsBackToPreviewInitializationFailed() =
+        runTest {
+            val cameraRepository = FakeCameraRepository(
+                startPreviewResult = Result.failure(IllegalStateException("boom")),
+            )
+            val controller = CameraSessionController(cameraRepository, backgroundScope)
+            advanceUntilIdle()
+
+            controller.onRetryPreview()
+            advanceUntilIdle()
+
+            assertEquals(
+                CameraError.PreviewInitializationFailed,
+                controller.state.value.errorState,
+            )
+        }
+
+    @Test
+    fun onToggleLensFacing_whenSwitchSucceeds_updatesLensFacingAndClearsError() = runTest {
+        val cameraRepository = FakeCameraRepository(
+            switchLensResult = Result.success(CameraLensFacing.Front),
+        )
+        val controller = CameraSessionController(cameraRepository, backgroundScope)
+        advanceUntilIdle()
+        assertEquals(CameraLensFacing.Back, controller.state.value.lensFacing)
+
+        controller.onToggleLensFacing()
+        advanceUntilIdle()
+
+        assertEquals(CameraLensFacing.Front, controller.state.value.lensFacing)
+        assertNull(controller.state.value.errorState)
+        assertEquals(1, cameraRepository.switchLensCallCount)
+        assertEquals(listOf(CameraLensFacing.Back), cameraRepository.switchLensRequests)
+    }
+
+    @Test
+    fun onToggleLensFacing_whenSwitchFails_setsLensSwitchFailedError() = runTest {
+        val cameraRepository = FakeCameraRepository(
+            switchLensResult = Result.failure(
+                CameraRepositoryException(CameraError.LensSwitchFailed),
+            ),
+        )
+        val controller = CameraSessionController(cameraRepository, backgroundScope)
+        advanceUntilIdle()
+
+        controller.onToggleLensFacing()
+        advanceUntilIdle()
+
+        assertEquals(CameraError.LensSwitchFailed, controller.state.value.errorState)
+        val previewState = assertIs<PreviewState.Error>(controller.state.value.previewState)
+        assertEquals(CameraError.LensSwitchFailed, previewState.error)
+    }
+
+    @Test
+    fun observePreviewState_syncsErrorAndMessageFromRepository() = runTest {
+        val cameraRepository = FakeCameraRepository()
+        val controller = CameraSessionController(cameraRepository, backgroundScope)
+        advanceUntilIdle()
+
+        cameraRepository.emitPreviewState(PreviewState.Error(CameraError.CameraUnavailable))
+        advanceUntilIdle()
+
+        val errored = controller.state.value
+        assertEquals(CameraError.CameraUnavailable, errored.errorState)
+        val previewState = assertIs<PreviewState.Error>(errored.previewState)
+        assertEquals(CameraError.CameraUnavailable, previewState.error)
+        val message = assertNotNull(errored.message)
+        assertEquals(CameraMessageType.Error, message.type)
+
+        cameraRepository.emitPreviewState(PreviewState.Showing)
+        advanceUntilIdle()
+
+        assertEquals(PreviewState.Showing, controller.state.value.previewState)
+        assertNull(controller.state.value.errorState)
+        assertNull(controller.state.value.message)
+    }
+
+    @Test
+    fun clearErrorAndPrepare_clearsErrorAndSetsPreviewPreparing() = runTest {
+        val controller = CameraSessionController(FakeCameraRepository(), backgroundScope)
+        advanceUntilIdle()
+        controller.setError(CameraError.PermissionDenied)
+
+        controller.clearErrorAndPrepare()
+
+        assertEquals(PreviewState.Preparing, controller.state.value.previewState)
+        assertNull(controller.state.value.errorState)
+        assertNull(controller.state.value.message)
+    }
+
+    @Test
+    fun resetPreviewIfErrored_clearsErrorOnlyWhenInErrorState() = runTest {
+        val controller = CameraSessionController(FakeCameraRepository(), backgroundScope)
+        advanceUntilIdle()
+
+        controller.resetPreviewIfErrored()
+        assertEquals(PreviewState.Preparing, controller.state.value.previewState)
+
+        controller.setError(CameraError.PermissionDenied)
+        controller.resetPreviewIfErrored()
+
+        assertEquals(PreviewState.Preparing, controller.state.value.previewState)
+        assertNull(controller.state.value.errorState)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/testing/FakeRepositories.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/testing/FakeRepositories.kt
@@ -1,0 +1,119 @@
+package com.example.vtubercamera_kmp_ver.camera.testing
+
+import com.example.vtubercamera_kmp_ver.camera.CameraError
+import com.example.vtubercamera_kmp_ver.camera.CameraLensFacing
+import com.example.vtubercamera_kmp_ver.camera.CameraRepository
+import com.example.vtubercamera_kmp_ver.camera.CameraZoomUiState
+import com.example.vtubercamera_kmp_ver.camera.PermissionRepository
+import com.example.vtubercamera_kmp_ver.camera.PermissionState
+import com.example.vtubercamera_kmp_ver.camera.PreviewState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+// commonTest 全体で共有するカメラリポジトリのフェイク実装。call 記録 / 結果差し替え / preview state 注入を提供する。
+internal class FakeCameraRepository(
+    private val resolveInitialLensResult: Result<CameraLensFacing> = Result.success(
+        CameraLensFacing.Back,
+    ),
+    private val startPreviewResult: Result<CameraLensFacing>? = null,
+    private val switchLensResult: Result<CameraLensFacing> = Result.success(CameraLensFacing.Front),
+) : CameraRepository {
+    private val previewState = MutableStateFlow<PreviewState>(PreviewState.Preparing)
+    private val zoomUiState = MutableStateFlow(
+        CameraZoomUiState(
+            currentCameraZoomRatio = 1f,
+            minCameraZoomRatio = 1f,
+            maxCameraZoomRatio = 5f,
+        ),
+    )
+
+    var startPreviewCallCount: Int = 0
+        private set
+
+    var resolveInitialLensCallCount: Int = 0
+        private set
+
+    var switchLensCallCount: Int = 0
+        private set
+
+    val startPreviewRequests = mutableListOf<CameraLensFacing>()
+    val resolveInitialLensRequests = mutableListOf<CameraLensFacing>()
+    val switchLensRequests = mutableListOf<CameraLensFacing>()
+    val setZoomRatioRequests = mutableListOf<Float>()
+
+    override suspend fun startPreview(lensFacing: CameraLensFacing): Result<CameraLensFacing> {
+        startPreviewCallCount += 1
+        startPreviewRequests += lensFacing
+        val result = startPreviewResult ?: Result.success(lensFacing)
+        if (result.isSuccess) {
+            previewState.value = PreviewState.Showing
+        }
+        return result
+    }
+
+    override suspend fun stopPreview() {
+        previewState.value = PreviewState.Preparing
+    }
+
+    override suspend fun switchLens(current: CameraLensFacing): Result<CameraLensFacing> {
+        switchLensCallCount += 1
+        switchLensRequests += current
+        val result = switchLensResult
+        if (result.isSuccess) {
+            previewState.value = PreviewState.Showing
+        }
+        return result
+    }
+
+    override suspend fun resolveInitialLens(preferred: CameraLensFacing): Result<CameraLensFacing> {
+        resolveInitialLensCallCount += 1
+        resolveInitialLensRequests += preferred
+        return resolveInitialLensResult
+    }
+
+    override fun observePreviewState(): Flow<PreviewState> {
+        return previewState.asStateFlow()
+    }
+
+    override fun onPlatformPreviewStarted(lensFacing: CameraLensFacing) {
+        previewState.value = PreviewState.Showing
+    }
+
+    override fun onPlatformPreviewError(lensFacing: CameraLensFacing, error: CameraError) {
+        previewState.value = PreviewState.Error(error)
+    }
+
+    override fun observeZoomState(): Flow<CameraZoomUiState> {
+        return zoomUiState.asStateFlow()
+    }
+
+    override fun onPlatformZoomStateChanged(zoomUiState: CameraZoomUiState) {
+        this.zoomUiState.value = CameraZoomUiState(
+            currentCameraZoomRatio = zoomUiState.currentCameraZoomRatio,
+            minCameraZoomRatio = zoomUiState.minCameraZoomRatio,
+            maxCameraZoomRatio = zoomUiState.maxCameraZoomRatio,
+        )
+    }
+
+    override fun setZoomRatio(updatedZoomRatio: Float) {
+        setZoomRatioRequests += updatedZoomRatio
+        zoomUiState.value = zoomUiState.value.copy(currentCameraZoomRatio = updatedZoomRatio)
+    }
+
+    fun emitPreviewState(state: PreviewState) {
+        previewState.value = state
+    }
+}
+
+internal class FakePermissionRepository(
+    private val checkCameraPermissionResult: PermissionState,
+) : PermissionRepository {
+    override suspend fun checkCameraPermission(): PermissionState {
+        return checkCameraPermissionResult
+    }
+
+    override suspend fun requestCameraPermission(): PermissionState {
+        return checkCameraPermissionResult
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/zoom/CameraZoomControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/zoom/CameraZoomControllerTest.kt
@@ -1,0 +1,73 @@
+package com.example.vtubercamera_kmp_ver.camera.zoom
+
+import com.example.vtubercamera_kmp_ver.camera.testing.FakeCameraRepository
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CameraZoomControllerTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun observeZoomState_syncsRepositoryZoomToState() = runTest {
+        val cameraRepository = FakeCameraRepository()
+        val controller = CameraZoomController(cameraRepository, backgroundScope)
+        advanceUntilIdle()
+
+        assertEquals(1f, controller.state.value.currentCameraZoomRatio)
+        assertEquals(1f, controller.state.value.minCameraZoomRatio)
+        assertEquals(5f, controller.state.value.maxCameraZoomRatio)
+    }
+
+    @Test
+    fun onCameraZoomChanged_clampsBelowMin() = runTest {
+        val cameraRepository = FakeCameraRepository()
+        val controller = CameraZoomController(cameraRepository, backgroundScope)
+        advanceUntilIdle()
+
+        controller.onCameraZoomChanged(0.1f)
+
+        assertEquals(1f, cameraRepository.setZoomRatioRequests.last())
+    }
+
+    @Test
+    fun onCameraZoomChanged_clampsAboveMax() = runTest {
+        val cameraRepository = FakeCameraRepository()
+        val controller = CameraZoomController(cameraRepository, backgroundScope)
+        advanceUntilIdle()
+
+        controller.onCameraZoomChanged(10f)
+
+        assertEquals(5f, cameraRepository.setZoomRatioRequests.last())
+    }
+
+    @Test
+    fun onCameraZoomChanged_appliesScaleWithinBounds() = runTest {
+        val cameraRepository = FakeCameraRepository()
+        val controller = CameraZoomController(cameraRepository, backgroundScope)
+        advanceUntilIdle()
+
+        controller.onCameraZoomChanged(2f)
+
+        assertEquals(2f, cameraRepository.setZoomRatioRequests.last())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/zoom/CameraZoomControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/zoom/CameraZoomControllerTest.kt
@@ -7,7 +7,10 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -30,7 +33,7 @@ class CameraZoomControllerTest {
     @Test
     fun observeZoomState_syncsRepositoryZoomToState() = runTest {
         val cameraRepository = FakeCameraRepository()
-        val controller = CameraZoomController(cameraRepository, backgroundScope)
+        val controller = CameraZoomController(cameraRepository, controllerScope())
         advanceUntilIdle()
 
         assertEquals(1f, controller.state.value.currentCameraZoomRatio)
@@ -41,7 +44,7 @@ class CameraZoomControllerTest {
     @Test
     fun onCameraZoomChanged_clampsBelowMin() = runTest {
         val cameraRepository = FakeCameraRepository()
-        val controller = CameraZoomController(cameraRepository, backgroundScope)
+        val controller = CameraZoomController(cameraRepository, controllerScope())
         advanceUntilIdle()
 
         controller.onCameraZoomChanged(0.1f)
@@ -52,7 +55,7 @@ class CameraZoomControllerTest {
     @Test
     fun onCameraZoomChanged_clampsAboveMax() = runTest {
         val cameraRepository = FakeCameraRepository()
-        val controller = CameraZoomController(cameraRepository, backgroundScope)
+        val controller = CameraZoomController(cameraRepository, controllerScope())
         advanceUntilIdle()
 
         controller.onCameraZoomChanged(10f)
@@ -63,11 +66,14 @@ class CameraZoomControllerTest {
     @Test
     fun onCameraZoomChanged_appliesScaleWithinBounds() = runTest {
         val cameraRepository = FakeCameraRepository()
-        val controller = CameraZoomController(cameraRepository, backgroundScope)
+        val controller = CameraZoomController(cameraRepository, controllerScope())
         advanceUntilIdle()
 
         controller.onCameraZoomChanged(2f)
 
         assertEquals(2f, cameraRepository.setZoomRatioRequests.last())
     }
+
+    private fun TestScope.controllerScope(): CoroutineScope =
+        CoroutineScope(backgroundScope.coroutineContext + UnconfinedTestDispatcher(testScheduler))
 }

--- a/docs/KMP_IMPLEMENTATION_SPEC.ja.md
+++ b/docs/KMP_IMPLEMENTATION_SPEC.ja.md
@@ -56,6 +56,18 @@
 - camera デバイス制御やネイティブ API の接続は platform 実装が担当する。
 - 現状は Android / iOS で実装の深さに差があるため、同一実装とは扱わない。
 
+## 3.1 CameraViewModel の責務分割
+
+`CameraViewModel` は肥大化を避けるため、ドメインごとの controller / presenter へ責務を委譲する薄い coordinator として実装する。`CameraScreen` から見た公開 API（11 個のコールバックと単一の `uiState: StateFlow<CameraUiState>`）は変更せず、内部のみを分割している。
+
+- **CameraSessionController** (`camera/session`): プレビュー開始 / 再試行 / レンズ切り替えと `observePreviewState()` による repository state 同期を担う。依存は `CameraRepository`。
+- **CameraPermissionCoordinator** (`camera/permission`): 権限の確認・要求・状態反映を担う。`PermissionChange`（`GrantedEntered` / `GrantedRefreshed` / `DeniedReceived` / `UnknownReceived`）を発行し、`CameraViewModel` が session 側のエフェクトへ wiring する。依存は `PermissionRepository`。
+- **CameraZoomController** (`camera/zoom`): ズーム倍率の計算・反映と `observeZoomState()` を担う。依存は `CameraRepository`。
+- **FaceTrackingPresenter** (`camera/facetracking`): `NormalizedFaceFrame` から `FaceTrackingUiState` と `AvatarRenderState` への変換を担う。`FaceToAvatarMapper` への委譲もここに寄せている。
+- **AvatarSelectionController** (`camera/avatar`): ファイル選択結果の反映、`AvatarAssetStore` 上のアセット寿命管理、読み込み失敗時の選択解除を担う。
+
+`CameraUiState` はこれらに対応する sub-state（`session` / `permission` / `zoom` / `faceTracking` / `avatarRender` / `avatarSelection`）を束ねる composite として再構成している。各 controller は自前の `StateFlow` を持ち、`CameraViewModel` がそれらを `uiState` へ同期合成する。ドメイン横断の唯一の結線点は「権限が Granted へ遷移した際に session のプレビュー開始を起動する」箇所で、`CameraViewModel.applyPermissionChange()` に集約している。
+
 ## 4. ドキュメント更新ルール
 
 - present tense（実装済み）を記述する場合は、必ず README と現行コードで確認する。

--- a/scripts/spec_sync_check.py
+++ b/scripts/spec_sync_check.py
@@ -135,6 +135,14 @@ def run_checks(active_exceptions: set[str]) -> list[Finding]:
     ios_content_view = read_text("iosApp/iosApp/ContentView.swift")
     camera_screen = read_text("composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt")
     camera_view_model = read_text("composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt")
+    # Aggregate of the per-domain camera modules so feature-detection patterns survive the
+    # responsibility split introduced by issue #149.
+    camera_module = (
+        camera_view_model
+        + read_text("composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/session/CameraSessionController.kt")
+        + read_text("composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/zoom/CameraZoomController.kt")
+        + read_text("composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/facetracking/FaceTrackingPresenter.kt")
+    )
     agents = read_text(".codex/AGENTS.md")
     copilot = read_text(".github/copilot-instructions.md")
     bitrise = read_text("bitrise.yml")
@@ -296,7 +304,7 @@ def run_checks(active_exceptions: set[str]) -> list[Finding]:
             check_id="lens_toggle",
             title="Lens toggle is backed by shared state and platform preview hosts",
             category="Code ahead of spec",
-            ok=all_in(camera_view_model, ("onToggleLensFacing", "switchLens")) and "lensFacing" in android_preview and "lensFacing" in ios_preview,
+            ok=all_in(camera_module, ("onToggleLensFacing", "switchLens")) and "lensFacing" in android_preview and "lensFacing" in ios_preview,
             ok_evidence=(
                 "CameraViewModel.kt has onToggleLensFacing and switchLens flow.",
                 "Android and iOS preview hosts accept lensFacing.",
@@ -315,8 +323,8 @@ def run_checks(active_exceptions: set[str]) -> list[Finding]:
             ok=(
                 "mlkit.face.detection" in build_gradle
                 and path_exists("composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidFaceTrackingAnalyzer.kt")
-                and "onFaceTrackingFrameChanged" in camera_view_model
-                and "FaceTrackingUiState" in camera_view_model
+                and "onFaceTrackingFrameChanged" in camera_module
+                and "FaceTrackingUiState" in camera_module
             ),
             ok_evidence=(
                 "composeApp/build.gradle.kts has ML Kit Face Detection.",

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -45,6 +45,27 @@ def render_generated_block() -> str:
     ios_avatar_interop = read_text("composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSAvatarRenderInterop.kt")
     camera_screen = read_text("composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt")
     camera_view_model = read_text("composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt")
+    camera_session_controller = read_text(
+        "composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/session/CameraSessionController.kt",
+    )
+    camera_zoom_controller = read_text(
+        "composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/zoom/CameraZoomController.kt",
+    )
+    face_tracking_presenter = read_text(
+        "composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/facetracking/FaceTrackingPresenter.kt",
+    )
+    camera_shared_definitions = read_text(
+        "composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraSharedDefinitions.kt",
+    )
+    # Aggregate of the per-domain camera modules so feature-detection patterns survive the
+    # responsibility split introduced by issue #149.
+    camera_module = (
+        camera_view_model
+        + camera_session_controller
+        + camera_zoom_controller
+        + face_tracking_presenter
+        + camera_shared_definitions
+    )
     vrm_avatar_parser = read_text("composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/VrmAvatarParser.kt")
     vrm_runtime_descriptor = read_text("composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/vrm/VrmRuntimeAssetDescriptor.kt")
     theme_mode_store = read_text("composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/theme/ThemeModeStore.kt")
@@ -66,15 +87,15 @@ def render_generated_block() -> str:
         ),
     ) and all_in(android_preview, ("ProcessCameraProvider", "PreviewView")):
         android_items.append("CameraX によるリアルタイムプレビュー")
-    if "onToggleLensFacing" in camera_view_model and "toCameraSelector()" in android_preview:
+    if "onToggleLensFacing" in camera_module and "toCameraSelector()" in android_preview:
         android_items.append("フロント / バックカメラ切り替え")
-    if all_in(camera_view_model, ("observeZoomState", "setZoomRatio")) and "onPlatformZoomStateChanged" in android_preview:
+    if all_in(camera_module, ("observeZoomState", "setZoomRatio")) and "onPlatformZoomStateChanged" in android_preview:
         android_items.append("ピンチ操作によるカメラズーム制御とズーム倍率表示")
     if "ActivityResultContracts.OpenDocument" in android_preview:
         android_items.append("OpenDocument による VRM / GLB ファイル選択")
     if "libs.mlkit.face.detection" in build_gradle and "AndroidFaceTrackingAnalyzer" in android_preview:
         android_items.append("ML Kit Face Detection による face tracking 解析と共有 state 反映")
-    if "FaceToAvatarMapper" in camera_view_model:
+    if "FaceToAvatarMapper" in camera_module:
         android_items.append("face tracking 結果をアバター表情・ボーン状態へマッピング")
     if all_in(build_gradle, ("libs.filament.android", "libs.gltfio.android")) and "VrmAvatarParser.parse" in android_preview and all_in(
         android_avatar_host,
@@ -122,11 +143,11 @@ def render_generated_block() -> str:
         shared_items.append("カメラ画面の基本 UI")
     if "class CameraViewModel" in camera_view_model:
         shared_items.append("`CameraViewModel` による画面状態管理（権限・プレビュー・ズーム・アバター状態）")
-    if "lensFacing" in camera_view_model:
+    if "lensFacing" in camera_module:
         shared_items.append("レンズ向き状態 (`Back` / `Front`)")
-    if all_in(camera_view_model, ("zoomUiState", "onCameraZoomChanged")):
+    if all_in(camera_module, ("zoomUiState", "onCameraZoomChanged")):
         shared_items.append("ズーム状態 (`CameraZoomUiState`) と zoom ratio の更新")
-    if all_in(camera_view_model, ("FaceTrackingUiState", "FaceToAvatarMapper")):
+    if all_in(camera_module, ("FaceTrackingUiState", "FaceToAvatarMapper")):
         shared_items.append("face tracking の共有表示モデルと avatar 反映 state")
     if all_in(vrm_avatar_parser, ("supportedExtensions", "vrm", "glb")):
         shared_items.append("VRM / GLB バイナリのパースと選択済み avatar metadata 抽出")
@@ -136,7 +157,7 @@ def render_generated_block() -> str:
         shared_items.append("アバターアセット管理 (`AvatarAssetStore`) と renderer slot への受け渡し")
     if "ThemeModeStore" in theme_mode_store:
         shared_items.append("ライト / ダーク / システムテーマ設定の永続化")
-    if "camera_error_permission_denied" in camera_view_model:
+    if "camera_error_permission_denied" in camera_module:
         shared_items.append("権限文言のリソース管理")
 
     not_implemented_items = [


### PR DESCRIPTION
## Summary
- `CameraViewModel`（332 行）に集中していた 5 ドメインの責務を独立した controller / presenter へ分離し、見通しとテスタビリティを改善する。
- `CameraScreen` から見た公開 API（11 個のコールバックと単一 `uiState`）は維持し、内部委譲のみで段階移行する（写真撮影 #143 / フラッシュ #145 / 録画 #147 / AR・VRM #148 の追加に先行）。

## Changes
- 新規 controller / presenter（各自 `StateFlow` の sub-state を保持）: `session/CameraSessionController`、`permission/CameraPermissionCoordinator`、`zoom/CameraZoomController`、`facetracking/FaceTrackingPresenter`、`avatar/AvatarSelectionController`。
- `CameraUiState` を `session` / `permission` / `zoom` / `faceTracking` / `avatarRender` / `avatarSelection` の sub-state 合成へ再構成（未使用の `cameraZoomScale` を削除）。
- `CameraViewModel` を薄い coordinator 化。各 controller の `StateFlow` を Unconfined scope で `uiState` へ同期合成し、権限遷移 → session 起動の結線を `applyPermissionChange()` に集約。
- `CameraScreen` の state 参照を sub-state パスへ更新（コールバックのシグネチャは不変）。
- commonTest: 既存 `CameraViewModelTest` を新 shape へ移行して regression を維持、fake を `testing/FakeRepositories.kt` へ抽出、5 クラスの単体テストを追加。
- docs: `docs/KMP_IMPLEMENTATION_SPEC.ja.md` に責務分割の節を追加。
- scripts: `update_readme.py` / `spec_sync_check.py` を分割後のモジュール構成へ追従。

## Test Plan
- [x] `python3 scripts/update_readme.py --check`（README 同期 OK）
- [x] `python3 scripts/spec_sync_check.py`（18 ok / 0 warning）
- [] `./gradlew :composeApp:compileKotlinMetadata` ＋ Android / iOS コンパイル ※本作業環境は network policy（Host not in allowlist）により Gradle / Android plugin を取得できず未実行
- [ ] `./gradlew :composeApp:allTests`（commonTest: 既存 regression + 追加した per-controller テスト）※同上
- [ ] 実機 / シミュレータでの手動確認（権限付与 → プレビュー、レンズ切替、ピンチズーム、ファイル選択 成功 / 失敗、顔トラッキング表示）

## Related Issues
- Closes #149

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf82VbkJuAPSHqpLUvGGvu)_