### PR TITLE
[codex] Document avatar renderer integration status

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ VTuberCamera の Kotlin Multiplatform 版リポジトリです。Android と iOS
 - VRM / GLB バイナリのパースと選択済み avatar metadata 抽出
 - VRM runtime descriptor による humanoid bone / expression / lookAt 情報の保持
 - アバターアセット管理 (`AvatarAssetStore`) と renderer slot への受け渡し
+- Android で face tracking 結果を avatar renderer の head pose / expression morph に反映する end-to-end 統合
+- iOS で ARKit face tracking 結果を共有 render state と native bridge へ伝達する統合
 - ライト / ダーク / システムテーマ設定の永続化
 - 権限文言のリソース管理
 
@@ -55,7 +57,7 @@ VTuberCamera の Kotlin Multiplatform 版リポジトリです。Android と iOS
 - フラッシュ制御
 - ギャラリー関連機能
 - 録画 / 配信向けの出力機能
-- face tracking と avatar renderer を完全に統合した AR / VRM end-to-end 体験
+- iOS native Filament renderer で選択済み avatar mesh へ head pose / expression morph を適用する実装
 
 ## リポジトリ構成
 
@@ -158,5 +160,5 @@ xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -configuration Debug 
 ## 今後の整理候補
 
 - 写真撮影、保存 / 削除、フラッシュ、ギャラリー関連機能を段階的に追加する
-- face tracking と avatar renderer を完全に統合した AR / VRM end-to-end 体験へ接続する
+- iOS native Filament renderer に avatar mesh loading と head pose / expression morph 適用を追加する
 - 録画 / 配信向けの出力機能を設計する

--- a/composeApp/src/androidUnitTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/tracking/AndroidFaceTrackingToAvatarMapperTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/example/vtubercamera_kmp_ver/avatar/tracking/AndroidFaceTrackingToAvatarMapperTest.kt
@@ -1,0 +1,68 @@
+package com.example.vtubercamera_kmp_ver.avatar.tracking
+
+import com.example.vtubercamera_kmp_ver.avatar.model.AvatarExpressionWeights
+import com.example.vtubercamera_kmp_ver.avatar.model.AvatarRigState
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarRenderState
+import com.example.vtubercamera_kmp_ver.avatar.state.AvatarTrackingStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AndroidFaceTrackingToAvatarMapperTest {
+
+    @Test
+    fun map_trackingStateAppliesAndroidRendererGainAndExpressionEmphasis() {
+        val mapped = AndroidFaceTrackingToAvatarMapper().map(
+            AvatarRenderState(
+                rig = AvatarRigState(
+                    headYawDegrees = 50f,
+                    headPitchDegrees = -40f,
+                    headRollDegrees = 40f,
+                ),
+                expressions = AvatarExpressionWeights(
+                    leftEyeBlink = 0.92f,
+                    rightEyeBlink = 0.51f,
+                    jawOpen = 0.6f,
+                    mouthSmile = 0.43f,
+                ),
+                trackingStatus = AvatarTrackingStatus.Tracking,
+                trackingConfidence = 0.95f,
+                sourceTimestampMillis = 100L,
+            ),
+        )
+
+        assertEquals(expected = 45f, actual = mapped.rig.headYawDegrees, absoluteTolerance = 0.0001f)
+        assertEquals(expected = -30f, actual = mapped.rig.headPitchDegrees, absoluteTolerance = 0.0001f)
+        assertEquals(expected = 35f, actual = mapped.rig.headRollDegrees, absoluteTolerance = 0.0001f)
+        assertEquals(expected = 1f, actual = mapped.expressions.leftEyeBlink, absoluteTolerance = 0.0001f)
+        assertEquals(expected = 0.5f, actual = mapped.expressions.rightEyeBlink, absoluteTolerance = 0.0001f)
+        assertEquals(expected = 0.72f, actual = mapped.expressions.jawOpen, absoluteTolerance = 0.0001f)
+        assertEquals(expected = 0.5f, actual = mapped.expressions.mouthSmile, absoluteTolerance = 0.0001f)
+        assertEquals(AvatarTrackingStatus.Tracking, mapped.trackingStatus)
+        assertEquals(0.95f, mapped.trackingConfidence)
+        assertEquals(100L, mapped.sourceTimestampMillis)
+    }
+
+    @Test
+    fun map_nonTrackingStatePassesThroughNeutralDecayUntouched() {
+        val state = AvatarRenderState(
+            rig = AvatarRigState(
+                headYawDegrees = 8f,
+                headPitchDegrees = -4f,
+                headRollDegrees = 3f,
+            ),
+            expressions = AvatarExpressionWeights(
+                leftEyeBlink = 0.3f,
+                rightEyeBlink = 0.2f,
+                jawOpen = 0.4f,
+                mouthSmile = 0.5f,
+            ),
+            trackingStatus = AvatarTrackingStatus.Lost,
+            trackingConfidence = 0.2f,
+            sourceTimestampMillis = 120L,
+        )
+
+        val mapped = AndroidFaceTrackingToAvatarMapper().map(state)
+
+        assertEquals(state, mapped)
+    }
+}

