### PR TITLE
Add photo capture support

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraPreview.kt
@@ -10,6 +10,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageCapture
 import androidx.camera.core.Preview
 import androidx.camera.core.ZoomState
 import androidx.camera.lifecycle.ProcessCameraProvider
@@ -209,15 +210,21 @@ actual fun CameraPreviewHost(
                     .build()
                     .also { it.setAnalyzer(analysisExecutor, faceTrackingAnalyzer) }
 
+                val imageCapture = ImageCapture.Builder()
+                    .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
+                    .build()
+
                 cameraProvider.unbindAll()
                 val camera = cameraProvider.bindToLifecycle(
                     lifecycleOwner,
                     selector,
                     preview,
                     analysis,
+                    imageCapture,
                 )
                 // AndroidCameraRepositoryをこの時だけキャストする。nullなら実行しない
                 (cameraRepository as? AndroidCameraRepository)?.onPlatformCameraControlReady(camera.cameraControl)
+                (cameraRepository as? AndroidCameraRepository)?.onPlatformImageCaptureReady(imageCapture)
                 // 現在の倍率をLiveDataで監視する
                 val zoomLiveData = camera.cameraInfo.zoomState
                 val zoomObserver = Observer<ZoomState> { zoomState ->
@@ -237,6 +244,7 @@ actual fun CameraPreviewHost(
             }.onFailure {
                 (previewView.tag as? AndroidFaceTrackingAnalyzer)?.close()
                 previewView.tag = null
+                (cameraRepository as? AndroidCameraRepository)?.onPlatformImageCaptureReady(null)
                 onFaceTrackingFrameChangedState.value(null)
                 cameraRepository.onPlatformPreviewError(
                     lensFacing = attemptedLensFacing,
@@ -254,6 +262,7 @@ actual fun CameraPreviewHost(
             if (cameraProviderFuture.isDone) {
                 cameraProviderFuture.get().unbindAll()
             }
+            (cameraRepository as? AndroidCameraRepository)?.onPlatformImageCaptureReady(null)
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraRepository.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraRepository.kt
@@ -2,10 +2,17 @@ package com.example.vtubercamera_kmp_ver.camera
 
 import androidx.camera.core.CameraControl
 import androidx.camera.core.CameraInfoUnavailableException
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
 import androidx.camera.core.CameraSelector
 import androidx.camera.lifecycle.ProcessCameraProvider
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.io.File
+import kotlin.coroutines.resume
 
 internal interface CameraLensAvailability {
     fun hasCamera(lensFacing: CameraLensFacing): Boolean
@@ -14,10 +21,12 @@ internal interface CameraLensAvailability {
 internal class AndroidCameraRepository(
     private val cameraAvailabilityProvider: suspend () -> CameraLensAvailability,
     private val previewState: MutableStateFlow<PreviewState> = MutableStateFlow(PreviewState.Preparing),
+    private val photoCaptureState: MutableStateFlow<PhotoCaptureState> = MutableStateFlow(PhotoCaptureState.Idle),
     private val zoomUiState: MutableStateFlow<CameraZoomUiState> = MutableStateFlow(CameraZoomUiState())
 ) : CameraRepository {
     private var pendingLensFacing: CameraLensFacing? = null
     private var cameraControl: CameraControl? = null
+    private var imageCapture: ImageCapture? = null
 
     override suspend fun startPreview(lensFacing: CameraLensFacing): Result<CameraLensFacing> {
         val cameraAvailability = cameraAvailabilityProvider()
@@ -60,6 +69,42 @@ internal class AndroidCameraRepository(
 
     override fun observePreviewState(): Flow<PreviewState> = previewState
 
+    override fun observePhotoCaptureState(): Flow<PhotoCaptureState> = photoCaptureState
+
+    override suspend fun capturePhoto(): Result<String?> {
+        val capture = imageCapture
+            ?: return Result.failure<String?>(
+                CameraRepositoryException(CameraError.PhotoCaptureFailed),
+            ).also {
+                photoCaptureState.value = PhotoCaptureState.Failed(CameraError.PhotoCaptureFailed)
+            }
+        photoCaptureState.value = PhotoCaptureState.Capturing
+        return withContext(Dispatchers.Main) {
+            suspendCancellableCoroutine { continuation ->
+                val outputFile = File.createTempFile("vtuber-camera-", ".jpg")
+                val outputOptions = ImageCapture.OutputFileOptions.Builder(outputFile).build()
+                capture.takePicture(
+                    outputOptions,
+                    Runnable::run,
+                    object : ImageCapture.OnImageSavedCallback {
+                        override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
+                            val uri = outputFileResults.savedUri?.toString() ?: outputFile.toURI().toString()
+                            photoCaptureState.value = PhotoCaptureState.Succeeded(uri)
+                            continuation.resume(Result.success(uri))
+                        }
+
+                        override fun onError(exception: ImageCaptureException) {
+                            photoCaptureState.value = PhotoCaptureState.Failed(CameraError.PhotoCaptureFailed)
+                            continuation.resume(
+                                Result.failure(CameraRepositoryException(CameraError.PhotoCaptureFailed)),
+                            )
+                        }
+                    },
+                )
+            }
+        }
+    }
+
     override fun onPlatformPreviewStarted(lensFacing: CameraLensFacing) {
         if (pendingLensFacing == null || pendingLensFacing == lensFacing) {
             pendingLensFacing = lensFacing
@@ -84,8 +129,12 @@ internal class AndroidCameraRepository(
         cameraControl?.setZoomRatio(updatedZoomRatio)
     }
 
-     fun onPlatformCameraControlReady(cameraControl: CameraControl) {
+    fun onPlatformCameraControlReady(cameraControl: CameraControl) {
         this.cameraControl = cameraControl
+    }
+
+    fun onPlatformImageCaptureReady(imageCapture: ImageCapture?) {
+        this.imageCapture = imageCapture
     }
 }
 

--- a/composeApp/src/androidUnitTest/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraRepositoryTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/example/vtubercamera_kmp_ver/camera/AndroidCameraRepositoryTest.kt
@@ -51,6 +51,20 @@ class AndroidCameraRepositoryTest {
     }
 
     @Test
+    fun capturePhoto_returnsPhotoCaptureFailedWhenImageCaptureIsNotReady() = runTest {
+        val repository = createRepository(availableLens = setOf(CameraLensFacing.Back))
+
+        val result = repository.capturePhoto()
+
+        val exception = assertIs<CameraRepositoryException>(result.exceptionOrNull())
+        assertEquals(CameraError.PhotoCaptureFailed, exception.error)
+        assertEquals(
+            PhotoCaptureState.Failed(CameraError.PhotoCaptureFailed),
+            repository.observePhotoCaptureState().first(),
+        )
+    }
+
+    @Test
     fun onPlatformPreviewStarted_ignoresStaleCallbackWhileSwitchIsPending() = runTest {
         val repository = createRepository(
             availableLens = setOf(CameraLensFacing.Back, CameraLensFacing.Front),

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="camera_permission_open_settings_button">設定を開く</string>
     <string name="camera_permission_launch_button">カメラを起動</string>
     <string name="camera_switch_button">カメラ切り替え</string>
+    <string name="camera_capture_button">写真撮影</string>
     <string name="theme_toggle_content_description">テーマ切り替え</string>
     <string name="theme_mode_system">S</string>
     <string name="theme_mode_light">L</string>
@@ -19,7 +20,9 @@
     <string name="camera_error_unavailable">カメラデバイスを利用できません。</string>
     <string name="camera_error_preview_initialization_failed">カメラプレビューの初期化に失敗しました。</string>
     <string name="camera_error_lens_switch_failed">カメラの切り替えに失敗しました。</string>
+    <string name="camera_error_photo_capture_failed">写真の撮影に失敗しました。</string>
     <string name="camera_error_unknown">不明なカメラエラーが発生しました。</string>
+    <string name="camera_photo_capture_succeeded">写真を保存しました。</string>
     <string name="file_picker_open_button">ファイルを開く</string>
     <string name="file_picker_open_failed">ファイルを開けませんでした。</string>
     <string name="file_picker_read_failed">ファイルの読み込みに失敗しました。</string>

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraScreen.kt
@@ -41,6 +41,7 @@ import org.jetbrains.compose.resources.stringResource
 import vtubercamera_kmp_ver.composeapp.generated.resources.Res
 import vtubercamera_kmp_ver.composeapp.generated.resources.avatar_error_dialog_confirm
 import vtubercamera_kmp_ver.composeapp.generated.resources.avatar_error_dialog_title
+import vtubercamera_kmp_ver.composeapp.generated.resources.camera_capture_button
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_permission_granted_description
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_permission_request_button
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_permission_required_message
@@ -111,6 +112,7 @@ fun CameraRoute(
         onLensFacingChanged = cameraViewModel::onLensFacingChanged,
         onLensFacingToggle = cameraViewModel::onToggleLensFacing,
         onCameraZoomChanged = cameraViewModel::onCameraZoomChanged,
+        onCapturePhoto = cameraViewModel::onCapturePhoto,
         themeMode = themeMode,
         onThemeModeToggle = onThemeModeToggle,
     )
@@ -135,6 +137,7 @@ fun CameraScreen(
     onLensFacingChanged: (CameraLensFacing) -> Unit,
     onLensFacingToggle: () -> Unit,
     onCameraZoomChanged: (Float) -> Unit,
+    onCapturePhoto: () -> Unit,
     themeMode: ThemeMode,
     onThemeModeToggle: () -> Unit,
     modifier: Modifier = Modifier,
@@ -168,6 +171,7 @@ fun CameraScreen(
                 onLensFacingChanged = onLensFacingChanged,
                 onLensFacingToggle = onLensFacingToggle,
                 onCameraZoomChanged = onCameraZoomChanged,
+                onCapturePhoto = onCapturePhoto,
                 themeMode = themeMode,
                 onThemeModeToggle = onThemeModeToggle,
             )
@@ -175,7 +179,7 @@ fun CameraScreen(
             else -> LoadingState()
         }
 
-        uiState.session.message?.let { message ->
+        (uiState.photoCapture.toCameraMessage() ?: uiState.session.message)?.let { message ->
             CameraMessageBanner(
                 message = message,
                 modifier = Modifier
@@ -210,6 +214,7 @@ private fun CameraPreviewState(
     onLensFacingChanged: (CameraLensFacing) -> Unit,
     onLensFacingToggle: () -> Unit,
     onCameraZoomChanged: (Float) -> Unit,
+    onCapturePhoto: () -> Unit,
     themeMode: ThemeMode,
     onThemeModeToggle: () -> Unit,
 ) {
@@ -247,6 +252,8 @@ private fun CameraPreviewState(
             zoomScale = uiState.zoom.currentCameraZoomRatio,
             onOpenFilePicker = onOpenFilePicker,
             onLensFacingToggle = onLensFacingToggle,
+            onCapturePhoto = onCapturePhoto,
+            isCapturingPhoto = uiState.photoCapture == PhotoCaptureState.Capturing,
             themeMode = themeMode,
             onThemeModeToggle = onThemeModeToggle,
         )
@@ -385,6 +392,8 @@ private fun BoxScope.CameraUiLayer(
     zoomScale: Float,
     onOpenFilePicker: () -> Unit,
     onLensFacingToggle: () -> Unit,
+    onCapturePhoto: () -> Unit,
+    isCapturingPhoto: Boolean,
     themeMode: ThemeMode,
     onThemeModeToggle: () -> Unit,
 ) {
@@ -424,6 +433,21 @@ private fun BoxScope.CameraUiLayer(
                 }
                 Button(onClick = onLensFacingToggle) {
                     Text(stringResource(Res.string.camera_switch_button))
+                }
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            Button(
+                onClick = onCapturePhoto,
+                enabled = !isCapturingPhoto,
+            ) {
+                if (isCapturingPhoto) {
+                    CircularProgressIndicator()
+                } else {
+                    Text(stringResource(Res.string.camera_capture_button))
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraSharedDefinitions.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraSharedDefinitions.kt
@@ -5,9 +5,11 @@ import org.jetbrains.compose.resources.StringResource
 import vtubercamera_kmp_ver.composeapp.generated.resources.Res
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_error_lens_switch_failed
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_error_permission_denied
+import vtubercamera_kmp_ver.composeapp.generated.resources.camera_error_photo_capture_failed
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_error_preview_initialization_failed
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_error_unavailable
 import vtubercamera_kmp_ver.composeapp.generated.resources.camera_error_unknown
+import vtubercamera_kmp_ver.composeapp.generated.resources.camera_photo_capture_succeeded
 
 // 画面から参照する共有のカメラ権限状態。
 enum class PermissionState {
@@ -30,7 +32,18 @@ enum class CameraError {
     CameraUnavailable,
     PreviewInitializationFailed,
     LensSwitchFailed,
+    PhotoCaptureFailed,
     Unknown,
+}
+
+sealed interface PhotoCaptureState {
+    data object Idle : PhotoCaptureState
+
+    data object Capturing : PhotoCaptureState
+
+    data class Succeeded(val uri: String?) : PhotoCaptureState
+
+    data class Failed(val error: CameraError) : PhotoCaptureState
 }
 
 // 共有のカメラ UI で、案内バナーとエラーバナーを区別する。
@@ -54,12 +67,24 @@ fun CameraError.toCameraMessage(): CameraMessage {
             Res.string.camera_error_preview_initialization_failed
         }
         CameraError.LensSwitchFailed -> Res.string.camera_error_lens_switch_failed
+        CameraError.PhotoCaptureFailed -> Res.string.camera_error_photo_capture_failed
         CameraError.Unknown -> Res.string.camera_error_unknown
     }
     return CameraMessage(
         type = CameraMessageType.Error,
         messageRes = messageRes,
     )
+}
+
+fun PhotoCaptureState.toCameraMessage(): CameraMessage? = when (this) {
+    PhotoCaptureState.Idle,
+    PhotoCaptureState.Capturing,
+    -> null
+    is PhotoCaptureState.Succeeded -> CameraMessage(
+        type = CameraMessageType.Guide,
+        messageRes = Res.string.camera_photo_capture_succeeded,
+    )
+    is PhotoCaptureState.Failed -> error.toCameraMessage()
 }
 
 // リポジトリ呼び出し失敗時も、ドメイン上のカメラエラー種別を保持する。
@@ -75,6 +100,10 @@ interface CameraRepository {
     suspend fun resolveInitialLens(preferred: CameraLensFacing): Result<CameraLensFacing>
 
     fun observePreviewState(): Flow<PreviewState>
+
+    fun observePhotoCaptureState(): Flow<PhotoCaptureState>
+
+    suspend fun capturePhoto(): Result<String?>
 
     fun onPlatformPreviewStarted(lensFacing: CameraLensFacing)
 

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraUiState.kt
@@ -10,6 +10,7 @@ data class CameraUiState(
     val session: CameraSessionUiState = CameraSessionUiState(),
     val permission: CameraPermissionUiState = CameraPermissionUiState(),
     val zoom: CameraZoomUiState = CameraZoomUiState(),
+    val photoCapture: PhotoCaptureState = PhotoCaptureState.Idle,
     val faceTracking: FaceTrackingUiState = FaceTrackingUiState(),
     val avatarRender: AvatarRenderState = AvatarRenderState.Neutral,
     val avatarSelection: AvatarSelectionUiState = AvatarSelectionUiState(),

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/CameraViewModel.kt
@@ -6,6 +6,7 @@ import com.example.vtubercamera_kmp_ver.camera.avatar.AvatarSelectionController
 import com.example.vtubercamera_kmp_ver.camera.facetracking.FaceTrackingPresenter
 import com.example.vtubercamera_kmp_ver.camera.permission.CameraPermissionCoordinator
 import com.example.vtubercamera_kmp_ver.camera.permission.PermissionChange
+import com.example.vtubercamera_kmp_ver.camera.photo.PhotoCaptureController
 import com.example.vtubercamera_kmp_ver.camera.session.CameraSessionController
 import com.example.vtubercamera_kmp_ver.camera.zoom.CameraZoomController
 import kotlinx.coroutines.CoroutineScope
@@ -37,6 +38,10 @@ class CameraViewModel(
         cameraRepository = cameraRepository,
         scope = viewModelScope,
     )
+    private val photoCaptureController = PhotoCaptureController(
+        cameraRepository = cameraRepository,
+        scope = viewModelScope,
+    )
     private val faceTrackingPresenter = FaceTrackingPresenter()
     private val avatarSelectionController = AvatarSelectionController()
 
@@ -63,6 +68,11 @@ class CameraViewModel(
         mirrorScope.launch {
             zoomController.state.collect { zoom ->
                 _uiState.update { it.copy(zoom = zoom) }
+            }
+        }
+        mirrorScope.launch {
+            photoCaptureController.state.collect { photoCapture ->
+                _uiState.update { it.copy(photoCapture = photoCapture) }
             }
         }
         mirrorScope.launch {
@@ -123,6 +133,10 @@ class CameraViewModel(
 
     fun onCameraZoomChanged(scaleChange: Float) {
         zoomController.onCameraZoomChanged(scaleChange)
+    }
+
+    fun onCapturePhoto() {
+        photoCaptureController.capturePhoto()
     }
 
     fun onDismissFilePickerError() {

--- a/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/photo/PhotoCaptureController.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/vtubercamera_kmp_ver/camera/photo/PhotoCaptureController.kt
@@ -1,0 +1,34 @@
+package com.example.vtubercamera_kmp_ver.camera.photo
+
+import com.example.vtubercamera_kmp_ver.camera.CameraRepository
+import com.example.vtubercamera_kmp_ver.camera.PhotoCaptureState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class PhotoCaptureController(
+    private val cameraRepository: CameraRepository,
+    private val scope: CoroutineScope,
+) {
+    private val _state = MutableStateFlow<PhotoCaptureState>(PhotoCaptureState.Idle)
+    val state: StateFlow<PhotoCaptureState> = _state.asStateFlow()
+
+    init {
+        scope.launch {
+            cameraRepository.observePhotoCaptureState().collect { captureState ->
+                _state.value = captureState
+            }
+        }
+    }
+
+    fun capturePhoto() {
+        if (_state.value == PhotoCaptureState.Capturing) {
+            return
+        }
+        scope.launch {
+            cameraRepository.capturePhoto()
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/testing/FakeRepositories.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/vtubercamera_kmp_ver/camera/testing/FakeRepositories.kt
@@ -6,6 +6,7 @@ import com.example.vtubercamera_kmp_ver.camera.CameraRepository
 import com.example.vtubercamera_kmp_ver.camera.CameraZoomUiState
 import com.example.vtubercamera_kmp_ver.camera.PermissionRepository
 import com.example.vtubercamera_kmp_ver.camera.PermissionState
+import com.example.vtubercamera_kmp_ver.camera.PhotoCaptureState
 import com.example.vtubercamera_kmp_ver.camera.PreviewState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,6 +21,7 @@ internal class FakeCameraRepository(
     private val switchLensResult: Result<CameraLensFacing> = Result.success(CameraLensFacing.Front),
 ) : CameraRepository {
     private val previewState = MutableStateFlow<PreviewState>(PreviewState.Preparing)
+    private val photoCaptureState = MutableStateFlow<PhotoCaptureState>(PhotoCaptureState.Idle)
     private val zoomUiState = MutableStateFlow(
         CameraZoomUiState(
             currentCameraZoomRatio = 1f,
@@ -74,6 +76,16 @@ internal class FakeCameraRepository(
 
     override fun observePreviewState(): Flow<PreviewState> {
         return previewState.asStateFlow()
+    }
+
+    override fun observePhotoCaptureState(): Flow<PhotoCaptureState> {
+        return photoCaptureState.asStateFlow()
+    }
+
+    override suspend fun capturePhoto(): Result<String?> {
+        photoCaptureState.value = PhotoCaptureState.Capturing
+        photoCaptureState.value = PhotoCaptureState.Succeeded("fake://photo.jpg")
+        return Result.success("fake://photo.jpg")
     }
 
     override fun onPlatformPreviewStarted(lensFacing: CameraLensFacing) {

--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraPreview.kt
@@ -50,6 +50,10 @@ import platform.AVFoundation.AVCaptureDeviceInput
 import platform.AVFoundation.AVCaptureDevicePositionBack
 import platform.AVFoundation.AVCaptureDevicePositionFront
 import platform.AVFoundation.AVCaptureSession
+import platform.AVFoundation.AVCapturePhoto
+import platform.AVFoundation.AVCapturePhotoCaptureDelegateProtocol
+import platform.AVFoundation.AVCapturePhotoOutput
+import platform.AVFoundation.AVCapturePhotoSettings
 import platform.AVFoundation.AVCaptureVideoPreviewLayer
 import platform.AVFoundation.AVMediaTypeVideo
 import platform.AVFoundation.position
@@ -60,7 +64,6 @@ import platform.AVFoundation.requestAccessForMediaType
 import platform.AVFoundation.videoZoomFactor
 import platform.CoreGraphics.CGRectZero
 import platform.Foundation.NSData
-import platform.Foundation.NSDate
 import platform.Foundation.NSError
 import platform.Foundation.NSNumber
 import platform.Foundation.NSURL
@@ -209,9 +212,13 @@ actual fun CameraPreviewHost(
                     (cameraRepository as? IOSCameraRepository)?.onPlatformCameraControlReady(
                         sessionManager.cameraControl(),
                     )
+                    (cameraRepository as? IOSCameraRepository)?.onPlatformPhotoCapturerReady(
+                        sessionManager.photoCapturer(),
+                    )
                     cameraRepository.onPlatformPreviewStarted(resolvedLens)
                 } else {
                     (cameraRepository as? IOSCameraRepository)?.onPlatformCameraControlReady(null)
+                    (cameraRepository as? IOSCameraRepository)?.onPlatformPhotoCapturerReady(null)
                     cameraRepository.onPlatformPreviewError(
                         lensFacing = resolvedLens,
                         error = CameraError.PreviewInitializationFailed,
@@ -225,6 +232,9 @@ actual fun CameraPreviewHost(
             sessionManager.stopPreview {
                 if (!isDisposed) {
                     (cameraRepository as? IOSCameraRepository)?.onPlatformCameraControlReady(null)
+                    (cameraRepository as? IOSCameraRepository)?.onPlatformPhotoCapturerReady(
+                        faceTrackingSessionManager.photoCapturer(),
+                    )
                     faceTrackingSessionManager.startPreview(
                         onFaceTrackingFrameChanged = { frame ->
                             currentOnFaceTrackingFrameChanged.value(frame)
@@ -246,6 +256,7 @@ actual fun CameraPreviewHost(
             isDisposed = true
             faceTrackingSessionManager.stopPreview()
             sessionManager.stopPreview()
+            (cameraRepository as? IOSCameraRepository)?.onPlatformPhotoCapturerReady(null)
             currentOnFaceTrackingFrameChanged.value(null)
         }
     }
@@ -438,6 +449,7 @@ private fun Throwable.toFilePickerError(): FilePickerResult.Error {
 private class IOSCameraSessionManager {
     private val session = AVCaptureSession()
     private val previewLayer = AVCaptureVideoPreviewLayer(session = session)
+    private val photoOutput = AVCapturePhotoOutput()
     // Serialize capture-session work off the main thread to avoid UI stalls.
     private val sessionQueue = dispatch_queue_create("com.example.vtubercamera.camera.session", null)
     private var currentInput: AVCaptureDeviceInput? = null
@@ -470,6 +482,9 @@ private class IOSCameraSessionManager {
             session.beginConfiguration()
             val previousInput = currentInput
             previousInput?.let { session.removeInput(it) }
+            if (!session.outputs.contains(photoOutput) && session.canAddOutput(photoOutput)) {
+                session.addOutput(photoOutput)
+            }
             if (!session.canAddInput(input)) {
                 previousInput?.takeIf { session.canAddInput(it) }?.let { restoredInput ->
                     session.addInput(restoredInput)
@@ -517,6 +532,49 @@ private class IOSCameraSessionManager {
         return currentCameraControl
     }
 
+    fun photoCapturer(): IOSPhotoCapturer {
+        return AVCapturePhotoOutputCapturer(photoOutput)
+    }
+}
+
+private class AVCapturePhotoOutputCapturer(
+    private val photoOutput: AVCapturePhotoOutput,
+) : IOSPhotoCapturer {
+    override fun capturePhoto(onComplete: (uri: String?, error: Throwable?) -> Unit) {
+        val delegate = IOSPhotoCaptureDelegate { uri, error ->
+            retainedPhotoDelegates.removeAll { it.didComplete }
+            onComplete(uri, error)
+        }
+        retainedPhotoDelegates += delegate
+        photoOutput.capturePhotoWithSettings(
+            settings = AVCapturePhotoSettings.photoSettings(),
+            delegate = delegate,
+        )
+    }
+
+    companion object {
+        private val retainedPhotoDelegates = mutableListOf<IOSPhotoCaptureDelegate>()
+    }
+}
+
+private class IOSPhotoCaptureDelegate(
+    private val onComplete: (uri: String?, error: Throwable?) -> Unit,
+) : NSObject(), AVCapturePhotoCaptureDelegateProtocol {
+    var didComplete: Boolean = false
+        private set
+
+    override fun captureOutput(
+        output: AVCapturePhotoOutput,
+        didFinishProcessingPhoto: AVCapturePhoto,
+        error: NSError?,
+    ) {
+        didComplete = true
+        if (error != null) {
+            onComplete(null, IllegalStateException(error.localizedDescription))
+            return
+        }
+        onComplete(null, null)
+    }
 }
 
 private class AVCaptureDeviceCameraControl(
@@ -593,6 +651,12 @@ private class IOSFaceTrackingSessionManager {
         sessionDelegate.onFaceTrackingFrameChanged = {}
         sessionDelegate.clearTrackedFace()
         previewView.session.pause()
+    }
+
+    fun photoCapturer(): IOSPhotoCapturer {
+        return IOSPhotoCapturer { onComplete ->
+            onComplete(null, IllegalStateException("Photo capture is unavailable during face tracking"))
+        }
     }
 }
 

--- a/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraRepository.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraRepository.kt
@@ -2,6 +2,7 @@ package com.example.vtubercamera_kmp_ver.camera
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlin.coroutines.resume
 
 internal typealias IOSCameraLensAvailability = (CameraLensFacing) -> Boolean
 
@@ -11,9 +12,14 @@ internal interface CameraControl {
     fun setZoomRatio(updatedZoomRatio: Float): CameraZoomUiState?
 }
 
+internal fun interface IOSPhotoCapturer {
+    fun capturePhoto(onComplete: (uri: String?, error: Throwable?) -> Unit)
+}
+
 internal class IOSCameraRepository(
     private val hasLens: IOSCameraLensAvailability,
     private val previewState: MutableStateFlow<PreviewState> = MutableStateFlow(PreviewState.Preparing),
+    private val photoCaptureState: MutableStateFlow<PhotoCaptureState> = MutableStateFlow(PhotoCaptureState.Idle),
     private val zoomUiState: MutableStateFlow<CameraZoomUiState> = MutableStateFlow(
         CameraZoomUiState()
     )
@@ -21,6 +27,7 @@ internal class IOSCameraRepository(
     private var pendingLensFacing: CameraLensFacing? = null
 
     private var cameraControl: CameraControl? = null
+    private var photoCapturer: IOSPhotoCapturer? = null
 
     // プレビュー開始前の状態を整え、利用可能なレンズを解決する。
     override suspend fun startPreview(lensFacing: CameraLensFacing): Result<CameraLensFacing> {
@@ -59,6 +66,29 @@ internal class IOSCameraRepository(
     // プレビュー状態の変更を監視する Flow を返す。
     override fun observePreviewState(): Flow<PreviewState> = previewState
 
+    override fun observePhotoCaptureState(): Flow<PhotoCaptureState> = photoCaptureState
+
+    override suspend fun capturePhoto(): Result<String?> {
+        val capturer = photoCapturer
+            ?: return Result.failure<String?>(
+                CameraRepositoryException(CameraError.PhotoCaptureFailed),
+            ).also {
+                photoCaptureState.value = PhotoCaptureState.Failed(CameraError.PhotoCaptureFailed)
+            }
+        photoCaptureState.value = PhotoCaptureState.Capturing
+        return kotlinx.coroutines.suspendCancellableCoroutine { continuation ->
+            capturer.capturePhoto { uri, error ->
+                if (error == null) {
+                    photoCaptureState.value = PhotoCaptureState.Succeeded(uri)
+                    continuation.resume(Result.success(uri))
+                } else {
+                    photoCaptureState.value = PhotoCaptureState.Failed(CameraError.PhotoCaptureFailed)
+                    continuation.resume(Result.failure(CameraRepositoryException(CameraError.PhotoCaptureFailed)))
+                }
+            }
+        }
+    }
+
     // ネイティブ側でプレビュー開始が完了したことを状態へ反映する。
     override fun onPlatformPreviewStarted(lensFacing: CameraLensFacing) {
         if (pendingLensFacing == null || pendingLensFacing == lensFacing) {
@@ -90,6 +120,10 @@ internal class IOSCameraRepository(
         this.cameraControl = cameraControl
         onPlatformZoomStateChanged(cameraControl?.zoomState() ?: CameraZoomUiState())
     }
+
+    fun onPlatformPhotoCapturerReady(photoCapturer: IOSPhotoCapturer?) {
+        this.photoCapturer = photoCapturer
+    }
 }
 
 // 指定レンズが使えない場合に代替レンズを含めて利用可否を解決する。
@@ -107,4 +141,3 @@ internal fun resolveAvailableLens(
 
 internal fun Float.coerceInZoomRange(minZoomRatio: Float, maxZoomRatio: Float): Float =
     coerceIn(minZoomRatio, maxZoomRatio)
-

--- a/composeApp/src/iosTest/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraRepositoryTest.kt
+++ b/composeApp/src/iosTest/kotlin/com/example/vtubercamera_kmp_ver/camera/IOSCameraRepositoryTest.kt
@@ -44,6 +44,20 @@ class IOSCameraRepositoryTest {
     }
 
     @Test
+    fun capturePhoto_returnsPhotoCaptureFailedWhenCapturerIsNotReady() = runTest {
+        val repository = createRepository(availableLens = setOf(CameraLensFacing.Back))
+
+        val result = repository.capturePhoto()
+
+        val exception = assertIs<CameraRepositoryException>(result.exceptionOrNull())
+        assertEquals(CameraError.PhotoCaptureFailed, exception.error)
+        assertEquals(
+            PhotoCaptureState.Failed(CameraError.PhotoCaptureFailed),
+            repository.observePhotoCaptureState().first(),
+        )
+    }
+
+    @Test
     fun onPlatformPreviewStarted_ignoresStaleCallbackWhileSwitchIsPending() = runTest {
         val repository = createRepository(availableLens = setOf(CameraLensFacing.Back, CameraLensFacing.Front))
 


### PR DESCRIPTION
## Summary
- Add shared photo capture support for the KMP camera screen.
- Wire Android CameraX and iOS AVFoundation capture paths into the existing camera repository flow.

## Changes
- Added `PhotoCaptureState`, capture messaging, and a `PhotoCaptureController`.
- Added a capture button and capture success/failure banner to the shared camera UI.
- Bound Android `ImageCapture` and iOS `AVCapturePhotoOutput` into platform camera sessions.
- Added repository tests for capture readiness failures on Android and iOS.

## Test Plan
- [x] `ANDROID_HOME=/Users/j____takumi/Library/Android/sdk ./gradlew :composeApp:testDebugUnitTest --tests com.example.vtubercamera_kmp_ver.camera.CameraViewModelTest --tests com.example.vtubercamera_kmp_ver.camera.AndroidCameraRepositoryTest`
- [x] `ANDROID_HOME=/Users/j____takumi/Library/Android/sdk ./gradlew :composeApp:compileKotlinIosSimulatorArm64`
- [x] `ANDROID_HOME=/Users/j____takumi/Library/Android/sdk ./gradlew :composeApp:iosSimulatorArm64Test`

## Related Issues
- Closes #143