--- a/docs/KMP_IMPLEMENTATION_SPEC.ja.md
+++ b/docs/KMP_IMPLEMENTATION_SPEC.ja.md
@@ -39,6 +39,8 @@
 - TrueDepth 対応デバイスの前面カメラで ARKit face tracking
 - avatar render state を Filament ブリッジへ伝達 (`IOSAvatarRenderInterop` / `IOSAvatarRenderBridge.swift`)
 - `iosApp` は Compose のホストアプリ（`MainViewController` 起動）
+- Android は ML Kit face tracking の正規化結果を共有 `AvatarRenderState` へ変換し、Filament renderer の head bone / expression morph へ適用する。
+- iOS は ARKit face tracking の正規化結果を共有 `AvatarRenderState` へ変換し、native bridge へ通知する。
 
 ## 2. 未実装 / 計画中（Phase 1 以降）
 
@@ -48,13 +50,17 @@
 - 撮影画像の保存 / 削除
 - フラッシュ制御
 - ギャラリー連携
-- face tracking と avatar renderer をつないだ AR / VRM の end-to-end 統合
+- iOS native Filament renderer で選択済み avatar mesh を読み込み、head pose / expression morph を適用する実装
 
 ## 3. 共有とプラットフォーム責務の整理
 
 - shared は UI と状態遷移の土台を担当する。
 - camera デバイス制御やネイティブ API の接続は platform 実装が担当する。
 - 現状は Android / iOS で実装の深さに差があるため、同一実装とは扱わない。
+- `FaceTrackingPresenter` は platform から受け取った `NormalizedFaceFrame` を `FaceToAvatarMapper` へ渡し、UI 表示用 `FaceTrackingUiState` と renderer 用 `AvatarRenderState` を同時に更新する。
+- 顔未検出または tracking confidence 低下時は `AvatarRenderState` を `NotTracked` / `Lost` へ遷移させ、前回姿勢から neutral へ平滑に戻す。
+- Android renderer は共有 state に Android 向けの軽い gain / emphasis を適用してから、head bone transform と VRM expression morph weights へ反映する。
+- iOS renderer bridge は共有 state を `VTCAvatarRenderState` へ変換して native 側へ渡す。`iosApp/Configuration/Filament.xcconfig` の SDK / linker 設定が空のため、native mesh loading / morph application は未実装として扱う。
 
 ## 3.1 CameraViewModel の責務分割
 

--- a/docs/spec-sync-exceptions.yaml
+++ b/docs/spec-sync-exceptions.yaml
@@ -49,13 +49,13 @@ exceptions:
     scope:
       - avatar_renderer
       - readme_summary
-    reason: README now distinguishes shipped avatar renderer groundwork from unfinished end-to-end AR / VRM integration, so this exception is no longer active.
+    reason: README now distinguishes Android dynamic avatar integration, iOS render-state bridge integration, and unfinished iOS native mesh rendering, so this exception is no longer active.
     evidence:
       - composeApp/build.gradle.kts: Android Filament and gltfio dependencies.
       - composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render
       - iosApp/iosApp/AvatarRender/FilamentAvatarView.swift
-      - README.md: renderer groundwork is listed separately from unfinished end-to-end AR / VRM integration.
-    reevaluate_when: Remove or rewrite this historical note when end-to-end AR / VRM integration is fully documented as shipped or reclassified.
+      - README.md: Android dynamic integration, iOS bridge integration, and remaining iOS native mesh renderer work are listed separately.
+    reevaluate_when: Remove this historical note when iOS native mesh rendering ships.
 
   - id: IOS_PHOTO_LIBRARY_PERMISSION_PLANNED
     category: Spec ahead of code

--- a/iosApp/iosAppTests/IOSAvatarRenderBridgeTests.swift
+++ b/iosApp/iosAppTests/IOSAvatarRenderBridgeTests.swift
@@ -67,6 +67,42 @@ struct IOSAvatarRenderBridgeTests {
     }
 
     @Test
+    func notificationObserversForwardRenderStateAndClearAvatar() {
+        let renderer = SpyRenderStateRenderer()
+        let bridge = IOSAvatarRenderBridge(renderer: renderer)
+        bridge.connect()
+        defer { bridge.disconnect() }
+
+        NotificationCenter.default.post(
+            name: IOSAvatarRenderBridge.avatarRenderStateDidChangeNotification,
+            object: nil,
+            userInfo: [
+                IOSAvatarRenderBridge.headYawDegreesKey: NSNumber(value: 14),
+                IOSAvatarRenderBridge.headPitchDegreesKey: NSNumber(value: -2),
+                IOSAvatarRenderBridge.headRollDegreesKey: NSNumber(value: 5),
+                IOSAvatarRenderBridge.leftEyeBlinkKey: NSNumber(value: 0.4),
+                IOSAvatarRenderBridge.rightEyeBlinkKey: NSNumber(value: 0.6),
+                IOSAvatarRenderBridge.jawOpenKey: NSNumber(value: 0.8),
+                IOSAvatarRenderBridge.mouthSmileKey: NSNumber(value: 0.2)
+            ]
+        )
+        NotificationCenter.default.post(
+            name: IOSAvatarRenderBridge.avatarSelectionDidClearNotification,
+            object: nil
+        )
+
+        let state = renderer.latestState
+        #expect(state?.headYawDegrees == 14)
+        #expect(state?.headPitchDegrees == -2)
+        #expect(state?.headRollDegrees == 5)
+        #expect(state?.leftEyeBlink == 0.4)
+        #expect(state?.rightEyeBlink == 0.6)
+        #expect(state?.jawOpen == 0.8)
+        #expect(state?.mouthSmile == 0.2)
+        #expect(renderer.clearAvatarCallCount == 1)
+    }
+
+    @Test
     func filamentRendererBridgeStoresLatestAvatarStateCopy() {
         let bridge = VTCFilamentRendererBridge()
         let state = VTCAvatarRenderState()
@@ -95,10 +131,13 @@ struct IOSAvatarRenderBridgeTests {
 @MainActor
 private final class SpyRenderStateRenderer: IOSAvatarRenderStateApplying {
     private(set) var latestState: VTCAvatarRenderState?
+    private(set) var clearAvatarCallCount = 0
 
     func applySelectedAvatar(_ payload: IOSVrmAssetPayload) {}
 
-    func clearAvatar() {}
+    func clearAvatar() {
+        clearAvatarCallCount += 1
+    }
 
     func updateAvatarState(_ state: VTCAvatarRenderState) {
         latestState = state

--- a/scripts/spec_sync_check.py
+++ b/scripts/spec_sync_check.py
@@ -390,7 +390,7 @@ def run_checks(active_exceptions: set[str]) -> list[Finding]:
     findings.append(
         make_finding(
             check_id="avatar_renderer_summary",
-            title="README distinguishes shipped avatar renderer groundwork from unfinished AR / VRM integration",
+            title="README distinguishes shipped avatar integration from unfinished iOS native mesh rendering",
             category="README/spec mismatch",
             ok=(
                 "filament.android" in build_gradle
@@ -402,18 +402,17 @@ def run_checks(active_exceptions: set[str]) -> list[Finding]:
                     or "Filament / gltfio による VRM avatar 表示基盤" in readme
                 )
                 and "SwiftUI + Filament による avatar view ホスト" in readme
-                and (
-                    "face tracking と avatar renderer をつないだ AR / VRM の end-to-end 統合" in readme
-                    or "face tracking と avatar renderer を完全に統合した AR / VRM end-to-end 体験" in readme
-                )
+                and "Android で face tracking 結果を avatar renderer の head pose / expression morph に反映する end-to-end 統合" in readme
+                and "iOS で ARKit face tracking 結果を共有 render state と native bridge へ伝達する統合" in readme
+                and "iOS native Filament renderer で選択済み avatar mesh へ head pose / expression morph を適用する実装" in readme_not_implemented
             ),
             ok_evidence=(
                 "Android Filament/gltfio dependencies and renderer host exist.",
                 "iOS Filament avatar view host exists.",
-                "README separates shipped renderer groundwork from unfinished end-to-end AR / VRM integration.",
+                "README documents Android dynamic integration, iOS render-state bridge integration, and the remaining iOS native mesh renderer work separately.",
             ),
-            problem_evidence=("Avatar renderer code exists, but README still needs finer-grained classification.",),
-            recommendation="Document the shipped renderer layer separately from unfinished end-to-end AR / VRM integration.",
+            problem_evidence=("Avatar renderer code exists, but README still needs finer-grained platform classification.",),
+            recommendation="Document Android dynamic avatar integration, iOS bridge integration, and unfinished iOS native mesh rendering separately.",
             active_exceptions=active_exceptions,
         )
     )

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -155,6 +155,14 @@ def render_generated_block() -> str:
         shared_items.append("VRM runtime descriptor による humanoid bone / expression / lookAt 情報の保持")
     if all_in(vrm_avatar_parser, ("AvatarAssetStore.store", "AvatarSelectionData")):
         shared_items.append("アバターアセット管理 (`AvatarAssetStore`) と renderer slot への受け渡し")
+    android_runtime_controller = read_text(
+        "composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/avatar/render/AndroidAvatarRuntimeController.kt"
+    )
+    has_shared_avatar_mapping = all_in(camera_module, ("FaceToAvatarMapper", "AvatarRenderState"))
+    if has_shared_avatar_mapping and "AndroidAvatarRuntimeController" in android_runtime_controller:
+        shared_items.append("Android で face tracking 結果を avatar renderer の head pose / expression morph に反映する end-to-end 統合")
+    if has_shared_avatar_mapping and "IOSAvatarRenderInterop" in ios_avatar_interop:
+        shared_items.append("iOS で ARKit face tracking 結果を共有 render state と native bridge へ伝達する統合")
     if "ThemeModeStore" in theme_mode_store:
         shared_items.append("ライト / ダーク / システムテーマ設定の永続化")
     if "camera_error_permission_denied" in camera_module:
@@ -166,7 +174,7 @@ def render_generated_block() -> str:
         "フラッシュ制御",
         "ギャラリー関連機能",
         "録画 / 配信向けの出力機能",
-        "face tracking と avatar renderer を完全に統合した AR / VRM end-to-end 体験",
+        "iOS native Filament renderer で選択済み avatar mesh へ head pose / expression morph を適用する実装",
     ]
 
     structure_items = [


### PR DESCRIPTION
## Summary
- Clarify the current avatar renderer integration status across Android and iOS.
- Capture Android dynamic face-tracking-to-avatar integration as shipped, while keeping iOS native mesh rendering scoped as pending.

## Changes
- Add Android tests for renderer-state gain/emphasis mapping and non-tracking pass-through behavior.
- Add iOS bridge observer tests for render-state forwarding and avatar clear notifications.
- Update README/spec docs, spec-sync exceptions, and README/spec-sync scripts to reflect the new platform classification.

## Test Plan
- [x] `ANDROID_HOME=/Users/j____takumi/Library/Android/sdk ./gradlew :composeApp:testDebugUnitTest`
- [x] `ANDROID_HOME=/Users/j____takumi/Library/Android/sdk ./gradlew :composeApp:iosSimulatorArm64Test --tests com.example.vtubercamera_kmp_ver.camera.IOSFaceTrackingSupportTest`
- [x] `ANDROID_HOME=/Users/j____takumi/Library/Android/sdk ./gradlew :composeApp:compileKotlinIosSimulatorArm64`
- [x] `xcodebuild test -project iosApp/iosApp.xcodeproj -scheme iosAppTest -destination 'id=A3F9A8DD-62CB-4184-8040-3F47DCEF7891' -only-testing:iosAppTests/IOSAvatarRenderBridgeTests`
- [x] `python3 scripts/update_readme.py`
- [x] `python3 scripts/spec_sync_check.py`

## Related Issues
- Refs #148